### PR TITLE
Updated Rtree version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lxml==4.6.5
 matplotlib==3.2.1
 memory-profiler==0.58.0
 pandas==1.3.0
-Rtree==0.9.4
+Rtree==0.9.7
 jupyter==1.0.0
 jupyter-contrib-nbextensions==0.5.1
 pytest>=5


### PR DESCRIPTION
Change from Rtree==0.9.4 to 0.9.7. `pip install -e` fails with Rtree==0.9.4.