### PR TITLE
Writing matsim XML's - Return the object, not the key in case of a dict

### DIFF
--- a/pam/write.py
+++ b/pam/write.py
@@ -204,7 +204,7 @@ def write_matsim_attributes(population, location, comment=None, household_key=No
 
             for k, v in attributes.items():
                 attribute_xml = et.SubElement(person_xml, 'attribute', {'class': 'java.lang.String', 'name': str(k)})
-                attribute_xml.text = str(v)
+                attribute_xml.text = str(v[1])
 
     write_xml(attributes_xml, location, matsim_DOCTYPE='objectAttributes', matsim_filename='objectattributes_v1')
 

--- a/pam/write.py
+++ b/pam/write.py
@@ -209,17 +209,11 @@ def write_matsim_attributes(population, location, comment=None, household_key=No
                 # We should ensure types further upstream
                 # This solves TfL Phase 2 issue 
 
-                if isinstance(v, (str,int)):
+                if not isinstance(v, dict):
                     attribute_xml.text = str(v)
-                
-                elif isinstance(v, dict):
+                else
                     attribute_xml.text = str(list(v.values())[0])
 
-                else:
-                    print(type(v))
-                    print(attributes)
-                    print(pid)
-                    print(v)
 
     write_xml(attributes_xml, location, matsim_DOCTYPE='objectAttributes', matsim_filename='objectattributes_v1')
 

--- a/pam/write.py
+++ b/pam/write.py
@@ -211,7 +211,7 @@ def write_matsim_attributes(population, location, comment=None, household_key=No
 
                 if not isinstance(v, dict):
                     attribute_xml.text = str(v)
-                else
+                else:
                     attribute_xml.text = str(list(v.values())[0])
 
 

--- a/pam/write.py
+++ b/pam/write.py
@@ -204,7 +204,22 @@ def write_matsim_attributes(population, location, comment=None, household_key=No
 
             for k, v in attributes.items():
                 attribute_xml = et.SubElement(person_xml, 'attribute', {'class': 'java.lang.String', 'name': str(k)})
-                attribute_xml.text = str(v[1])
+
+                # This is hacky
+                # We should ensure types further upstream
+                # This solves TfL Phase 2 issue 
+
+                if isinstance(v, (str,int)):
+                    attribute_xml.text = str(v)
+                
+                elif isinstance(v, dict):
+                    attribute_xml.text = str(list(v.values())[0])
+
+                else:
+                    print(type(v))
+                    print(attributes)
+                    print(pid)
+                    print(v)
 
     write_xml(attributes_xml, location, matsim_DOCTYPE='objectAttributes', matsim_filename='objectattributes_v1')
 


### PR DESCRIPTION
An issue with expected types when writing to Matsim xml.

Output before fix:
```
  <object id="10002061023">
    <attribute class="java.lang.String" name="psex">{10002061023: 'Male'}</attribute>
    <attribute class="java.lang.String" name="page">{10002061023: 40}</attribute>
    <attribute class="java.lang.String" name="pdlicense">{10002061023: 1}</attribute>
    <attribute class="java.lang.String" name="hincome">{10002061023: 4}</attribute>
    <attribute class="java.lang.String" name="hsize">{10002061023: 4}</attribute>
    <attribute class="java.lang.String" name="hid">{10002061023: 640586395095}</attribute>
    <attribute class="java.lang.String" name="subpopulation">{10002061023: 'License'}</attribute>
    <attribute class="java.lang.String" name="source">{10002061023: 'phase-2-tfl'}</attribute>
  </object>
```

Output after fix:
```
<object id="10002061023">
    <attribute class="java.lang.String" name="psex">Male</attribute>
    <attribute class="java.lang.String" name="page">40</attribute>
    <attribute class="java.lang.String" name="pdlicense">1</attribute>
    <attribute class="java.lang.String" name="hincome">4</attribute>
    <attribute class="java.lang.String" name="hsize">4</attribute>
    <attribute class="java.lang.String" name="hid">10002061023</attribute>
    <attribute class="java.lang.String" name="subpopulation">License</attribute>
    <attribute class="java.lang.String" name="source">phase-2-tfl</attribute>
  </object>
```
I don't think this is solved, some more effort needs to go into ensuring types are correct. This should happen further upstream, likely at ingestion. At present, users will likely use the types as inferred by Pandas when reading from csv - as was the case with the example above. 

I present this improvement as an incremental change which should at least make debugging better.