### PR TITLE
Make S3 code bucket a build variable

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -48,6 +48,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: eu-west-1
     - name: Push zip to S3
+      env:
+        AWS_S3_CODE_BUCKET: ${{ secrets.AWS_S3_CODE_BUCKET }}
       run: |
         echo $GITHUB_REPOSITORY
         echo $GITHUB_SHA

--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -64,7 +64,7 @@ jobs:
         zip -r app.zip .
         repo_slug=`echo $GITHUB_REPOSITORY | awk -F '/' '{print $2}'`
         echo $repo_slug
-        aws s3 cp app.zip s3://arup-arup-ukimea-tcs-dev-test-code/$repo_slug.zip
+        aws s3 cp app.zip "s3://$AWS_S3_CODE_BUCKET/$repo_slug.zip"
     - name: Send build success notification
       if: success()
       uses: rtCamp/action-slack-notify@v2.0.0


### PR DESCRIPTION
Zip files are still being pushed to S3 by the CI build, as evidenced by the first zip file below, timestamped from a few minutes ago:

```bash
2021-09-06 10:04:18   29675625 ZXNljHl.zip
2021-08-26 15:05:11   24273416 thOjyJ2.zip
...
```