### PR TITLE
Jitterer

### DIFF
--- a/pam/samplers/time.py
+++ b/pam/samplers/time.py
@@ -1,0 +1,76 @@
+from random import randrange
+from datetime import timedelta
+from copy import deepcopy
+
+from pam.core import Population, Person, Household
+from pam.activity import Plan, Activity, Leg
+from pam.utils import minutes_to_datetime as mtdt
+from pam.utils import td_to_s, minutes_to_timedelta
+from pam.variables import END_OF_DAY
+
+
+def apply_jitter_to_plan(
+    plan: Plan,
+    jitter: timedelta,
+    min_duration: timedelta
+    ):
+    """
+    Apply time jitter to activity durations in a plan, leg durations are kept the same.
+    Activity durations are jittered in sequence order. At each step the activity
+    is jittered according to the maximum jitter and minimum duration of all activities
+    in the plan.
+    Args:
+        plan (Plan): plan to be jittered
+        jitter (timedelta): maximum jitter
+        min_duration (timedelta): minimum activity duration
+    """
+    if plan.length == 1:  # do nothing
+        return None
+    for i in range(0, plan.length-1, 2):
+        jitter_activity(plan, i, jitter=jitter, min_duration=min_duration)
+
+
+def jitter_activity(
+    plan: Plan,
+    i: int,
+    jitter: timedelta,
+    min_duration: timedelta
+    ):
+    """
+    Jitter duration of given activity at index i. Remaining activities and legs after activity are also shifted.
+    Leg durations are not changed.
+    Subsequent activity durations are equally change to maintain 24hr plan.
+    """
+    act = plan[i]
+    if not isinstance(act, Activity):
+        raise UserWarning(f"Expected type of Activity for act, not {type(act)}")
+
+    prev_duration = act.duration
+    tail = (len(plan) - i)/2
+
+    min_start = max(act.start_time + min_duration, act.end_time - jitter)
+
+    allowance = plan[-1].end_time - act.end_time
+    for j in range(i+1, len(plan), 2):  # legs
+        allowance =- plan[j].duration
+    for j in range(i+2, len(plan)+1, 2):  # acts
+        allowance =- min_duration
+
+    max_end = min(plan[-1].end_time - allowance, act.end_time + jitter)
+    duration = (max_end - min_start).seconds
+
+    new_duration = timedelta(seconds=randrange(duration))
+    change = (new_duration - prev_duration)/tail
+
+    time = act.shift_duration(new_duration)
+    time = plan[i+1].shift_start_time(time)  # shift first tail leg
+
+    for j in range(i+2, len(plan)-1, 2):  # tail acts
+        time = plan[j].shift_start_time(time)
+        time = plan[j].shift_duration(plan[j].duration-change)
+        time = plan[j+1].shift_start_time(time)  # leg
+
+    # final act
+    time = plan[-1].shift_start_time(time)
+    plan[-1].end_time = END_OF_DAY
+

