### PR TITLE
read non-selected plans

### DIFF
--- a/pam/core.py
+++ b/pam/core.py
@@ -701,6 +701,7 @@ class Person:
         self.person_freq = freq
         self.attributes = attributes
         self.plan = activity.Plan(home_area=home_area)
+        self.plans_non_selected = []
         self.home_area = home_area
         self.vehicle = None
         if vehicle:

--- a/tests/test_3_read_matsim.py
+++ b/tests/test_3_read_matsim.py
@@ -2,6 +2,7 @@ import os
 import pytest
 
 from pam.read import load_attributes_map, read_matsim
+from pam.activity import Plan
 
 
 test_trips_path = os.path.abspath(
@@ -127,3 +128,13 @@ def test_fail_v12_plus_attributes():
 def test_fail_bad_version():
     with pytest.raises(UserWarning):
         population = read_matsim(test_tripsv12_path, version=1)
+
+def test_parse_simple_matsim_non_selected():
+   population = read_matsim(test_trips_path, test_attributes_path, keep_non_selected=True)
+   person1 = population['census_1']['census_1']
+   person2 = population['census_2']['census_2']
+   assert person1.has_valid_plan
+   assert person2.has_valid_plan
+   assert len(person1.plans_non_selected) == 1
+   assert len(person2.plans_non_selected) == 0
+   assert isinstance(person1.plans_non_selected[0], Plan)


### PR DESCRIPTION
Enables PAM to read non-selected plans from MATSim plan outputs. This option is enabled by setting the `keep_non_selected` argument of the `read.read_matsim` as True. The non-selected plans are stored as a list of plans under person.plans_non_selected.

```
population = read.read_matsim(
    plans_path = "output_plans.xml.gz",
    crop = False,
    keep_non_selected = True
)

population.random_person().plans_non_selected
```
>>returns: [<pam.Plan>, <pam.Plan>, etc]



