### PR TITLE
Home area fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ weighted-facility-sampling_demo.ipynb
 notebooks/Downloads/
 outputs/
 michael-local-requirements.txt
+venv

--- a/pam/activity.py
+++ b/pam/activity.py
@@ -2,7 +2,9 @@ from datetime import datetime
 from datetime import timedelta
 import logging
 from copy import copy
+from sunau import Au_read
 
+from pam.location import Location
 from pam.plot import plans as plot
 import pam.utils
 import pam.variables
@@ -12,9 +14,16 @@ from pam.variables import END_OF_DAY
 
 class Plan:
 
-    def __init__(self, home_area=None, freq=None):
+    def __init__(self, home_area=None, home_location:Location=None, home_loc=None, freq=None):
         self.day = []
-        self.home_location = Location(area=home_area)
+        if home_location:
+            self.home_location = home_location
+        else:
+            self.home_location = Location()
+        if home_area:
+            self.home_location.area = home_area
+        if home_loc:
+            self.home_location.loc = home_loc
         self.logger = logging.getLogger(__name__)
         self.plan_freq = freq
         self.score = None
@@ -983,49 +992,3 @@ class Leg(PlanComponent):
         # calculate leg euclidean distance in km:
         # assumes grid definition of Location class
         return ((self.end_location.loc.x-self.start_location.loc.x)**2 + (self.end_location.loc.y-self.start_location.loc.y)**2)**0.5 / 1000
-
-
-class Location:
-    def __init__(self, loc=None, link=None, area=None):
-        self.loc = loc
-        self.link = link
-        self.area = area
-
-    @property
-    def min(self):
-        if self.loc is not None:
-            return self.loc
-        if self.link is not None:
-            return self.link
-        if self.area is not None:
-            return self.area
-
-    @property
-    def max(self):
-        if self.area is not None:
-            return self.area
-        if self.link is not None:
-            return self.link
-        if self.loc is not None:
-            return self.loc
-
-    @property
-    def exists(self):
-        if self.area or self.link or self.loc:
-            return True
-
-    def __str__(self):
-        return str(self.min)
-
-    def __eq__(self, other):
-        if isinstance(other, str):
-            return self.area == other
-        if self.loc is not None and other.loc is not None:
-            return self.loc == other.loc
-        if self.link is not None and other.link is not None:
-            return self.link == other.link
-        if self.area is not None and other.area is not None:
-            return self.area == other.area
-        raise UserWarning(
-            "Cannot check for location equality without same loc types (areas/locs/links)."
-        )

--- a/pam/activity.py
+++ b/pam/activity.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from datetime import timedelta
 import logging
 from copy import copy
-from sunau import Au_read
+from typing import Optional
 
 from pam.location import Location
 from pam.plot import plans as plot
@@ -14,7 +14,13 @@ from pam.variables import END_OF_DAY
 
 class Plan:
 
-    def __init__(self, home_area=None, home_location:Location=None, home_loc=None, freq=None):
+    def __init__(
+        self,
+        home_area=None,
+        home_location: Optional[Location] = None,
+        home_loc=None,
+        freq=None
+        ):
         self.day = []
         if home_location:
             self.home_location = home_location

--- a/pam/core.py
+++ b/pam/core.py
@@ -3,7 +3,7 @@ import random
 import pickle
 import copy
 from collections import defaultdict
-from typing import Union
+from typing import Optional
 
 from pam.location import Location
 import pam.activity as activity
@@ -477,7 +477,7 @@ class Household:
         hid,
         attributes={},
         freq=None,
-        location: Location = None,
+        location: Optional[Location] = None,
         area=None,
         loc=None
         ):
@@ -734,7 +734,7 @@ class Person:
         pid,
         freq=None,
         attributes={},
-        home_location: Location = None,
+        home_location: Optional[Location] = None,
         home_area=None,
         home_loc=None,
         vehicle: Vehicle = None

--- a/pam/core.py
+++ b/pam/core.py
@@ -5,6 +5,7 @@ import copy
 from collections import defaultdict
 from typing import Union
 
