### PR TITLE
make activity loader use first activity type, not assume home

### DIFF
--- a/pam/read.py
+++ b/pam/read.py
@@ -304,10 +304,14 @@ def load_activity_plan(
                 # home_area=home_area
             )
 
+            first_act = trips.iloc[0].activity.lower()
+            if not first_act == "home":
+                logger.warning(f" Person pid:{pid} hid:{hid} plan does not start with 'home' activity")
+
             person.add(
                 activity.Activity(
                     seq=0,
-                    act='home',
+                    act=first_act,
                     area=origin_area,
                     start_time=utils.minutes_to_datetime(0),
                 )


### PR DESCRIPTION
This makes the `load_activity_plan` method consistent with other methods, where it is not assumed the first activity is a `home` type. 

Came across this when using activity_plan type with freight, delivery plans. 