### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+**/.git
+**/reports

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim-stretch
 
 RUN apt-get update \
 && apt-get upgrade -y \
-&& apt-get -y install mono-mcs libspatialindex-dev --no-install-recommends \
+&& apt-get -y install libspatialindex-dev --no-install-recommends \
 && rm -rf /var/lib/apt/lists/* \
 && /usr/local/bin/python -m pip install --upgrade pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.7-slim-stretch
+
+RUN apt-get update \
+&& apt-get upgrade -y \
+&& apt-get -y install mono-mcs libspatialindex-dev --no-install-recommends \
+&& rm -rf /var/lib/apt/lists/* \
+&& /usr/local/bin/python -m pip install --upgrade pip
+
+COPY . .
+
+RUN pip3 install -e .
+ENV PYTHONPATH=./scripts:${PYTHONPATH}
+
+ENTRYPOINT ["python3"]


### PR DESCRIPTION
See https://arupdigital.atlassian.net/browse/LAB-1098

```
$ docker build -t "pam-draft-skinny" .

Sending build context to Docker daemon  28.93MB
Step 1/6 : FROM python:3.7-slim-stretch
 ---> c73214bf83f8
Step 2/6 : RUN apt-get update && apt-get upgrade -y && apt-get -y install mono-mcs libspatialindex-dev --no-install-recommends && rm -rf /var/lib/apt/lists/* && /usr/local/bin/python -m pip install --upgrade pip
 ---> Using cache
 ---> 49a6fa8a362f
Step 3/6 : COPY . .
 ---> c592c1a50134
Step 4/6 : RUN pip3 install -e .
 ---> Running in a24721df7301
Obtaining file:///
Collecting colorama==0.4.4
  Downloading colorama-0.4.4-py2.py3-none-any.whl (16 kB)
Collecting descartes==1.1.0
  Downloading descartes-1.1.0-py3-none-any.whl (5.8 kB)
Collecting geopandas==0.7.0
  Downloading geopandas-0.7.0-py2.py3-none-any.whl (928 kB)
Collecting ipykernel==5.2.1
  Downloading ipykernel-5.2.1-py3-none-any.whl (118 kB)
Collecting lxml==4.6.2
  Downloading lxml-4.6.2-cp37-cp37m-manylinux1_x86_64.whl (5.5 MB)
Collecting matplotlib==3.2.1
  Downloading matplotlib-3.2.1-cp37-cp37m-manylinux1_x86_64.whl (12.4 MB)
Collecting pandas>=1
  Downloading pandas-1.2.3-cp37-cp37m-manylinux1_x86_64.whl (9.9 MB)
Collecting Rtree==0.9.4
  Downloading Rtree-0.9.4.tar.gz (62 kB)
Collecting jupyter==1.0.0
...
```

```
$ docker images | grep pam
pam-draft-skinny    latest    a8f856e5abfa    52 minutes ago    791MB
```

```
docker run pam-draft-skinny notebooks/notebook_smoke_tests.py -d notebooks -k pam -k python37364bit373pyenve4f55e1c90f74740a9da8a10ea80341d -k python3

Installed kernelspec pam in /root/.local/share/jupyter/kernels/pam
Installed kernelspec python37364bit373pyenve4f55e1c90f74740a9da8a10ea80341d in /root/.local/share/jupyter/kernels/python37364bit373pyenve4f55e1c90f74740a9da8a10ea80341d
Installed kernelspec python3 in /root/.local/share/jupyter/kernels/python3
[NbConvertApp] Converting notebook notebooks/NTS Population Synthesis Example.ipynb to notebook
[NbConvertApp] Writing 362154 bytes to /tmp/NTS Population Synthesis Example.ipynb
[NbConvertApp] Converting notebook notebooks/PAM Policies walk-through.ipynb to notebook
[NbConvertApp] Writing 1133213 bytes to /tmp/PAM Policies walk-through.ipynb
[NbConvertApp] Converting notebook notebooks/PAM-stats.ipynb to notebook
...
------------------------------------------------------
Executing notebook 'notebooks/pam-getting-started.ipynb'...
jupyter nbconvert --ExecutePreprocessor.timeout=120 --to notebook --execute "notebooks/pam-getting-started.ipynb" --output-dir=/tmp
Shell process return value was 0
------------------------------------------------------
Executing notebook 'notebooks/vulnerability_probabilities.ipynb'...
jupyter nbconvert --ExecutePreprocessor.timeout=120 --to notebook --execute "notebooks/vulnerability_probabilities.ipynb" --output-dir=/tmp
Shell process return value was 0
------------------------------------------------------
Executing notebook 'notebooks/weighted-facility-sampling_demo.ipynb'...
jupyter nbconvert --ExecutePreprocessor.timeout=120 --to notebook --execute "notebooks/weighted-facility-sampling_demo.ipynb" --output-dir=/tmp
Shell process return value was 0

-------------------------------------------------------------
                        Summary
-------------------------------------------------------------
NTS Population Synthesis Example.ipynb: PASSED in 0:00:14
PAM Policies walk-through.ipynb: PASSED in 0:00:31
PAM-stats.ipynb: PASSED in 0:00:20
PAM_Complex_Policies.ipynb: PASSED in 0:00:17
PAM_Simple_Policies.ipynb: PASSED in 0:02:17
PAM_stability.ipynb: PASSED in 0:01:03
Travel plots.ipynb: PASSED in 0:00:05
pam-geo-sampling.ipynb: PASSED in 0:00:53
pam-getting-started.ipynb: PASSED in 0:00:26
vulnerability_probabilities.ipynb: PASSED in 0:00:05
weighted-facility-sampling_demo.ipynb: PASSED in 0:00:24

0 failed, 11 passed in 0:06:42
-------------------------------------------------------------
```