--- a/pam/samplers/time.py
+++ b/pam/samplers/time.py
@@ -48,7 +48,7 @@ def jitter_activity(
     prev_duration = act.duration
     tail = (len(plan) - i)/2
 
-    min_start = max(act.start_time + min_duration, act.end_time - jitter)
+    min_end = max(act.start_time + min_duration, act.end_time - jitter)
 
     allowance = plan[-1].end_time - act.end_time
     for j in range(i+1, len(plan), 2):  # legs
@@ -57,9 +57,10 @@ def jitter_activity(
         allowance =- min_duration
 
     max_end = min(plan[-1].end_time - allowance, act.end_time + jitter)
-    duration = (max_end - min_start).seconds
+    jitter_range = (max_end - min_end).seconds
 
-    new_duration = timedelta(seconds=randrange(duration))
+    jitter = timedelta(seconds=randrange(jitter_range))
+    new_duration = min_end - act.start_time + jitter
     change = (new_duration - prev_duration)/tail
 
     time = act.shift_duration(new_duration)

--- a/pam/scoring.py
+++ b/pam/scoring.py
@@ -146,24 +146,21 @@ class CharyparNagelPlanScorer:
         activities = list(plan.activities)
         if len(activities) == 1:
             return self.score_activity(activities[0], cnfg)
-        wrapped_activity, other_activities = self.activities_wrapper(activities)
-        return self.score_activity(wrapped_activity, cnfg) \
-            + sum([self.score_activity(act, cnfg) for act in other_activities if act.act != "pt interaction"])
+        activities = self.activities_wrapper(activities)
+        return sum([self.score_activity(act, cnfg) for act in activities if act.act != "pt interaction"])
 
 
     def activities_wrapper(self, activities):
-        non_wrapped = activities[1:-1]
         if not activities[0].act == activities[-1].act:
-            self.logger.warning(
-                f"Wrapping non-alike activities: {activities[0].act} -> {activities[-1].act}"
-                )
+            return activities
 
-        wrapped_act = Activity(
+        activities[-1] = Activity(
             act=activities[0].act,
             start_time=activities[-1].start_time,
             end_time=activities[0].end_time + td(days=1)
         )
-        return wrapped_act, non_wrapped
+        del activities[0]
+        return activities
 
     def score_activity(self, activity, cnfg):
         return sum([

--- a/pam/scoring.py
+++ b/pam/scoring.py
@@ -146,21 +146,24 @@ class CharyparNagelPlanScorer:
         activities = list(plan.activities)
         if len(activities) == 1:
             return self.score_activity(activities[0], cnfg)
-        activities = self.activities_wrapper(activities)
-        return sum([self.score_activity(act, cnfg) for act in activities if act.act != "pt interaction"])
+        wrapped_activity, other_activities = self.activities_wrapper(activities)
+        return self.score_activity(wrapped_activity, cnfg) \
+            + sum([self.score_activity(act, cnfg) for act in other_activities if act.act != "pt interaction"])
 
 
     def activities_wrapper(self, activities):
+        non_wrapped = activities[1:-1]
         if not activities[0].act == activities[-1].act:
-            return activities
+            self.logger.warning(
+                f"Wrapping non-alike activities: {activities[0].act} -> {activities[-1].act}"
+                )
 
-        activities[-1] = Activity(
+        wrapped_act = Activity(
             act=activities[0].act,
             start_time=activities[-1].start_time,
             end_time=activities[0].end_time + td(days=1)
         )
-        del activities[0]
-        return activities
+        return wrapped_act, non_wrapped
 
     def score_activity(self, activity, cnfg):
         return sum([

--- a/tests/test_13_sample_time.py
+++ b/tests/test_13_sample_time.py
@@ -23,7 +23,7 @@ def test_jitter_activity_mid_plan(Steve):
     assert Steve.plan.validate()
 
 
-def test_jitter_activity_mid_plan2(Steve):
+def test_jitter_activity_later_in_plan(Steve):
     jitter_activity(
         plan = Steve.plan,
         i = 4,

--- a/tests/test_13_sample_time.py
+++ b/tests/test_13_sample_time.py
@@ -1,0 +1,42 @@
+from datetime import timedelta
+from tests.fixtures import Steve
+from pam.samplers.time import jitter_activity, apply_jitter_to_plan
+
+
+def test_jitter_activity(Steve):
+    jitter_activity(
+        plan = Steve.plan,
+        i = 0,
+        jitter = timedelta(minutes=5),
+        min_duration = timedelta(minutes=5)
+        )
+    assert Steve.plan.validate()
+
+
+def test_jitter_activity_mid_plan(Steve):
+    jitter_activity(
+        plan = Steve.plan,
+        i = 2,
+        jitter = timedelta(minutes=5),
+        min_duration = timedelta(minutes=5)
+        )
+    assert Steve.plan.validate()
+
+
+def test_jitter_activity_mid_plan2(Steve):
+    jitter_activity(
+        plan = Steve.plan,
+        i = 4,
+        jitter = timedelta(minutes=5),
+        min_duration = timedelta(minutes=5)
+        )
+    assert Steve.plan.validate()
+
+
+def test_apply_jitter_to_plan(Steve):
+    apply_jitter_to_plan(
+        plan = Steve.plan,
+        jitter = timedelta(minutes=5),
+        min_duration = timedelta(minutes=5)
+        )
+    assert Steve.plan.validate()

--- a/tests/test_2_activity_components.py
+++ b/tests/test_2_activity_components.py
@@ -143,3 +143,41 @@ def test_locations_equal_with_no_shared_location_type():
     locationd = Location(loc=None, link=2, area=None)
     with pytest.raises(UserWarning):
         assert not locationb == locationd
+
+
+def test_plan_contains_empty():
+    plan = Plan()
+    assert Activity() not in plan
+
+
+def test_plan_contains_true():
+    plan = Plan()
+    act = Activity(start_time=0, loc=0)
+    plan.add(act)
+    assert act in plan
+
+
+def test_plan_contains_true_multiple():
+    plan = Plan()
+    act = Activity(start_time=0, loc=0)
+    plan.add(act)
+    plan.add(Leg())
+    plan.add(Activity(start_time=1, loc=0))
+    assert act in plan
+
+
+def test_plan_contains_true_multiple_different_order():
+    plan = Plan()
+    plan.add(Activity(start_time=0, loc=0))
+    plan.add(Leg())
+    act = Activity(start_time=1, loc=0)
+    plan.add(act)
+    assert act in plan
+
+
+def test_plan_contains_false():
+    plan = Plan()
+    act = Activity(start_time=0, loc=0)
+    plan.add(act)
+    act = Activity(start_time=0, loc=1)
+    assert act not in plan


### PR DESCRIPTION
Adds a time.jitter function to pam.samplers.

```
def apply_jitter_to_plan(
    plan: Plan,
    jitter: timedelta,
    min_duration: timedelta
    ):
```

> Apply time jitter to activity durations in a plan, leg durations are kept the same. Activity durations are jittered in sequence order. At each step the activity is jittered according to the maximum jitter and minimum duration of all activities in the plan.

Hard to test but experience has been good so far.

@alex-kaye @ana-kop I share with you because this might be useful in a random walk implementation, eg:

```
def sort_of_random_walk(plan, steps=n):
    best_score = scorer.score(plan)
    for i in range(n):
        proposed_plan = deepcopy(plan)
        apply_jitter_to_plan(proposed_plan, ...)
        score = scorer.score(proposed_plan)
        if score > best_score:
            plan = proposed_plan
            best_score = score
```