### PR TITLE
sample cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,5 +614,6 @@ The `pam.cropping` module allows to spatially subset populations, by simplifying
 Some of PAM's functionality can be invoked via its Command Line Interface (CLI). The currently supported methods are: 
 
 * plan cropping: `pam crop <path_population_xml> <path_core_area_geojson> <path_output_directory>`.
+* down/up-sampling an xml population: `pam sample <path_population_xml> <path_core_area_geojson> <path_output_directory> -s <sample_percentage> -v <matsim_version>`. For example, you can use: `pam sample tests/test_data/test_matsim_plansv12.xml tests/test_data/output/sampled -s 0.1` to create a downsampled (to 10%) version of the input (`test_matsim_plansv12.xml`) population.
 
 To further explore the CLI commands, start by typing `pam --help` in a terminal.

--- a/README.md
+++ b/README.md
@@ -614,6 +614,6 @@ The `pam.cropping` module allows to spatially subset populations, by simplifying
 Some of PAM's functionality can be invoked via its Command Line Interface (CLI). The currently supported methods are: 
 
 * plan cropping: `pam crop <path_population_xml> <path_core_area_geojson> <path_output_directory>`.
-* down/up-sampling an xml population: `pam sample <path_population_xml> <path_core_area_geojson> <path_output_directory> -s <sample_percentage> -v <matsim_version>`. For example, you can use: `pam sample tests/test_data/test_matsim_plansv12.xml tests/test_data/output/sampled -s 0.1` to create a downsampled (to 10%) version of the input (`test_matsim_plansv12.xml`) population.
+* down/up-sampling an xml population: `pam sample <path_population_xml> <path_output_directory> -s <sample_percentage> -v <matsim_version>`. For example, you can use: `pam sample tests/test_data/test_matsim_plansv12.xml tests/test_data/output/sampled -s 0.1` to create a downsampled (to 10%) version of the input (`test_matsim_plansv12.xml`) population.
 
 To further explore the CLI commands, start by typing `pam --help` in a terminal.

--- a/pam/cli.py
+++ b/pam/cli.py
@@ -2,6 +2,11 @@ import click
 import logging
 from pathlib import Path
 from pam.cropping import crop_xml
+from pam.samplers import population as population_sampler
+from pam import read, write
+from typing import Optional
+import os
+
 
 @click.group()
 def cli():
@@ -22,7 +27,7 @@ def crop(path_population_input, path_boundary, dir_population_output,
          matsim_version, comment, buffer):
     """
     Crop a population's plans outside a core area.
-    
+
     :param path_population_input: Path to a MATSim population (xml)
     :param path_boundary: Path to the core area geojson file
     :param dir_population_output: Path to the output (cropped) MATSim population 
@@ -39,12 +44,77 @@ def crop(path_population_input, path_boundary, dir_population_output,
     logger = logging.getLogger(__name__)
     logger.info('Starting population cropping')
     crop_xml(
-        path_population_input = path_population_input,
-        path_boundary = path_boundary,
-        dir_population_output = dir_population_output,
-        version = matsim_version,
-        comment = comment,
-        buffer = buffer
+        path_population_input=path_population_input,
+        path_boundary=path_boundary,
+        dir_population_output=dir_population_output,
+        version=matsim_version,
+        comment=comment,
+        buffer=buffer
     )
     logger.info('Population cropping complete')
     logger.info(f'Output saved at {dir_population_output}/plan.xml')
+
+
+@cli.command()
+@click.argument("path_population_input", type=click.Path(exists=True))
+@click.argument("dir_population_output", type=click.Path(exists=False, writable=True))
+@click.option("--sample_percentage", "-s")
+@click.option("--matsim_version", "-v", default=12)
+@click.option("--comment", "-c", default="cropped population")
+@click.option("--seed", default=None)
+def sample(path_population_input: str, dir_population_output: str, sample_percentage: str,
+           matsim_version: int, comment: str, seed: Optional[int]):
+    """
+    Down- or up-sample a PAM population.
+
+    :param path_population_input: Path to a MATSim population (xml)
+    :param dir_population_output: Path to the output (cropped) MATSim population 
+    :param sample_percentage: The sample percentage (as a ratio to the input population size).
+        For example, use 0.1 to produce a 10% version of the input population
+    :param matsim_version: MATSim version
+    :param comment: A short comment included in the output population
+    :param seed: A random seed.
+
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(name)-12s %(levelname)-3s %(message)s',
+        datefmt='%m-%d %H:%M'
+    )
+    logger = logging.getLogger(__name__)
+    logger.info('Starting population sampling')
+
+    # read
+    population_input = read.read_matsim(
+        path_population_input,
+        household_key="hid",
+        weight=1,
+        version=matsim_version
+    )
+    print(population_input)
+    logger.info(f'Initial population size (number of agents): {len(population_input)}')
+
+    # sample
+    sample_percentage = float(sample_percentage)
+    population_output = population_sampler.sample(
+        population=population_input,
+        sample=sample_percentage,
+        seed=seed,
+        verbose=True
+    )
+
+    # export
+    if not os.path.exists(dir_population_output):
+        os.makedirs(dir_population_output)
+
+    write.write_matsim(
+        population_output,
+        plans_path=os.path.join(dir_population_output, 'plans.xml'),
+        attributes_path=os.path.join(dir_population_output, 'attributes.xml'),
+        version=matsim_version,
+        comment=comment
+    )
+
+    logger.info('Population sampling complete')
+    logger.info(f'Output population size (number of agents): {len(population_output)}')
+    logger.info(f'Output saved at {dir_population_output}/plans.xml')