+from pam.location import Location
 import pam.activity as activity
 import pam.plot as plot
 from pam import write
@@ -471,15 +472,27 @@ class Population:
 class Household:
     logger = logging.getLogger(__name__)
 
-    def __init__(self, hid, attributes={}, freq=None, area=None, loc=None):
+    def __init__(
+        self,
+        hid,
+        attributes={},
+        freq=None,
+        location: Location = None,
+        area=None,
+        loc=None
+        ):
         self.hid = hid
         self.people = {}
         self.attributes = attributes
         self.hh_freq=freq
-        if area is not None or loc is not None:
-            self._location = activity.Location(area=area, loc=loc)
+        if location:
+            self._location = location
         else:
-            self._location = None
+            self._location = Location()
+        if area:  # potential overwrite
+            self._location.area = area
+        if loc:  # potential overwrite
+            self._location.loc = loc
 
     def add(self, person):
         if not isinstance(person, Person):
@@ -537,12 +550,32 @@ class Household:
 
     @property
     def location(self):
-        if self._location is not None:
+        if self._location.exists:
             return self._location
         for person in self.people.values():
-            if person.home is not None:
+            if person.home.exists:
                 return person.home
         self.logger.warning(f"Failed to find location for household: {self.hid}")
+        return self._location
+
+    def set_location(self, location:Location):
+        """
+        Set both hh and person home_location, but note that hhs and
+        their persons do not share location object.
+        """
+        self._location = location
+        for _, person in self:
+            person.set_location(location.copy())
+
+    def set_area(self, area):
+        self._location.area = area
+        for _, person in self:
+            person.set_area(area)
+
+    def set_loc(self, loc):
+        self._location.loc = loc
+        for _, person in self:
+            person.set_loc(loc)
 
     @property
     def activity_classes(self):
@@ -696,13 +729,29 @@ class Household:
 class Person:
     logger = logging.getLogger(__name__)
 
-    def __init__(self, pid, freq=None, attributes={}, home_area=None, vehicle: Vehicle = None):
+    def __init__(
+        self,
+        pid,
+        freq=None,
+        attributes={},
+        home_location: Location = None,
+        home_area=None,
+        home_loc=None,
+        vehicle: Vehicle = None
+        ):
         self.pid = pid
         self.person_freq = freq
         self.attributes = attributes
-        self.plan = activity.Plan(home_area=home_area)
+        if home_location is not None:
+            self.home_location = home_location
+        else:
+            self.home_location = Location()
+        if home_area:
+            self.home_location.area = home_area
+        if home_loc:
+            self.home_location.loc = home_loc
+        self.plan = activity.Plan(home_location=self.home_location)  # person and their plan share Location
         self.plans_non_selected = []
-        self.home_area = home_area
         self.vehicle = None
         if vehicle:
             self.assign_vehicle(vehicle)
@@ -748,8 +797,22 @@ class Person:
 
     @property
     def home(self):
+        if self.home_location.exists:
+            return self.home_location
         if self.plan:
             return self.plan.home
+
+    def set_location(self, location:Location):
+        self.home_location = location
+        self.plan.home_location = location
+
+    def set_area(self, area):
+        self.home_location.area = area
+        self.plan.home_location.area = area
+
+    def set_loc(self, loc):
+        self.home_location.loc = loc
+        self.plan.home_location.loc = loc
 
     @property
     def activities(self):

--- a/pam/location.py
+++ b/pam/location.py
@@ -1,0 +1,47 @@
+class Location:
+    def __init__(self, loc=None, link=None, area=None):
+        self.loc = loc
+        self.link = link
+        self.area = area
+
+    @property
+    def min(self):
+        if self.loc is not None:
+            return self.loc
+        if self.link is not None:
+            return self.link
+        if self.area is not None:
+            return self.area
+
+    @property
+    def max(self):
+        if self.area is not None:
+            return self.area
+        if self.link is not None:
+            return self.link
+        if self.loc is not None:
+            return self.loc
+
+    @property
+    def exists(self):
+        if self.area or self.link or self.loc:
+            return True
+
+    def __str__(self):
+        return str(self.min)
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            return self.area == other
+        if self.loc is not None and other.loc is not None:
+            return self.loc == other.loc
+        if self.link is not None and other.link is not None:
+            return self.link == other.link
+        if self.area is not None and other.area is not None:
+            return self.area == other.area
+        raise UserWarning(
+            "Cannot check for location equality without same loc types (areas/locs/links)."
+        )
+
+    def copy(self):
+        return Location(loc=self.loc, link=self.link, area=self.area)

