### PR TITLE
implements one-hot encode decode and distances

### DIFF
--- a/pam/array/decode.py
+++ b/pam/array/decode.py
@@ -1,0 +1,139 @@
+import numpy as np
+from datetime import datetime, timedelta
+
+from pam.activity import Plan, Activity, Leg
+from pam.variables import START_OF_DAY, END_OF_DAY
+
+
+def one_hot_to_plan(
+    array:np.array,
+    mapping:dict,
+    bin_size:int=3600,
+    duration:int=86400,
+    start_of_day:datetime=START_OF_DAY,
+    end_of_day:datetime=END_OF_DAY,
+    leg_encoding:str="travel",
+    default_leg_mode:str="car",
+    default_activity:str="other"
+    ) -> Plan:
+    """
+    Decode a one-hot encoded plan array for a given mapping. Attempts to create a valida plan sequence
+    by assuming obviously missing components. Does not support locations, these must be created
+    manually.
+
+    Args:
+        array (np.array): input one-hot encoded plan.
+        mapping (dict): encoding index to activity, eg {0: 'home', 1:'travel'}.
+        bin_size (int, optional): in seconds. Defaults to 3600.
+        duration (int, optional): in seconds. Defaults to 86400.
+        start_of_day (datetime, optional): start datetime of first activity. Defaults to START_OF_DAY.
+        end_of_day (datetime, optional): end time of last activity. Defaults to END_OF_DAY.
+        leg_encoding (str, optional): activity encoding for travel components. Defaults to "travel".
+        default_leg_mode (str, optional): assumed leg mode when unknown. Defaults to "car".
+        default_activity (str, optional): assumed activity when unknown. Defaults to "other".
+
+    Raises:
+        UserWarning: may raise a UserWarning if bin_size and duration are not consistent with array size.
+
+    Returns:
+        Plan: pam.activity.Plan
+    """
+    bins = int(duration / bin_size)
+    if not len(array) == bins:
+        raise UserWarning("Specified plan duration and bin lengths do not match given array length.")
+
+    proposed_plan = []
+    for act, start_time in iter_array(
+        array=array,
+        mapping=mapping,
+        start_of_day=start_of_day,
+        bin_size=bin_size
+        ):
+        if act == leg_encoding:  # add leg
+            proposed_plan.append(Leg(mode=default_leg_mode, start_time=start_time))
+        else:
+            proposed_plan.append(Activity(act=act, start_time=start_time))
+
+    add_end_times(proposed_plan, end_of_day)
+    print(proposed_plan)
+    fix_missing_start_activity(proposed_plan, start_of_day, bin_size)
+    fix_missing_end_activity(proposed_plan, end_of_day, bin_size)
+    fix_missing_components(proposed_plan, default_leg_mode, default_activity)
+
+    plan = Plan()
+    plan.day = proposed_plan
+    return plan
+
+
+def iter_array(array, mapping, start_of_day=START_OF_DAY, bin_size=3600):
+    prev = None
+    for i, time_bin in enumerate(array):
+        if (prev is None) or (not np.array_equal(time_bin, prev)):  # new component class
+            component_class = mapping.get(np.argmax(time_bin))
+            if component_class is None:
+                raise UserWarning(f"Not found index of {np.argmax(time_bin)} in supplied mapping: {mapping}.")
+            yield component_class, start_of_day + timedelta(seconds=(i * bin_size))
+        prev = time_bin
+
+
+def add_end_times(plan:list, end_of_day=END_OF_DAY):
+    # add end_times
+    for i in range(len(plan)-1):
+        plan[i].end_time = plan[i+1].start_time
+    plan[-1].end_time = end_of_day
+
+
+def fix_missing_start_activity(plan:list, start_of_day=START_OF_DAY, bin_size=3600):
+    if not isinstance(plan[0], Activity):
+        end_time = start_of_day + timedelta(seconds=int(bin_size/2))  # expected duration
+        plan.insert(
+            0,
+            Activity(
+                act="home",  # sensible assumption
+                start_time=start_of_day,
+                end_time=end_time
+            ))
+        plan[1].start_time = end_time
+
+
+def fix_missing_end_activity(plan:list, end_of_day=END_OF_DAY, bin_size=3600):
+    if not isinstance(plan[-1], Activity):
+        start_time = end_of_day - timedelta(seconds=int(bin_size/2))  # expected duration
+        plan.append(
+            Activity(
+                act="home",  # sensible assumption
+                start_time=start_time,
+                end_time=end_of_day
+            ))
+        plan[-2].end_time = start_time
+
+
+def fix_missing_components(plan:list, bin_size=3600, default_leg_mode="car", default_activity="other"):
+    for i in range(len(plan)-1):
+        if type(plan[i]) is type(plan[i+1]):
+            start_time = plan[i].end_time - timedelta(seconds=int(bin_size/4))
+            end_time = plan[i].end_time + timedelta(seconds=int(bin_size/4))
+
+            if isinstance(plan[i], Activity):  # add missing Leg
+                plan.insert(
+                    i+1,
+                    Leg(
+                        mode=default_leg_mode,
+                        start_time=start_time,
+                        end_time=end_time
+                    )
+                )
+                plan[i].end_time = start_time
+                plan[i+2].start_time = end_time
+
+            if isinstance(plan[i], Leg):  # add missing Activity
+                plan.insert(
+                    i+1,
+                    Activity(
+                        act=default_activity,
+                        start_time=start_time,
+                        end_time=end_time
+                    )
+                )
+                plan[i].end_time = start_time
+                plan[i+2].start_time = end_time