--- a/tests/test_16_cli.py
+++ b/tests/test_16_cli.py
@@ -31,17 +31,24 @@ def test_cli_cropping(path_test_plan, path_boundary, tmp_path):
     assert os.path.exists(os.path.join(path_output_dir, 'plans.xml'))
 
 
-def test_cli_sample(path_test_plan, tmp_path):
+@pytest.mark.parametrize('sample_percentage', ['1','2'])
+def test_cli_sample(path_test_plan, tmp_path, sample_percentage):
     """ Double the population of 5 agents """
     path_output_dir = str(tmp_path)
     runner = CliRunner()
-    result = runner.invoke(sample, [path_test_plan, path_output_dir, '-s' '2'])
+    result = runner.invoke(sample, [path_test_plan, path_output_dir, '-s', sample_percentage])
     assert result.exit_code == 0
     assert os.path.exists(os.path.join(path_output_dir, 'plans.xml'))
+
+    population_input = read.read_matsim(
+        path_test_plan,
+        household_key="hid",
+        version=12
+    )
 
     population = read.read_matsim(
         os.path.join(path_output_dir, 'plans.xml'),
         household_key="hid",
         version=12
     )
-    assert len(population) == 10
+    assert len(population) == (len(population_input) * float(sample_percentage))

--- a/tests/test_16_cli.py
+++ b/tests/test_16_cli.py
@@ -1,7 +1,8 @@
 from click.testing import CliRunner
 import click
 import pytest
-from pam.cli import crop
+from pam.cli import crop, sample
+from pam import read
 import os
 
 
@@ -28,3 +29,19 @@ def test_cli_cropping(path_test_plan, path_boundary, tmp_path):
                            path_boundary, path_output_dir])
     assert result.exit_code == 0
     assert os.path.exists(os.path.join(path_output_dir, 'plans.xml'))
+
+
+def test_cli_sample(path_test_plan, tmp_path):
+    """ Double the population of 5 agents """
+    path_output_dir = str(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(sample, [path_test_plan, path_output_dir, '-s' '2'])
+    assert result.exit_code == 0
+    assert os.path.exists(os.path.join(path_output_dir, 'plans.xml'))
+
+    population = read.read_matsim(
+        os.path.join(path_output_dir, 'plans.xml'),
+        household_key="hid",
+        version=12
+    )
+    assert len(population) == 10


### PR DESCRIPTION
Allows down- or up-sampling a MATSim (xml) population via the command line, by invoking: `pam sample <path_population_xml> <path_core_area_geojson> <path_output_directory> -s <sample_percentage> -v <matsim_version>` 

For example, we can decrease the size of a hypothetical `plans.xml` file from 1000 agents to 100 by running `pam sample plans.xml output/resampled -s 0.1`. 