--- a/pam/read.py
+++ b/pam/read.py
@@ -642,7 +642,7 @@ def trip_based_travel_diary_read(
                 person.stay_at_home()
                 continue
 
-            home_area = household.location.area or person_trips.hzone.iloc[0]
+            home_area = getattr(household.location, 'area', None) or person_trips.hzone.iloc[0]
             origin_area = person_trips.ozone.iloc[0]
 
             if not origin_area == home_area:
@@ -767,7 +767,7 @@ def from_to_travel_diary_read(
             else:
                 person_attributes = {}
 
-            home_area = household.location.area or person_attributes.get('hzone', None)
+            home_area = getattr(household.location, 'area', None) or person_attributes.get('hzone', None)
 
             person = core.Person(
                 pid,

--- a/pam/read.py
+++ b/pam/read.py
@@ -448,7 +448,7 @@ def add_persons_from_persons_attributes(
             person = core.Person(
                 pid,
                 attributes=person_attributes,
-                home_area=person_attributes.pop('hzone', None),
+                home_area=person_attributes.get('hzone', None),
                 freq=person_attributes.pop('freq', None)
                 )
             household.add(person)
@@ -642,7 +642,7 @@ def trip_based_travel_diary_read(
                 person.stay_at_home()
                 continue
 
-            home_area = person_trips.hzone.iloc[0]
+            home_area = household.location.area or person_trips.hzone.iloc[0]
             origin_area = person_trips.ozone.iloc[0]
 
             if not origin_area == home_area:
@@ -657,7 +657,7 @@ def trip_based_travel_diary_read(
                 pid,
                 attributes=person_attributes,
                 freq=person_attributes.pop('freq', None),
-                # home_area=home_area
+                home_area=home_area
             )
 
             loc = None
@@ -767,10 +767,13 @@ def from_to_travel_diary_read(
             else:
                 person_attributes = {}
 
+            home_area = household.location.area or person_attributes.get('hzone', None)
+
             person = core.Person(
                 pid,
                 attributes=person_attributes,
                 freq=person_attributes.pop('freq', None),
+                home_area=home_area
             )
 
             first_act = person_trips.iloc[0].oact.lower()

--- a/tests/test_2_activity_plan.py
+++ b/tests/test_2_activity_plan.py
@@ -187,7 +187,7 @@ def test_move_activity_with_home_default():
 
     plan.move_activity(2)
 
-    assert plan[2].location == 'a'
+    assert plan[2].location.area == 'a'
 
 
 def test_move_activity_with_home_default_updates_legs():
@@ -200,8 +200,8 @@ def test_move_activity_with_home_default_updates_legs():
 
     plan.move_activity(2)
 
-    assert plan[1].end_location == 'a'
-    assert plan[3].start_location == 'a'
+    assert plan[1].end_location.area == 'a'
+    assert plan[3].start_location.area == 'a'
 
 
 def test_move_activity_with_different_default():

--- a/tests/test_3_read_travel_diary.py
+++ b/tests/test_3_read_travel_diary.py
@@ -113,8 +113,6 @@ def test_build_population_from_persons_and_hhs(hhs_attributes, persons_attribute
 
 
 def test_read_trips_only(trips):
-    print(trips.describe())
-    print(trips.dtypes)
     population = load_travel_diary(trips=trips)
     assert len(population) == 3
 
@@ -351,7 +349,7 @@ def test_use_trips_freq_as_persons_and_hhs_freq_no_persons_attributes(trips):
 
 def test_trip_based_encoding(trips):
     population = load_travel_diary(trips=trips, tour_based=False)
-    assert len(population) == 3 
+    assert len(population) == 3
 
 
 def test_act_based_encoding(activity_encoded_trips):
@@ -367,11 +365,11 @@ def test_read_trips_location(trips):
         persons_attributes=None,
         hhs_attributes=None
         )
-    assert population[0][0].home_area == 'Harrow'
-    
-    # person and household location match 
+    assert population[0][0].home.area == 'Harrow'
+
+    # person and household location match
     for hid, pid, person in population.people():
-        assert person.home_area == population[hid].location.area
+        assert person.home.area == population[hid].location.area
 
 
 def test_read_trips_and_persons_and_hhs_home_location(trips, persons_attributes, hhs_attributes):
@@ -380,8 +378,46 @@ def test_read_trips_and_persons_and_hhs_home_location(trips, persons_attributes,
         persons_attributes=persons_attributes,
         hhs_attributes=hhs_attributes
         )
-    assert population[0][0].home_area == 'Harrow'
-    
-    # person and household location match 
+    assert population[0][0].home.area == 'Harrow'
+
+    # person and household location match
     for hid, pid, person in population.people():
-        assert person.home_area == population[hid].location.area
+        assert person.home.area == population[hid].location.area
+
+
+def test_home_location_consistency_between_person_and_plan(trips, persons_attributes, hhs_attributes):
+    """
+    Note that this works because people share a location object with their plans.
+    """
+    population = load_travel_diary(
+        trips=trips,
+        persons_attributes=persons_attributes,
+        hhs_attributes=hhs_attributes
+        )
+    hh = population[0]
+    person = hh[0]
+    assert person.home.area == "Harrow"
+    assert person.plan.home == "Harrow"
+    person.home.area = "Test"
+    assert person.home.area == "Test"
+    assert person.plan.home == "Test"
+
+
+def test_home_location_consistency_between_hhs_and_persons_when_changing_hh_area(trips, persons_attributes, hhs_attributes):
+    population = load_travel_diary(
+        trips=trips,
+        persons_attributes=persons_attributes,
+        hhs_attributes=hhs_attributes
+        )
+    hh = population[0]
+    person = hh[0]
+
+    assert hh.location.area == "Harrow"
+    assert person.home == "Harrow"
+    hh.location.area = "Test"
+    assert person.home == "Harrow"  # no change
+    hh.set_area("Test")
+    hh.set_loc("Test")
+    assert person.home == "Test"
+    assert hh.location == person.home
+

--- a/tests/test_3_read_travel_diary.py
+++ b/tests/test_3_read_travel_diary.py
@@ -357,3 +357,31 @@ def test_trip_based_encoding(trips):
 def test_act_based_encoding(activity_encoded_trips):
     population = load_travel_diary(trips=activity_encoded_trips)
     assert len(population) == 3
+
+
+# test inferring home location
+
+def test_read_trips_location(trips):
+    population = load_travel_diary(
+        trips=trips,
+        persons_attributes=None,
+        hhs_attributes=None
+        )
+    assert population[0][0].home_area == 'Harrow'
+    
+    # person and household location match 
+    for hid, pid, person in population.people():
+        assert person.home_area == population[hid].location.area
+
+
+def test_read_trips_and_persons_and_hhs_home_location(trips, persons_attributes, hhs_attributes):
+    population = load_travel_diary(
+        trips=trips,
+        persons_attributes=persons_attributes,
+        hhs_attributes=hhs_attributes
+        )
+    assert population[0][0].home_area == 'Harrow'
+    
+    # person and household location match 
+    for hid, pid, person in population.people():
+        assert person.home_area == population[hid].location.area


### PR DESCRIPTION
Tries to bring more consistency when assigning home locations to persons. If a household location exists, it will get assigned as the `home_location` for every household member. This ensures that all household members will have the same home location, and that agents without any activities ("stay at home") will still have a location.

If there is no household location, PAM will infer the home location from the trips/activities table.