### PR TITLE
Fix release file creation in CI build

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -49,7 +49,18 @@ jobs:
         aws-region: eu-west-1
     - name: Push zip to S3
       run: |
+        echo $GITHUB_REPOSITORY
+        echo $GITHUB_SHA
         echo $GITHUB_SHA > release
+        if test "$GITHUB_REF" = "refs/heads/master"; then
+          echo "Branch is master - no need to make a release name..."
+        else
+          echo "Making a release name for non-master branch..."
+          branch=`echo $GITHUB_REF | awk -F '/' '{print $3}'`
+          release_name=`echo $GITHUB_ACTOR-$branch`
+          echo "Release name: $release_name"
+          echo $release_name > release_name
+        fi
         zip -r app.zip .
         repo_slug=`echo $GITHUB_REPOSITORY | awk -F '/' '{print $2}'`
         echo $repo_slug

--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -49,7 +49,7 @@ jobs:
         aws-region: eu-west-1
     - name: Push zip to S3
       run: |
-        echo $BITBUCKET_COMMIT > release
+        echo $GITHUB_SHA > release
         zip -r app.zip .
         repo_slug=`echo $GITHUB_REPOSITORY | awk -F '/' '{print $2}'`
         echo $repo_slug


### PR DESCRIPTION
A fix for the CD build introduced for https://arupdigital.atlassian.net/browse/LAB-1098.

Caused this error in the [CodeBuild job](https://eu-west-1.console.aws.amazon.com/codesuite/codebuild/758645626094/projects/pam/build/pam%3A9968e11b-0282-4b30-9894-84806ee2786c/?region=eu-west-1), because there was no file called `release` inside the zip file (the CodeBuild job spec sets the env var via `SHA=$(cat release)`, hence `$SHA` is empty when read):

```
...
Step 6/6 : ENTRYPOINT python3
--
495 | ---> Running in dd01aa257ef2
496 | ---> ecc1247f3955
497 | Removing intermediate container dd01aa257ef2
498 | Successfully built ecc1247f3955
499 | Successfully tagged pam:latest
500 |  
501 | [Container] 2021/03/19 12:50:40 Running command docker tag $IMAGE_REPO_NAME $REPOSITORY_URI:$SHA
502 | Error parsing reference: "758645626094.dkr.ecr.eu-west-1.amazonaws.com/pam:" is not a valid repository/tag: invalid reference format
503 |  
504 | [Container] 2021/03/19 12:50:40 Command did not exit successfully docker tag $IMAGE_REPO_NAME $REPOSITORY_URI:$SHA exit status 1
505 | [Container] 2021/03/19 12:50:40 Phase complete: BUILD State: FAILED
506 | [Container] 2021/03/19 12:50:40 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: docker tag $IMAGE_REPO_NAME $REPOSITORY_URI:$SHA. Reason: exit status 1
```