### PR TITLE
Pin pandas version to fix unit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ geopandas==0.7.0
 ipykernel==5.2.1
 lxml==4.6.2
 matplotlib==3.2.1
-pandas==1.2.5
+pandas==1.3.0
 Rtree==0.9.4
 jupyter==1.0.0
 jupyter-contrib-nbextensions==0.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ geopandas==0.7.0
 ipykernel==5.2.1
 lxml==4.6.2
 matplotlib==3.2.1
-pandas>=1
+pandas==1.2.5
 Rtree==0.9.4
 jupyter==1.0.0
 jupyter-contrib-nbextensions==0.5.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,6 +142,7 @@ def correct_cyclist_geodataframe():
 
 def test_build_geodataframe_for_pt_person(pt_person, correct_pt_person_geodataframe):
     gdf = pt_person.build_travel_geodataframe()
+    gdf = gdf[correct_pt_person_geodataframe.columns]
     assert_frame_equal(gdf, correct_pt_person_geodataframe)
 
 
@@ -156,6 +157,7 @@ def test_building_geodataframe_with_reprojection(pt_person, correct_pt_person_ge
 
 def test_build_geodataframe_for_cyclist(cyclist, correct_cyclist_geodataframe):
     gdf = cyclist.build_travel_geodataframe()
+    gdf = gdf[correct_cyclist_geodataframe.columns]
     assert_frame_equal(gdf, correct_cyclist_geodataframe)
 
 
@@ -168,6 +170,7 @@ def test_build_hhld_geodataframe(pt_person, cyclist, correct_pt_person_geodatafr
     correct_gdf = correct_gdf.append(correct_cyclist_geodataframe)
     correct_gdf = correct_gdf.reset_index(drop=True)
     correct_gdf['hid'] = 'household_id'
+    gdf = gdf[correct_gdf.columns]
     assert_frame_equal(gdf, correct_gdf)
 
 
@@ -190,7 +193,7 @@ def test_build_pop_geodataframe(pt_person, cyclist, correct_pt_person_geodatafra
     correct_gdf = correct_gdf.append(correct_cyclist_geodataframe)
 
     correct_gdf = correct_gdf.reset_index(drop=True)
-
+    gdf = gdf[correct_gdf.columns]
     assert_frame_equal(gdf, correct_gdf)
 
 


### PR DESCRIPTION
There has been a change in Pandas version `1.3.0` around the test utility function `assert_frame_equal` (see the [release notes](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.3.0.html#other)). Although I didn't look into exactly why this bug fix breaks some of our tests, regressing to Pandas `1.2.5`, which is the latest version that is older than `1.3`, fixes our tests.

I was able to reproduce the test failures locally via `pip install pandas==1.3.0`, and then fix via `pip install pandas==1.2.5`.

It may be worth someone with knowledge of the code and tests having a quick look to make sure the tests in question are not relying on broken behaviour in `assert_frame_equal()`.

The [build now completes](https://github.com/arup-group/pam/runs/3104892398?check_suite_focus=true).