### PR TITLE
London worker classification

### DIFF
--- a/notebooks/london-workers-classification.ipynb
+++ b/notebooks/london-workers-classification.ipynb
@@ -1,0 +1,489 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:46:55.725347Z",
+     "start_time": "2020-05-05T12:46:55.482694Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import os\n",
+    "from collections import defaultdict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Intro\n",
+    "\n",
+    "This notebook shows the methodology for building a 'work from home' and a 'key worker' sampler for the population of London. The sampler uses a distribution based on person occupation, gender and work status (full-time or part-time). \n",
+    "\n",
+    "## Methodology\n",
+    "\n",
+    "Firstly we manually define three mappings based on SOC2010 occupation categories (level 2):\n",
+    "\n",
+    "- occ_mapping: mapping from SOC2010 cats to the lopops occupation cats\n",
+    "- key_worker_mapping: mapping from SOC2010 cats to key worker cat {0: not key worker, 1: key worker}\n",
+    "- home_worker_mapping: mapping from SOC2010 cats to home worker cat {0: not able to WFH, 1: able to WFH}\n",
+    "\n",
+    "We then use this mapping to build a frequency based distributions that are dependant on person occupation, work status and gender."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Occupation Descriptions\n",
+    "\n",
+    "We use the following descriptions to make the occ_mapping:\n",
+    "\n",
+    "### occ1 Modern professional occupations\n",
+    "\n",
+    "eg: teacher – nurse – physiotherapist – social worker – welfare officer – artist – musician – police officer (sergeant or above) – software designer\n",
+    "\n",
+    "### occ2 Clerical and intermediate occupations\n",
+    "\n",
+    "eg: secretary – personal assistant – clerical worker – office clerk – call centre agent – nursing auxiliary – nursery nurse\n",
+    "\n",
+    "### occ3 Senior managers or administrators\n",
+    "\n",
+    "(usually responsible for planning, organising and co-ordinating work, and for finance)\n",
+    "\n",
+    "eg: finance manager – chief executive\n",
+    "\n",
+    "### occ4 Technical and craft occupations\n",
+    "\n",
+    "eg: motor mechanic – fitter – inspector – plumber – printer – tool maker – electrician – gardener – train driver\n",
+    "\n",
+    "### occ5 Semi-routine manual and service occupations\n",
+    "\n",
+    "eg: postal worker – machine operative – security guard – caretaker – farm worker – catering assistant – receptionist – sales assistant\n",
+    "\n",
+    "### occ6 Routine manual and service occupations\n",
+    "\n",
+    "eg: HGV driver – van driver – cleaner – porter – packer – sewing machinist – messenger – labourer – waiter/waitress – bar staff\n",
+    "\n",
+    "### occ7 Middle or junior managers\n",
+    "\n",
+    "eg: office manager – retail manager – bank manager – restaurant manager – warehouse manager – publican\n",
+    "\n",
+    "### occ8 Traditional professional occupations\n",
+    "\n",
+    "eg: accountant – solicitor – medical practitioner – scientist – civil/mechanical engineer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mappings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:46:55.758688Z",
+     "start_time": "2020-05-05T12:46:55.728215Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# {i:[occ, key_worker, home_worker]}\n",
+    "\n",
+    "full_mapping = {\n",
+    "    '111 Chief Executives and Senior Officials': ['occ3', 0, 1.0],\n",
+    "    '112 Production Managers and Directors': ['occ3', 0, 1.0],\n",
+    "    '113 Functional Managers and Directors': ['occ3', 0, 1.0],\n",
+    "    '115 Financial Institution Managers and Directors': ['occ3', 0, 1.0],\n",
+    "    '116 Managers and Directors in Transport and Logistics': ['occ3', 0, 1.0],\n",
+    "    '117 Senior Officers in Protective Services': ['occ3', 0, 1.0],\n",
+    "    '118 Health and Social Services Managers and Directors': ['occ3', 0, 1.0],\n",
+    "    '119 Managers and Directors in Retail and Wholesale': ['occ3', 0, 1.0],\n",
+    "    '121 Managers and Proprietors in Agriculture Related Services': ['occ3', 0, 1.0],\n",
+    "    '122 Managers and Proprietors in Hospitality and Leisure Services': ['occ3', 0, 1.0],\n",
+    "    '124 Managers and Proprietors in Health and Care Services': ['occ3', 0, 1.0],\n",
+    "    '125 Managers and Proprietors in Other Services': ['occ3', 0, 1.0],\n",
+    "    '211 Natural and Social Science Professionals': ['occ8', 0, 1.0],\n",
+    "    '212 Engineering Professionals': ['occ8', 0, 1.0],\n",
+    "    '213 Information Technology and Telecommunications Professionals': ['occ1', 0, 1.0],\n",
+    "    '214 Conservation and Environment Professionals': ['occ1', 0, 1.0],\n",
+    "    '215 Research and Development Managers': ['occ1', 0, 1.0],\n",
+    "    '221 Health Professionals': ['occ8', 1, 0.0],\n",
+    "    '222 Therapy Professionals': ['occ8', 1, 0.0],\n",
+    "    '223 Nursing and Midwifery Professionals': ['occ8', 1, 0.0],\n",
+    "    '231 Teaching and Educational Professionals': ['occ8', 1, 0.0],\n",
+    "    '241 Legal Professionals': ['occ8', 0, 1.0],\n",
+    "    '242 Business, Research and Administrative Professionals': ['occ1', 0, 1.0],\n",
+    "    '243 Architects, Town Planners and Surveyors': ['occ8', 0, 1.0],\n",
+    "    '244 Welfare Professionals': ['occ1', 0, 1.0],\n",
+    "    '245 Librarians and Related Professionals': ['occ8', 0, 1.0],\n",
+    "    '246 Quality and Regulatory Professionals': ['occ1', 0, 1.0],\n",
+    "    '247 Media Professionals': ['occ1', 1, 1.0],\n",
+    "    '311 Science, Engineering and Production Technicians': ['occ1', 0, 1.0],\n",
+    "    '312 Draughtspersons and Related Architectural Technicians': ['occ8', 0, 1.0],\n",
+    "    '313 Information Technology Technicians': ['occ1', 0, 1.0],\n",
+    "    '321 Health Associate Professionals': ['occ1', 0, 1.0],\n",
+    "    '323 Welfare and Housing Associate Professionals': ['occ1', 0, 1.0],\n",
+    "    '331 Protective Service Occupations': ['occ1', 0, 1.0],\n",
+    "    '341 Artistic, Literary and Media Occupations': ['occ1', 0, 1.0],\n",
+    "    '342 Design Occupations': ['occ1', 0, 1.0],\n",
+    "    '344 Sports and Fitness Occupations': ['occ1', 0, 1.0],\n",
+    "    '351 Transport Associate Professionals': ['occ1', 0, 1.0],\n",
+    "    '352 Legal Associate Professionals': ['occ8', 0, 1.0],\n",
+    "    '353 Business, Finance and Related Associate Professionals': ['occ1', 0, 1.0],\n",
+    "    '354 Sales, Marketing and Related Associate Professionals': ['occ1', 0, 1.0],\n",
+    "    '355 Conservation and Environmental associate professionals': ['occ1', 0, 1.0],\n",
+    "    '356 Public Services and Other Associate Professionals': ['occ1', 0, 1.0],\n",
+    "    '411 Administrative Occupations: Government and Related Organisations': ['occ2', 0, 1.0],\n",
+    "    '412 Administrative Occupations: Finance': ['occ2', 0, 1.0],\n",
+    "    '413 Administrative Occupations: Records': ['occ2', 0, 1.0],\n",
+    "    '415 Other Administrative Occupations': ['occ2', 0, 1.0],\n",
+    "    '416 Administrative Occupations: Office Managers and Supervisors': ['occ7', 0, 1.0],\n",
+    "    '421 Secretarial and Related Occupations': ['occ2', 0, 1.0],\n",
+    "    '511 Agricultural and Related Trades': ['occ5', 1, 0.0],\n",
+    "    '521 Metal Forming, Welding and Related Trades': ['occ4', 0, 0.0],\n",
+    "    '522 Metal Machining, Fitting and Instrument Making Trades': ['occ4', 0, 0.0],\n",
+    "    '523 Vehicle Trades': ['occ4', 0, 0.0],\n",
+    "    '524 Electrical and Electronic Trades': ['occ4', 0, 0.0],\n",
+    "    '525 Skilled Metal, Electrical and Electronic Trades Supervisors': ['occ4', 0, 0.0],\n",
+    "    '531 Construction and Building Trades': ['occ4', 0, 0.0],\n",
+    "    '532 Building Finishing Trades': ['occ4', 0, 0.0],\n",
+    "    '533 Construction and Building Trades Supervisors': ['occ4', 0, 0.0],\n",
+    "    '541 Textiles and Garments Trades': ['occ6', 0, 0.0],\n",
+    "    '542 Printing Trades': ['occ6', 0, 0.0],\n",
+    "    '543 Food Preparation and Hospitality Trades': ['occ5', 0, 0.0],\n",
+    "    '544 Other Skilled Trades': ['occ4', 0, 0.0],\n",
+    "    '612 Childcare and Related Personal Services': ['occ2', 1, 0.0],\n",
+    "    '613 Animal Care and Control Services': ['occ2', 1, 0.0],\n",
+    "    '614 Caring Personal Services': ['occ2', 1, 0.0],\n",
+    "    '621 Leisure and Travel Services': ['occ2', 0, 0.0],\n",
+    "    '622 Hairdressers and Related Services': ['occ2', 0, 0.0],\n",
+    "    '623 Housekeeping and Related Services': ['occ2', 0, 0.0],\n",
+    "    '624 Cleaning and Housekeeping Managers and Supervisors': ['occ7', 0, 0.0],\n",
+    "    '711 Sales Assistants and Retail Cashiers': ['occ6', 0, 0.0],\n",
+    "    '712 Sales Related Occupations': ['occ6', 0, 0.0],\n",
+    "    '713 Sales Supervisors': ['occ7', 0, 0.0],\n",
+    "    '721 Customer Service Occupations': ['occ6', 0, 0.0],\n",
+    "    '722 Customer Service Managers and Supervisors': ['occ7', 0, 0.0],\n",
+    "    '811 Process Operatives': ['occ5', 0, 0.0],\n",
+    "    '812 Plant and Machine Operatives': ['occ5', 0, 0.0],\n",
+    "    '813 Assemblers and Routine Operatives': ['occ5', 0, 0.0],\n",
+    "    '814 Construction Operatives': ['occ5', 0, 0.0],\n",
+    "    '821 Road Transport Drivers': ['occ5', 1, 0.0],\n",
+    "    '822 Mobile Machine Drivers and Operatives': ['occ5', 1, 0.0],\n",
+    "    '823 Other Drivers and Transport Operatives': ['occ5', 1, 0.0],\n",
+    "    '911 Elementary Agricultural Occupations': ['occ6', 1, 0.0],\n",
+    "    '912 Elementary Construction Occupations': ['occ6', 0, 0.0],\n",
+    "    '913 Elementary Process Plant Occupations': ['occ6', 0, 0.0],\n",
+    "    '921 Elementary Administration Occupations': ['occ6', 0, 0.0],\n",
+    "    '923 Elementary Cleaning Occupations': ['occ6', 0, 0.0],\n",
+    "    '924 Elementary Security Occupations': ['occ6', 1, 0.0],\n",
+    "    '925 Elementary Sales Occupations': ['occ6', 0, 0.0],\n",
+    "    '926 Elementary Storage Occupations': ['occ6', 0, 0.0],\n",
+    "    '927 Other Elementary Services Occupations': ['occ6', 0, 0.0]\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:46:55.775070Z",
+     "start_time": "2020-05-05T12:46:55.760619Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "occ_mapping = {k: v[0] for k, v in full_mapping.items()}\n",
+    "key_worker_mapping = {k: v[1] for k, v in full_mapping.items()}\n",
+    "home_worker_mapping = {k: v[2] for k, v in full_mapping.items()}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Distribution\n",
+    "We retrieve the SOC2010 codes from the NOMIS official labour market statistics from https://www.nomisweb.co.uk/datasets/aps210/reports/employment-by-sex-by-ftpt-by-emp-self. We extract data for London only and use the provided breakdown by gender and work status (full-time/part-time) to build a distribution of key workers and workers able to work from home."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:46:55.796197Z",
+     "start_time": "2020-05-05T12:46:55.776699Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def clean(df):\n",
+    "    \"\"\"\n",
+    "    Prepare SOC2010 table by combining full time and part time columns and forcing to numeric.\n",
+    "    \"\"\"\n",
+    "    for col in ['Full-time', 'Full-time.1', 'Part-time','Part-time.1']:\n",
+    "        df[col] = pd.to_numeric(df[col], errors='coerce').fillna(0).astype(int)\n",
+    "\n",
+    "    df['ft'] = df['Full-time'] + df['Full-time.1']\n",
+    "    df['pt'] = df['Part-time'] + df['Part-time.1']\n",
+    "        \n",
+    "    df = df[['SOC2010', 'ft', 'pt']]\n",
+    "    \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:46:55.819263Z",
+     "start_time": "2020-05-05T12:46:55.798750Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def load_data(occ_mapping):\n",
+    "    \"\"\"\n",
+    "    Load and combine male and female data\n",
+    "    \"\"\"\n",
+    "    male = pd.read_excel('/Users/fred.shone/Downloads/emp04sep2018.xls', sheet_name='Men', skiprows=4)\n",
+    "    male = male.loc[male.SOC2010.isin(list(occ_mapping))]  # filter for level 2 SOC2010 codes\n",
+    "    male = clean(male)\n",
+    "    male['gender'] = 'male'\n",
+    "\n",
+    "    female = pd.read_excel('/Users/fred.shone/Downloads/emp04sep2018.xls', sheet_name='Women', skiprows=4)\n",
+    "    female = female.loc[female.SOC2010.isin(list(occ_mapping))]  # filter for level 2 SOC2010 codes\n",
+    "    female = clean(female)\n",
+    "    female['gender'] = 'female'\n",
+    "\n",
+    "    data = pd.concat([female, male])\n",
+    "    data['occ'] = data['SOC2010'].map(occ_mapping)\n",
+    "    \n",
+    "    return data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:46:55.846852Z",
+     "start_time": "2020-05-05T12:46:55.822753Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def build_dist(occ_mapping, name, mapping):\n",
+    "    \"\"\"\n",
+    "    Build distribution dict.\n",
+    "    \"\"\"\n",
+    "    data = load_data(occ_mapping)\n",
+    "    data[name] = data['SOC2010'].map(mapping) # apply wfh mapping\n",
+    "    \n",
+    "    melted = pd.melt(data, id_vars=['gender', 'occ', name], value_vars=['ft', 'pt']) # melt work status into index\n",
+    "    \n",
+    "    grouped = melted.groupby(['gender', 'occ', 'variable', name]).value.sum()  # group to find unique outcomes\n",
+    "    \n",
+    "    grouped = grouped.unstack(level=name)  # unstack wfh (we only care about wfh=1)\n",
+    "    grouped = grouped.fillna(0).astype(int)  # fill for zero freq of wfh\n",
+    "    \n",
+    "    totals = grouped[0] + grouped[1]  # calc probability for each line\n",
+    "    grouped[0] = grouped[0] / totals\n",
+    "    grouped[1] = grouped[1] / totals\n",
+    "\n",
+    "    dist = defaultdict(lambda: defaultdict(dict))  # build dict\n",
+    "\n",
+    "    for (gender, occ, work), line in grouped.iterrows():\n",
+    "        dist[occ][work][gender] = line[1]\n",
+    "    \n",
+    "    return dist"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:45:10.157646Z",
+     "start_time": "2020-05-05T12:45:10.132974Z"
+    }
+   },
+   "source": [
+    "## Work From Home Sampler Distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:46:56.066842Z",
+     "start_time": "2020-05-05T12:46:55.849198Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "defaultdict(<function __main__.build_dist.<locals>.<lambda>()>,\n",
+       "            {'occ1': defaultdict(dict,\n",
+       "                         {'ft': {'female': 1.0, 'male': 1.0},\n",
+       "                          'pt': {'female': 1.0, 'male': 1.0}}),\n",
+       "             'occ2': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.5097493472126429,\n",
+       "                           'male': 0.6306422558286575},\n",
+       "                          'pt': {'female': 0.49521826378117134,\n",
+       "                           'male': 0.42618583086831563}}),\n",
+       "             'occ3': defaultdict(dict,\n",
+       "                         {'ft': {'female': 1.0, 'male': 1.0},\n",
+       "                          'pt': {'female': 1.0, 'male': 1.0}}),\n",
+       "             'occ4': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.0, 'male': 0.0},\n",
+       "                          'pt': {'female': 0.0, 'male': 0.0}}),\n",
+       "             'occ5': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.0, 'male': 0.0},\n",
+       "                          'pt': {'female': 0.0, 'male': 0.0}}),\n",
+       "             'occ6': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.0, 'male': 0.0},\n",
+       "                          'pt': {'female': 0.0, 'male': 0.0}}),\n",
+       "             'occ7': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.39982480603525333,\n",
+       "                           'male': 0.2329414635490257},\n",
+       "                          'pt': {'female': 0.28792951233796316, 'male': 0.0}}),\n",
+       "             'occ8': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.1825373742760679,\n",
+       "                           'male': 0.5715565318185437},\n",
+       "                          'pt': {'female': 0.10287669728348259,\n",
+       "                           'male': 0.2831083871976065}})})"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wfh_distribution = build_dist(occ_mapping, 'wfh', home_worker_mapping)\n",
+    "wfh_distribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Key Worker Sampler Distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-05T12:46:56.291732Z",
+     "start_time": "2020-05-05T12:46:56.069438Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "defaultdict(<function __main__.build_dist.<locals>.<lambda>()>,\n",
+       "            {'occ1': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.03496410641509246,\n",
+       "                           'male': 0.018932783373260178},\n",
+       "                          'pt': {'female': 0.02851651409950532,\n",
+       "                           'male': 0.04149215443426522}}),\n",
+       "             'occ2': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.41994351733774976,\n",
+       "                           'male': 0.23481447312435133},\n",
+       "                          'pt': {'female': 0.4115572630910834,\n",
+       "                           'male': 0.3376381983342774}}),\n",
+       "             'occ3': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.0, 'male': 0.0},\n",
+       "                          'pt': {'female': 0.0, 'male': 0.0}}),\n",
+       "             'occ4': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.0, 'male': 0.0},\n",
+       "                          'pt': {'female': 0.0, 'male': 0.0}}),\n",
+       "             'occ5': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.2146727132583496,\n",
+       "                           'male': 0.5965862174997756},\n",
+       "                          'pt': {'female': 0.28206362192598294,\n",
+       "                           'male': 0.726142049613971}}),\n",
+       "             'occ6': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.031761148568127555,\n",
+       "                           'male': 0.12142902956136813},\n",
+       "                          'pt': {'female': 0.05297393050472775,\n",
+       "                           'male': 0.05052617394060236}}),\n",
+       "             'occ7': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.0, 'male': 0.0},\n",
+       "                          'pt': {'female': 0.0, 'male': 0.0}}),\n",
+       "             'occ8': defaultdict(dict,\n",
+       "                         {'ft': {'female': 0.8174626257239321,\n",
+       "                           'male': 0.42844346818145634},\n",
+       "                          'pt': {'female': 0.8971233027165174,\n",
+       "                           'male': 0.7168916128023934}})})"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "key_distribution = build_dist(occ_mapping, 'key', key_worker_mapping)\n",
+    "key_distribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.7.3 64-bit ('3.7.3': pyenv)",
+   "language": "python",
+   "name": "python37364bit373pyenve4f55e1c90f74740a9da8a10ea80341d"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pam/samplers/attributes.py
+++ b/pam/samplers/attributes.py
@@ -17,7 +17,7 @@ def bin_integer_transformer(features, target, bins, default=None):
     return default
 
 
-def discrete_joint_distribution_sampler(features, mapping, distribution):
+def discrete_joint_distribution_sampler(features, mapping, distribution, careful=False):
     """
     Randomly sample from a joint distribution based some discrete features.
 
@@ -28,14 +28,20 @@ def discrete_joint_distribution_sampler(features, mapping, distribution):
 
     Mapping provides the feature name for each level of the distribution, eg:
     ['age', 'gender']
+
+    Missing keys return False, unless careful is set to True, which will raise an error.
     """
     p = distribution
     for key in mapping:
         value = features.get(key)
         if value is None:
             raise KeyError(f"Can not find mapping: {key} in sampling features: {features}")
+
         p = p.get(value)
         if p is None:
-            raise KeyError(f"Can not find feature for {key}: {value} in distribution: {p}")
+            if careful:
+                raise KeyError(f"Can not find feature for {key}: {value} in distribution: {p}")
+            else:
+                return False
 
     return random() <= p

--- a/scripts/.coveragerc
+++ b/scripts/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-omit = venv/*, tests/*
+omit = venv/*, tests/*, notebooks/*
 
 [report]
 fail_under = 79

--- a/tests/test_9_samplers.py
+++ b/tests/test_9_samplers.py
@@ -28,7 +28,7 @@ def fred():
 
     return {
         'age': -3,
-        'agebin': None,
+        'agebin': '',
         'gender': 1
     }
 
@@ -69,3 +69,14 @@ def test_apply_discrete_joint_distribution_sampler_to_michael(michael, cat_joint
 def test_applt_discrete_joint_distribution_sampler_to_kasia(kasia, cat_joint_distribution):
     mapping, dist = cat_joint_distribution
     assert attributes.discrete_joint_distribution_sampler(kasia, mapping, dist) == True
+
+
+def test_applt_discrete_joint_distribution_sampler_to_fred_carefully(fred, cat_joint_distribution):
+    mapping, dist = cat_joint_distribution
+    with pytest.raises(KeyError):
+        attributes.discrete_joint_distribution_sampler(fred, mapping, dist, careful=True)
+
+
+def test_applt_discrete_joint_distribution_sampler_to_fred_not_carefully(fred, cat_joint_distribution):
+    mapping, dist = cat_joint_distribution
+    assert attributes.discrete_joint_distribution_sampler(fred, mapping, dist) == False


### PR DESCRIPTION
# Notebook

Adds a prelim [notebook](https://github.com/arup-group/pam/blob/london-worker-classification/notebooks/london-workers-classification.ipynb) for person classification as 'able to wfh' and 'key worker' - based on NOMIS employment stats for London. The methodology is pretty janky:

1. using SOC2010 level 2 employment categories (this is currently a big dictionary in the notebook):
1.1 manually map to lopops occupation categories
1.2 manually classify as  'able to wfh' and 'key worker'
2. based on london population for each category (gender, occ and work status (ft/pt):
2.1 wrangle tables so that frequencies are exposed for  'able to wfh' and 'key worker'
2.2 convert to probability based on frequency
2.3 build distribution dicts

eg:
`{'occ1': {'ft': {'male': 0.5, 'female': 0.4}...`

Note that the distribution for each point is binary, ie probability of being key worker.

I am very happy to take feedback on the mappings or the methodology - feels wrong at the moment.

# Code

Also made some small changes to the attribute sampler so that if it fails to find a key it returns False. This behaviour is controlled by the value `careful` and set as default to not be careful, ie to return False. I like this behaviour because then the input distribution dictionaries do not need to be exhaustive.

For example in the case of work from home, a person with work status `in education` would be missing from the distribution dictionary, rather than failing it is useful to return False.

However, this does facilitate silent fails if a distribution dict is miss specified.