### PR TITLE
Fix the code coverage script path in the daily scheduled CI build

### DIFF
--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Run tests
       run: |
         export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-        ./scripts/code-coverage.sh
+        ./scripts/code-qa/code-coverage.sh
 
     - name: Send build success notification
       if: success()


### PR DESCRIPTION
The daily scheduled build failed because the code coverage script has moved:

<img width="1014" alt="Screen Shot 2022-05-13 at 15 48 25" src="https://user-images.githubusercontent.com/250899/168309228-02fe4a80-39cc-4a19-9f3e-00e724d0cd3c.png">
