### PR TITLE
Nice up the notebooks smoke test report

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ prettytable==3.3.0
 pytest-cov>=2.8.1
 pytest-mock>=3.1.0
 pytest>=5
+rich==12.5.1
 Rtree>=0.9.7
 s2sphere>=0.2.5
 typing>=3.7.4


### PR DESCRIPTION
## Before

#### Running locally
<img width="652" alt="Screen Shot 2022-07-15 at 16 44 42" src="https://user-images.githubusercontent.com/250899/179265602-ec33fea8-a46e-4d21-8f54-d7741e2d0a4a.png">


#### Running in GitHub Actions
<img width="1427" alt="Screen Shot 2022-07-15 at 17 24 15" src="https://user-images.githubusercontent.com/250899/179266017-66bc2658-3284-4e40-9229-5536a3dfe0a8.png">


## After

#### Running locally
<img width="658" alt="Screen Shot 2022-07-15 at 17 14 42" src="https://user-images.githubusercontent.com/250899/179265631-e9cdc8cf-0a52-443b-9fd2-981ee6f84d98.png">


#### Running in GitHub Actions
<img width="1421" alt="Screen Shot 2022-07-15 at 17 26 41" src="https://user-images.githubusercontent.com/250899/179266450-d1843ec4-329b-4751-a17f-5dcbc9b320d0.png">


## Additional Functionality
You can now optionally pass one or more notebook paths as params to the python script, where before you could pass only a directory from which the list of notebooks would be discovered.

This was mostly just to give me a faster feedback loop than running all the notebooks while working on these changes, but could still be generally useful in situations where you're making changes to one or two notebooks and want the same sort of fast feedback. For example:

```bash
python scripts/code-qa/notebook_smoke_tests.py \
-k pam \
-k python37364bit373pyenve4f55e1c90f74740a9da8a10ea80341d \
-k python3 \
-n 'examples/03_PAM-Create-Population.ipynb' \
-n 'examples/12_Travel plots.ipynb' \
-n 'examples/10_PAM-stats.ipynb' \
-n 'examples/16_vehicles.ipynb MAKE THIS FAIL'
```
<img width="600" alt="Screen Shot 2022-07-15 at 17 34 50" src="https://user-images.githubusercontent.com/250899/179267987-18a50e26-79ce-4b4c-8820-fccb7e710f0a.png">





