### PR TITLE
zone -> hzone in write

### DIFF
--- a/pam/write.py
+++ b/pam/write.py
@@ -415,7 +415,7 @@ def to_csv(
         hh_data = {
             'hid': hid,
             'freq': hh.freq,
-            'zone': hh.location.area,
+            'hzone': hh.location.area,
         }
         if isinstance(hh.attributes, dict):
             hh_data.update(hh.attributes)
@@ -431,7 +431,7 @@ def to_csv(
                 'pid': pid,
                 'hid': hid,
                 'freq': person.freq,
-                'zone': hh.location.area,
+                'hzone': hh.location.area,
             }
             if isinstance(person.attributes, dict):
                 people_data.update(person.attributes)

--- a/tests/test_8_write.py
+++ b/tests/test_8_write.py
@@ -416,11 +416,11 @@ def test_write_to_csv_no_locs(population_heh, tmpdir):
         assert os.path.exists(os.path.join(tmpdir, f"{name}.csv"))
 
     hh_df = pd.read_csv(os.path.join(tmpdir, "households.csv"))
-    assert list(hh_df.columns) == ['hid', 'freq', 'zone']
+    assert list(hh_df.columns) == ['hid', 'freq', 'hzone']
     assert len(hh_df) == 1
 
     people_df = pd.read_csv(os.path.join(tmpdir, "people.csv"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'zone', 'hh_size', 'inc']
+    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
     assert len(people_df) == 1
 
     legs_df = pd.read_csv(os.path.join(tmpdir, "legs.csv"), index_col=0)
@@ -451,11 +451,11 @@ def test_write_to_csv_locs(population_heh, tmpdir):
         assert os.path.exists(os.path.join(tmpdir, f"{name}.csv"))
 
     hh_df = pd.read_csv(os.path.join(tmpdir, "households.csv"))
-    assert list(hh_df.columns) == ['hid', 'freq', 'zone']
+    assert list(hh_df.columns) == ['hid', 'freq', 'hzone']
     assert len(hh_df) == 1
 
     people_df = pd.read_csv(os.path.join(tmpdir, "people.csv"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'zone', 'hh_size', 'inc']
+    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
     assert len(people_df) == 1
 
     legs_df = pd.read_csv(os.path.join(tmpdir, "legs.csv"), index_col=0)
@@ -478,11 +478,11 @@ def test_write_to_csv_locs(population_heh, tmpdir):
         assert os.path.exists(os.path.join(tmpdir, f"{name}.geojson"))
 
     hh_df = gp.read_file(os.path.join(tmpdir, "households.geojson"))
-    assert list(hh_df.columns) == ['hid', 'freq', 'zone', 'geometry']
+    assert list(hh_df.columns) == ['hid', 'freq', 'hzone', 'geometry']
     assert len(hh_df) == 1
 
     people_df = gp.read_file(os.path.join(tmpdir, "people.geojson"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'zone', 'hh_size', 'inc', 'geometry']
+    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
     assert len(people_df) == 1
 
     legs_df = gp.read_file(os.path.join(tmpdir, "legs.geojson"), index_col=0)
@@ -520,11 +520,11 @@ def test_write_to_csv_some_locs(population_heh, tmpdir):
         assert os.path.exists(os.path.join(tmpdir, f"{name}.csv"))
 
     hh_df = pd.read_csv(os.path.join(tmpdir, "households.csv"))
-    assert list(hh_df.columns) == ['hid', 'freq', 'zone']
+    assert list(hh_df.columns) == ['hid', 'freq', 'hzone']
     assert len(hh_df) == 2
 
     people_df = pd.read_csv(os.path.join(tmpdir, "people.csv"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'zone', 'hh_size', 'inc']
+    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
     assert len(people_df) == 2
 
     legs_df = pd.read_csv(os.path.join(tmpdir, "legs.csv"), index_col=0)
@@ -547,11 +547,11 @@ def test_write_to_csv_some_locs(population_heh, tmpdir):
         assert os.path.exists(os.path.join(tmpdir, f"{name}.geojson"))
 
     hh_df = gp.read_file(os.path.join(tmpdir, "households.geojson"))
-    assert list(hh_df.columns) == ['hid', 'freq', 'zone', 'geometry']
+    assert list(hh_df.columns) == ['hid', 'freq', 'hzone', 'geometry']
     assert len(hh_df) == 2  
 
     people_df = gp.read_file(os.path.join(tmpdir, "people.geojson"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'zone', 'hh_size', 'inc', 'geometry']
+    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
     assert len(people_df) == 2
 
     legs_df = gp.read_file(os.path.join(tmpdir, "legs.geojson"), index_col=0)
@@ -578,11 +578,11 @@ def test_write_to_csv_convert_locs(population_heh, tmpdir):
         assert os.path.exists(os.path.join(tmpdir, f"{name}.csv"))
 
     hh_df = pd.read_csv(os.path.join(tmpdir, "households.csv"))
-    assert list(hh_df.columns) == ['hid', 'freq', 'zone']
+    assert list(hh_df.columns) == ['hid', 'freq', 'hzone']
     assert len(hh_df) == 1
 
     people_df = pd.read_csv(os.path.join(tmpdir, "people.csv"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'zone', 'hh_size', 'inc']
+    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
     assert len(people_df) == 1
 
     legs_df = pd.read_csv(os.path.join(tmpdir, "legs.csv"), index_col=0)
@@ -605,11 +605,11 @@ def test_write_to_csv_convert_locs(population_heh, tmpdir):
         assert os.path.exists(os.path.join(tmpdir, f"{name}.geojson"))
 
     hh_df = gp.read_file(os.path.join(tmpdir, "households.geojson"))
-    assert list(hh_df.columns) == ['hid', 'freq', 'zone', 'geometry']
+    assert list(hh_df.columns) == ['hid', 'freq', 'hzone', 'geometry']
     assert len(hh_df) == 1
 
     people_df = gp.read_file(os.path.join(tmpdir, "people.geojson"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'zone', 'hh_size', 'inc', 'geometry']
+    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
     assert len(people_df) == 1
 
     legs_df = gp.read_file(os.path.join(tmpdir, "legs.geojson"), index_col=0)


### PR DESCRIPTION
Very small fix to pam.write.

Seems like recent changes require writing the household location attribute as `hzone` rather than `zone` -- or else read will fail to pick it up, with this error:
https://github.com/arup-group/pam/blob/663f49d36b1c8533d44a6d71582b697eeee91d7f/pam/read.py#L236