--- a/pam/array/decode.py
+++ b/pam/array/decode.py
@@ -17,7 +17,7 @@ def one_hot_to_plan(
     default_activity:str="other"
     ) -> Plan:
     """
-    Decode a one-hot encoded plan array for a given mapping. Attempts to create a valida plan sequence
+    Decode a one-hot encoded plan array for a given mapping. Attempts to create a valid plan sequence
     by assuming obviously missing components. Does not support locations, these must be created
     manually.
 
@@ -55,7 +55,6 @@ def one_hot_to_plan(
             proposed_plan.append(Activity(act=act, start_time=start_time))
 
     add_end_times(proposed_plan, end_of_day)
-    print(proposed_plan)
     fix_missing_start_activity(proposed_plan, start_of_day, bin_size)
     fix_missing_end_activity(proposed_plan, end_of_day, bin_size)
     fix_missing_components(proposed_plan, default_leg_mode, default_activity)

--- a/pam/array/distance.py
+++ b/pam/array/distance.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+
+def accuracy(actual:np.array, predicted:np.array) -> float:
+    assert actual.shape == predicted.shape
+    correct = 0
+    for ia, ib in zip(actual, predicted):
+        if np.argmax(ia) == np.argmax(ib):
+            correct += 1
+    return correct / len(predicted)
+
+
+def cross_entropy(actual:np.array, predicted:np.array) -> float:
+    assert actual.shape == predicted.shape
+    epsilon = 1e-12
+    predicted = np.clip(predicted, epsilon, 1. - epsilon)
+    return -np.sum(actual * np.log(predicted)) / actual.shape[0]

--- a/pam/array/encode.py
+++ b/pam/array/encode.py
@@ -1,0 +1,47 @@
+import numpy as np
+
+from pam.activity import Plan
+from pam.utils import td_to_s
+
+
+def plan_to_one_hot(
+    plan: Plan,
+    mapping:dict,
+    bin_size:int=3600,
+    duration:int=86400
+    ) -> np.array:
+    """
+    Transform a pam.activity.Plan into a one-hot encoded array. Output array is two dimensional.
+    First axis represents time, binnned according to bin_size given in seconds.
+    Seconds axis is a one-hot endcoding of activity type based on the given mapping. Note that Leg
+    components will have the encoding "travel" which should be included in the mapping. Location and
+    mode information is lost. Some plan components may be lost if their durations are less than
+    the chosen bin six. Plan components beyond 24 hours are cropped.
+
+    Args:
+        plan (Plan): input Plan object to be encoded as one-hot
+        mapping (dict): dictionary mapping of activity types to one-hot index, eg {"home":0, "travel":1}
+        bin_size (int, optional): time bin size (in seconds). Defaults to 3600.
+        duration (int, optional): day_duration (in seconds). Defaults to 86400.
+
+    Returns:
+        np.array: one-hot encoded plan
+    """
+    bins = int(duration / bin_size)
+    encoded = np.zeros((bins,len(mapping)))
+
+    start_bin = 0
+    reference_time = plan.day[0].start_time
+    for component in plan.day:
+        index = mapping.get(component.act, None)
+        end_bin = round(td_to_s(component.end_time - reference_time) / bin_size)
+
+        if end_bin >= duration:  # deal with last component
+            end_bin = duration
+            encoded[start_bin:end_bin, index] = 1.0
+            break
+
+        encoded[start_bin:end_bin, index] = 1.0
+        start_bin = end_bin
+
+    return encoded

--- a/pam/utils.py
+++ b/pam/utils.py
@@ -82,9 +82,7 @@ def td_to_s(td):
     """
     Convert timedelta to seconds since start of day.
     """
-    # if not td.seconds and td.days:
-    #     return 24*60*60
-    return td.seconds
+    return (td.days * 86400) + td.seconds
 
 
 def get_linestring(from_point, to_point):

--- a/pam/variables.py
+++ b/pam/variables.py
@@ -1,8 +1,8 @@
 from datetime import datetime
 
 
-# End Of Day
-# END_OF_DAY = datetime(year=1900, month=1, day=1, hour=23, minute=59, second=59)
+# default datetimes for plan start and end (24 hours)
+START_OF_DAY = datetime(year=1900, month=1, day=1, hour=0, minute=0, second=0)
 END_OF_DAY = datetime(year=1900, month=1, day=2, hour=0, minute=0, second=0)
 
 
@@ -10,13 +10,13 @@ END_OF_DAY = datetime(year=1900, month=1, day=2, hour=0, minute=0, second=0)
 EXPECTED_EUCLIDEAN_SPEEDS = {
     'average':10*1000/3600,
     'car':20*1000/3600,
-    'bus':10*1000/3600, 
-    'rail':15*1000/3600, 
-    'pt':15*1000/3600, 
-    'subway':15*1000/3600, 
-    'walk':5*1000/3600, 
+    'bus':10*1000/3600,
+    'rail':15*1000/3600,
+    'pt':15*1000/3600,
+    'subway':15*1000/3600,
+    'walk':5*1000/3600,
     'cycle':15*1000/3600
-} # mode speeds expressed as *euclidean* meters per second 
+} # mode speeds expressed as *euclidean* meters per second
 
 TRANSIT_MODES = ['bus','rail','pt', 'subway'] # modes for which the maximum walk distance applies
 SMALL_VALUE = 0.000001

--- a/tests/test_14_encode_array.py
+++ b/tests/test_14_encode_array.py
@@ -1,0 +1,472 @@
+import numpy as np
+from datetime import datetime
+
+from pam.array import encode, decode, distance
+from pam.activity import Plan, Leg, Activity
+from pam.utils import minutes_to_datetime as mtdt
+from pam.variables import END_OF_DAY
+
+
+def test_home_plan_to_array():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=END_OF_DAY
+        ))
+    encoded = encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":0, "work":1, "travel":2},
+            bin_size=3600,
+            duration=86400
+        )
+    np.testing.assert_array_equal(
+        encoded,
+        np.stack([np.array((1,0,0))] * 24)
+    )
+
+
+def test_home_plan_to_array_alternate():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=END_OF_DAY
+        ))
+    encoded = encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":1, "work":2, "travel":0},
+            bin_size=3600,
+            duration=86400
+        )
+    np.testing.assert_array_equal(
+        encoded,
+        np.stack([np.array((0,1,0))] * 24)
+    )
+
+
+def test_too_long_plan_to_array():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=END_OF_DAY
+        ))
+    np.testing.assert_array_equal(
+        encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":0, "work":1, "travel":2},
+            bin_size=3600,
+            duration=86401
+        ),
+        np.stack([np.array((1,0,0))] * 24)
+    )
+
+
+def test_home_work_plan_to_array_with_hour_bins():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=mtdt(600),
+        ))
+    plan.add(Leg(
+        mode = "walk",
+        start_area = "A",
+        end_area = "B",
+        start_time=mtdt(600),
+        end_time=mtdt(720),
+        ))
+    plan.add(Activity(
+        act = "work",
+        area = "B",
+        start_time=mtdt(720),
+        end_time=END_OF_DAY,
+        ))
+    encoded = encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":0, "work":1, "travel":2},
+            bin_size=3600,
+            duration=86400
+        )
+    np.testing.assert_array_equal(
+        encoded[:10,:],
+        np.stack([np.array((1,0,0))] * 10)
+    )
+    np.testing.assert_array_equal(
+        encoded[10:12,:],
+        np.stack([np.array((0,0,1))] * 2)
+    )
+    np.testing.assert_array_equal(
+        encoded[12:,:],
+        np.stack([np.array((0,1,0))] * 12)
+    )
+
+
+def test_home_work_plan_to_array_with_half_hour_bins():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=mtdt(600),
+        ))
+    plan.add(Leg(
+        mode = "walk",
+        start_area = "A",
+        end_area = "B",
+        start_time=mtdt(600),
+        end_time=mtdt(720),
+        ))
+    plan.add(Activity(
+        act = "work",
+        area = "B",
+        start_time=mtdt(720),
+        end_time=END_OF_DAY,
+        ))
+    encoded = encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":0, "work":1, "travel":2},
+            bin_size=1800,
+            duration=86400
+        )
+    np.testing.assert_array_equal(
+        encoded[:20,:],
+        np.stack([np.array((1,0,0))] * 20)
+    )
+    np.testing.assert_array_equal(
+        encoded[20:24,:],
+        np.stack([np.array((0,0,1))] * 4)
+    )
+    np.testing.assert_array_equal(
+        encoded[24:,:],
+        np.stack([np.array((0,1,0))] * 24)
+    )
+
+
+def test_rounding_down_to_hour():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=mtdt(629),
+        ))
+    plan.add(Leg(
+        mode = "walk",
+        start_area = "A",
+        end_area = "B",
+        start_time=mtdt(629),
+        end_time=mtdt(749),
+        ))
+    plan.add(Activity(
+        act = "work",
+        area = "B",
+        start_time=mtdt(749),
+        end_time=END_OF_DAY,
+        ))
+    encoded = encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":0, "work":1, "travel":2},
+            bin_size=3600,
+            duration=86400
+        )
+    np.testing.assert_array_equal(
+        encoded[:10,:],
+        np.stack([np.array((1,0,0))] * 10)
+    )
+    np.testing.assert_array_equal(
+        encoded[10:12,:],
+        np.stack([np.array((0,0,1))] * 2)
+    )
+    np.testing.assert_array_equal(
+        encoded[12:,:],
+        np.stack([np.array((0,1,0))] * 12)
+    )
+
+
+def test_rounding_up_to_hour():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=mtdt(599),
+        ))
+    plan.add(Leg(
+        mode = "walk",
+        start_area = "A",
+        end_area = "B",
+        start_time=mtdt(599),
+        end_time=mtdt(719),
+        ))
+    plan.add(Activity(
+        act = "work",
+        area = "B",
+        start_time=mtdt(719),
+        end_time=END_OF_DAY,
+        ))
+    encoded = encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":0, "work":1, "travel":2},
+            bin_size=3600,
+            duration=86400
+        )
+    np.testing.assert_array_equal(
+        encoded[:10,:],
+        np.stack([np.array((1,0,0))] * 10)
+    )
+    np.testing.assert_array_equal(
+        encoded[10:12,:],
+        np.stack([np.array((0,0,1))] * 2)
+    )
+    np.testing.assert_array_equal(
+        encoded[12:,:],
+        np.stack([np.array((0,1,0))] * 12)
+    )
+
+
+def test_rounding_up_to_hour():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=mtdt(600),
+        ))
+    plan.add(Leg(
+        mode = "walk",
+        start_area = "A",
+        end_area = "B",
+        start_time=mtdt(600),
+        end_time=mtdt(629),
+        ))
+    plan.add(Activity(
+        act = "work",
+        area = "B",
+        start_time=mtdt(629),
+        end_time=END_OF_DAY,
+        ))
+    encoded = encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":0, "work":1, "travel":2},
+            bin_size=3600,
+            duration=86400
+        )
+    np.testing.assert_array_equal(
+        encoded[:10,:],
+        np.stack([np.array((1,0,0))] * 10)
+    )
+    np.testing.assert_array_equal(
+        encoded[10:,:],
+        np.stack([np.array((0,1,0))] * 14)
+    )
+
+
+def test_rounding_out_a_short_component():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        area = "A",
+        start_time=mtdt(0),
+        end_time=mtdt(599),
+        ))
+    plan.add(Leg(
+        mode = "walk",
+        start_area = "A",
+        end_area = "B",
+        start_time=mtdt(599),
+        end_time=mtdt(719),
+        ))
+    plan.add(Activity(
+        act = "work",
+        area = "B",
+        start_time=mtdt(719),
+        end_time=END_OF_DAY,
+        ))
+    encoded = encode.plan_to_one_hot(
+            plan=plan,
+            mapping={"home":0, "work":1, "travel":2},
+            bin_size=3600,
+            duration=86400
+        )
+    np.testing.assert_array_equal(
+        encoded[:10,:],
+        np.stack([np.array((1,0,0))] * 10)
+    )
+    np.testing.assert_array_equal(
+        encoded[10:12,:],
+        np.stack([np.array((0,0,1))] * 2)
+    )
+    np.testing.assert_array_equal(
+        encoded[12:,:],
+        np.stack([np.array((0,1,0))] * 12)
+    )
+
+
+def test_iter_array():
+    assert list(decode.iter_array(
+        array = np.stack([np.array((1,0,0))] * 3),
+        mapping = {0:"home"}
+    )) == [
+        ("home", datetime(year=1900, month=1, day=1, hour=0, minute=0, second=0))
+    ]
+
+    assert list(decode.iter_array(
+        array = np.stack([np.array((0,1,0))] * 3),
+        mapping = {0:"home", 1:"work"}
+    )) == [
+        ("work", datetime(year=1900, month=1, day=1, hour=0, minute=0, second=0))
+    ]
+
+    l = list(decode.iter_array(
+        array = np.array([[1,0,0],[0,1,0]]),
+        mapping = {0:"home", 1:"work"}
+    ))
+
+    assert l[0] == ("home", datetime(year=1900, month=1, day=1, hour=0, minute=0, second=0))
+    assert l[1] == ("work", datetime(year=1900, month=1, day=1, hour=1, minute=0, second=0))
+
+    l = list(decode.iter_array(
+        array = np.array([[1,0,0],[1,0,0],[0,1,0]]),
+        mapping = {0:"home", 1:"work"}
+    ))
+
+    assert l[0] == ("home", datetime(year=1900, month=1, day=1, hour=0, minute=0, second=0))
+    assert l[1] == ("work", datetime(year=1900, month=1, day=1, hour=2, minute=0, second=0))
+
+
+def test_add_end_times():
+    start_times = [
+        datetime(year=1900, month=1, day=1, hour=i, minute=0, second=0) for i in range(3)
+    ]
+    plan = [Activity(start_time=st) for st in start_times]
+    decode.add_end_times(plan)
+    for i in range(2):
+        assert plan[i].end_time == plan[i+1].start_time
+
+
+def test_fix_missing_start_activity():
+    start_times = [
+        datetime(year=1900, month=1, day=1, hour=i, minute=0, second=0) for i in range(3)
+    ]
+    plan = [Activity(start_time=st) for st in start_times]
+    decode.fix_missing_start_activity(plan)
+    assert len(plan) == 3
+
+    start_times = [
+        datetime(year=1900, month=1, day=1, hour=i, minute=0, second=0) for i in range(3)
+    ]
+    plan = [Leg(start_time=st) for st in start_times]
+    decode.fix_missing_start_activity(plan)
+    assert len(plan) == 4
+    assert isinstance(plan[0], Activity)
+    assert plan[0].end_time == plan[1].start_time
+
+
+def test_fix_missing_end_activity():
+    start_times = [
+        datetime(year=1900, month=1, day=1, hour=i, minute=0, second=0) for i in range(3)
+    ]
+    plan = [Activity(start_time=st) for st in start_times]
+    decode.fix_missing_start_activity(plan)
+    assert len(plan) == 3
+
+    start_times = [
+        datetime(year=1900, month=1, day=1, hour=i, minute=0, second=0) for i in range(3)
+    ]
+    plan = [Leg(start_time=st) for st in start_times]
+    decode.fix_missing_end_activity(plan)
+    assert len(plan) == 4
+    assert isinstance(plan[-1], Activity)
+    assert plan[-2].end_time == plan[-1].start_time
+
+
+def test_fix_missing_leg():
+    times = [
+        (
+            datetime(year=1900, month=1, day=1, hour=i, minute=0, second=0),
+            datetime(year=1900, month=1, day=1, hour=i+1, minute=0, second=0)
+        ) for i in range(2)
+    ]
+    plan = [Activity(start_time=st, end_time=et) for st, et in times]
+    decode.fix_missing_components(plan)
+    assert len(plan) == 3
+    assert isinstance(plan[1], Leg)
+    assert plan[0].end_time == datetime(year=1900, month=1, day=1, hour=0, minute=45, second=0)
+    assert plan[1].start_time == datetime(year=1900, month=1, day=1, hour=0, minute=45, second=0)
+    assert plan[1].end_time == datetime(year=1900, month=1, day=1, hour=1, minute=15, second=0)
+    assert plan[2].start_time == datetime(year=1900, month=1, day=1, hour=1, minute=15, second=0)
+
+
+def test_fix_missing_activity():
+    times = [
+        (
+            datetime(year=1900, month=1, day=1, hour=i, minute=0, second=0),
+            datetime(year=1900, month=1, day=1, hour=i+1, minute=0, second=0)
+        ) for i in range(2)
+    ]
+    plan = [Leg(start_time=st, end_time=et) for st, et in times]
+    decode.fix_missing_components(plan)
+    assert len(plan) == 3
+    assert isinstance(plan[1], Activity)
+    assert plan[0].end_time == datetime(year=1900, month=1, day=1, hour=0, minute=45, second=0)
+    assert plan[1].start_time == datetime(year=1900, month=1, day=1, hour=0, minute=45, second=0)
+    assert plan[1].end_time == datetime(year=1900, month=1, day=1, hour=1, minute=15, second=0)
+    assert plan[2].start_time == datetime(year=1900, month=1, day=1, hour=1, minute=15, second=0)
+
+
+def test_plan_one_hot_encode_decode_consistent():
+    plan = Plan()
+    plan.add(Activity(
+        act = "home",
+        start_time=mtdt(0),
+        end_time=mtdt(600),
+        ))
+    plan.add(Leg(
+        start_time=mtdt(600),
+        end_time=mtdt(720),
+        ))
+    plan.add(Activity(
+        act = "work",
+        start_time=mtdt(720),
+        end_time=END_OF_DAY,
+        ))
+    encoded_plan = encode.plan_to_one_hot(
+            plan = plan,
+            mapping = {"home":0, "work":1, "travel":2},
+            bin_size = 3600,
+            duration = 86400
+        )
+    decoded_plan = decode.one_hot_to_plan(
+        array = encoded_plan,
+        mapping = {0:"home", 1:"work", 2:"travel"},
+        bin_size = 3600,
+        duration = 86400
+    )
+    assert len(decoded_plan) == 3
+    for i in range(3):
+        assert type(plan[i]) == type(decoded_plan[i])
+        assert plan[i].act == decoded_plan[i].act
+        assert plan[i].start_time == decoded_plan[i].start_time
+        assert plan[i].end_time == decoded_plan[i].end_time
+
+
+def test_accuracy():
+    a = np.array([[1,0,0],[1,0,0],[0,1,0],[0,0,1],[0,0,0]])
+    b = np.array([[0,0,0],[0,1,0],[0,1,0],[0,0,1],[0,0,0]])
+    assert distance.accuracy(a, a) == 1
+    assert distance.accuracy(b, b) == 1
+    assert distance.accuracy(a, b) == 0.8
+
+
+def test_one_hot_cross_entropy():
+    a = np.array([[1,0,0],[1,0,0],[0,1,0],[0,0,1],[0,0,0]])
+    b = np.array([[0,0,0],[0,1,0],[0,0,0],[0,1,0],[1,0,0]])
+    assert 0 < distance.cross_entropy(a, a) < 1e-3
+    assert 0 < distance.cross_entropy(b, b) < 1e-3
+    assert distance.cross_entropy(a, b) - 22.1048168 < 1e-3


### PR DESCRIPTION
no one really needs this PR yet but i think it's kind of cool:

mostly implements a function to transform a Plan into a one-hot encoded array:
```
from pam import array
 encoded = array.encode.plan_to_one_hot(
  plan=plan,
  mapping={"home":0, "work":1, "travel":2},
  bin_size=3600,  # seconds
  duration=86400  # seconds
  )
```
This proves a 2d numpy array with the first dimension representing time bins and the second a one-hot encoding of activity and travel, eg:
```
[[1,0,0],[1,0,0],[0,1,0],[0,0,1]...]  # home-home-travel-work...
```
This is designed to work with the VAE experiments (although this returns only the array for a single plan and is only 2d, whereas existing experiment have a third dimension (which is redundant)).

also provides a "decode" function, such that plans can be (mostly) recovered:
```
encoded_plan = array.encode.plan_to_one_hot(
  plan = plan,
  mapping = {"home":0, "work":1, "travel":2},
  bin_size=3600,  # seconds
  duration=86400  # seconds
    )
decoded_plan = array.decode.one_hot_to_plan(
    array = encoded_plan,
    mapping = {0:"home", 1:"work", 2:"travel"},
  bin_size=3600,  # seconds
  duration=86400  # seconds
)
```
Some info is obviously lost. For example there is no encoding of locations.

Activity and Leg times and durations are also binned such that there is some precision loss and short components can be lost altogther (ie activities or trips shorter than the bin size). The decode method will go some way to recover a valid plan sequence by inferring missing start and end activities, and ensuring a proper sequence. However locations are not recovered (something to think about in future).

Other than supporting the VAE work. This is also buit to provide a simple way of comparing activity sequences:

```
encoded_plan_A = array.encode.plan_to_one_hot(
        plan = plan_A,
        mapping = {"home":0, "work":1, "travel":2},
    )
encoded_plan_B = array.encode.plan_to_one_hot(
        plan = plan_B,
        mapping = {"home":0, "work":1, "travel":2},
    )

print(array.distance.accuracy(encoded_plan_A, encoded_plan_B)
print(array.distance.test_one_hot_cross_entropy(encoded_plan_A, encoded_plan_B)
```

These are pretty rudimentary measures of difference but i fancy them for some other experiment i am going to try so here they are.
