### PR TITLE
ensures matsim read write maintains data

### DIFF
--- a/examples/09_pam-geo-sampling.ipynb
+++ b/examples/09_pam-geo-sampling.ipynb
@@ -2,7 +2,14 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-04-15T14:22:45.434401Z",
+     "start_time": "2020-04-15T14:22:43.811833Z"
+    }
+   },
+   "outputs": [],
    "source": [
     "import os\n",
     "import pandas as pd\n",
@@ -12,49 +19,44 @@
     "from matplotlib import pyplot as plt\n",
     "\n",
     "import numpy as np"
-   ],
-   "outputs": [],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-04-15T14:22:45.434401Z",
-     "start_time": "2020-04-15T14:22:43.811833Z"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# PAM - Geometry Sampling\n",
     "\n",
     "This notebook shows how to sample geometrical locations from ozone/dzone regions.\n"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "source": [
-    "trips = pd.read_csv('data/example_data/example_travel_diaries.csv')\n",
-    "attributes = pd.read_csv('data/example_data/example_attributes.csv')\n",
-    "attributes.set_index('pid', inplace=True)"
-   ],
-   "outputs": [],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-04-15T14:23:03.601994Z",
      "start_time": "2020-04-15T14:23:03.510974Z"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "trips = pd.read_csv('data/example_data/example_travel_diaries.csv')\n",
+    "attributes = pd.read_csv('data/example_data/example_attributes.csv')\n",
+    "attributes.set_index('pid', inplace=True)"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "source": [
-    "trips.head(20)"
-   ],
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-04-15T14:23:04.174895Z",
+     "start_time": "2020-04-15T14:23:04.079557Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/html": [
        "<div>\n",
@@ -462,28 +464,37 @@
        "19  1122  1127  1000  "
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 4
+     "output_type": "execute_result"
     }
    ],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-04-15T14:23:04.174895Z",
-     "start_time": "2020-04-15T14:23:04.079557Z"
-    }
-   }
+   "source": [
+    "trips.head(20)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Sample Geometries\n",
     "Transform trip ozone/dzone to geographically sampled points"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/fred.shone/.ve/pam/lib/python3.7/site-packages/pandas/core/dtypes/cast.py:118: ShapelyDeprecationWarning: The array interface is deprecated and will no longer work in Shapely 2.0. Convert the '.coords' to a numpy array instead.\n",
+      "  arr = construct_1d_object_array_from_listlike(values)\n"
+     ]
+    }
+   ],
    "source": [
     "from pam.samplers.spatial import GeometryRandomSampler\n",
     "\n",
@@ -494,139 +505,151 @@
     "geo_trips = trips.copy()\n",
     "geo_trips['start_loc'] = geo_trips.apply(lambda x: geom_sampler.sample_point(x['ozone']), axis=1)\n",
     "geo_trips['end_loc'] = geo_trips.apply(lambda x: geom_sampler.sample_point(x['dzone']), axis=1)\n"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Build Activity Plans\n",
     "\n",
     "First we convert the travel diary data to Activity Plans:"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "source": [
-    "from pam import read\n",
-    "population = read.load_travel_diary(geo_trips, attributes, include_loc=True)"
-   ],
-   "outputs": [],
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-04-15T14:23:49.071281Z",
      "start_time": "2020-04-15T14:23:37.908537Z"
     }
-   }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Using tour based purpose parser (recommended)\n",
+      "Adding pid->hh mapping to persons_attributes from trips.\n",
+      "Adding home locations to persons attributes using trips attributes.\n",
+      "Using freq of 'None' for all persons.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pam import read\n",
+    "population = read.load_travel_diary(geo_trips, attributes, include_loc=True)"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "Let's check out an example Activity Plan and Attributes:"
-   ],
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-04-09T14:32:22.432201Z",
      "start_time": "2020-04-09T14:32:15.568791Z"
     }
-   }
+   },
+   "source": [
+    "Let's check out an example Activity Plan and Attributes:"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "source": [
-    "household = population.households['census_120']\n",
-    "person = household.people['census_120']\n",
-    "person.print()\n",
-    "person.plot()"
-   ],
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-04-15T14:23:58.041512Z",
+     "start_time": "2020-04-15T14:23:58.002047Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Person: census_120\n",
-      "{'gender': 'other', 'job': 'work', 'occ': 'white', 'inc': 'low'}\n",
-      "0:\tActivity(0 act:home, location:POINT (549435.6681744548 171044.1908635257), time:00:00:00 --> 09:47:00, duration:9:47:00)\n",
-      "1:\tLeg(0 mode:pt, area:POINT (549435.6681744548 171044.1908635257) --> POINT (547017.2703928507 180563.651372189), time:09:47:00 --> 10:04:00, duration:0:17:00)\n",
-      "2:\tActivity(1 act:work, location:POINT (547017.2703928507 180563.651372189), time:10:04:00 --> 17:12:00, duration:7:08:00)\n",
-      "3:\tLeg(1 mode:pt, area:POINT (543370.212784305 177604.3069484807) --> POINT (544690.4654892718 172666.9404792268), time:17:12:00 --> 17:29:00, duration:0:17:00)\n",
-      "4:\tActivity(2 act:home, location:POINT (544690.4654892718 172666.9404792268), time:17:29:00 --> 00:00:00, duration:6:31:00)\n"
+      "{'gender': 'other', 'job': 'work', 'occ': 'white', 'inc': 'low', 'hzone': 'Bexley'}\n",
+      "0:\tActivity(0 act:home, location:POINT (549552.7664551701 175428.9619809439), time:00:00:00 --> 09:47:00, duration:9:47:00)\n",
+      "1:\tLeg(240 mode:pt, area:POINT (549552.7664551701 175428.9619809439) --> POINT (547419.752224589 177633.2205424352), time:09:47:00 --> 10:04:00, duration:0:17:00)\n",
+      "2:\tActivity(241 act:work, location:POINT (547419.752224589 177633.2205424352), time:10:04:00 --> 17:12:00, duration:7:08:00)\n",
+      "3:\tLeg(241 mode:pt, area:POINT (543441.0576277913 172896.28892256372) --> POINT (550717.0955785038 175894.57709614074), time:17:12:00 --> 17:29:00, duration:0:17:00)\n",
+      "4:\tActivity(242 act:home, location:POINT (550717.0955785038 175894.57709614074), time:17:29:00 --> 00:00:00, duration:6:31:00)\n"
      ]
     },
     {
-     "output_type": "display_data",
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAACkCAYAAADsQZkEAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAdy0lEQVR4nO3dd5xdZZ3H8c8vPZSAkNBDsSEEFRUVFRFpihKxgWB0ZXHXwqqIuypYsWNFLMAqKquChSpxLZRVigIikAgJRZFAAiQ0kZZCZn77xzmD13Fmcu+YybnP5PN+ve5rzj1tvvfMnXnO+c1znhuZiSRJkiRJkso1pukAkiRJkiRJ+udY4JEkSZIkSSqcBR5JkiRJkqTCWeCRJEmSJEkqnAUeSZIkSZKkwlngkSRJkiRJKpwFHkmSJEmSpMJZ4JEkSZIkSSqcBR5JkkahiFgQEUsj4qGIWBIRp0TEek3nGkyd75P19LYRkXX2vvw/jYh9ms65JkXENyLixojojYhD+y17U0RcFREPRMSiiPhcRIxrWb5RRJwdEQ9HxK0R8fo1/gIkSdIaZYFHkqTRa2Zmrgc8E9gF+FAnG0elyXOFDev8TwfOB87uX+gY5eYChwNXD7BsHeDdwFTgucBewH+1LP86sALYFJgFnBgRM0Y0rSRJapQFHkmSRrnMvB34ObATQETsGhG/jYj7I2JuROzRt25E/DoiPhURvwEeAR4fEYdGxJ8j4sGIuCUiZtXrjomID9U9RO6KiO9GxAb1sr5eOG+KiNsi4p6I+OAw8y/OzOOBY4DPtlt0iogZEXF+RNxX9wL6QEvuoyLi5oi4NyJ+HBEbtZM7Ip4TEb+ve84siYgv1fP3iIhF/b7/gojYe6jtVvG6v56ZFwLLBlh2YmZekpkr6p/vqcAL6u+1LvAa4MOZ+VBmXgqcC7yxneMmSZLKZIFHkqRRLiKmAy8DromILYH/BT4JbETV6+PMiJjWsskbgbcA6wN3A18B9svM9YHnA3Pq9Q6tHy8GHg+sB3yt37ffDdieqofJRyJih3/ipZwFbFLvj4g4ISJOGGjFiFgfuAD4BbAF8ETgwnrxO4FXAi+ql/2FqsdLO7mPB47PzCnAE4Aft5l9uNu1a3dgXj39ZGBlZt7UsnwuYA8eSZJGMQs8kiSNXudExP3ApcBFwKeBNwA/y8yfZWZvZp4P/J6qANTnlMycl5krgZVAL7BTREzOzDszs6+QMAv4Umb+OTMfAo4GDm4dCwb4WGYuzcy5VEWGp/8Tr+eO+utGAJl5eGYePsi6+wOLM/OLmbksMx/MzCvqZW8DPpiZizJzOVXPoNe2mftR4IkRMbXuHXN5m9mHu90qRcRhVLfgfaGetR7wQL/V/kpVsJMkSaOUBR5JkkavV2bmhpm5TV0MWQpsAxxY3551f10A2g3YvGW7hX0Tmfkw8DqqosidEfG/EfGUevEWwK0t290KjKMa96XP4pbpR6iKD8O1Zf31vjbWnQ7cPMiybajG8+l7/dcDPbSX+81UPWRuiIgrI2L/NrMPd7shRcQrgc9Q9bC6p579EDCl36pTgAdXx/eUJEndyQKPJElrl4XA9+rCT99j3cw8tmWdbN0gM3+ZmftQFYFuAL5ZL7qDqljSZ2uqHj9LRij7q4C7gBvbWHch1W1jgy3br98xmFSPZTOkzPxjZh5CdavYZ4Ez6jFvHqYa+BiAiBgLTGtju2GLiJdS/SxmZua1LYtuAsZFxJNa5j2dv93CJUmSRiELPJIkrV2+D8yMiJdExNiImFQPELzVQCtHxKYRcUBdjFhO1Tukt178A+DIiNguqo9g/zTwo/rWrtWmzvAO4KPA0ZnZu6ptgJ8Cm0fEuyNiYkSsHxHPrZedBHwqIrap9z8tIg5oM8sbImJaneH+enYvVVFlUkS8PCLGU31i2cQ2thvqe02IiElAAOPrn9WYetmeVAMrvyYzf9e6Xd3r6izg4xGxbkS8ADgA+F47r1GSJJXJAo8kSWuRzFxIdbH/AaoBlBcC72Xwc4IxwHuoeuvcRzUw8dvrZd+mKhpcDNxC9WlP71yNce+PiIeBa6nGCDowM7/dtzAiToqIkwbaMDMfBPYBZlLdbvVHqsGgoRrw+FzgvIh4ELic6qPG2/FSYF5EPFTv5+B6rJ6/Un2k+cnA7VQ9ehatartVfK/zgKVUA1t/o57evV72YWAD4GcR8VD9+HnLtocDk6l6PP0AeHvL2EmSJGkUisxc9VqSJEmSJEnqWvbgkSRJkiRJKpwFHkmSpAZExKyW26taH95KJUmSOuYtWpIkSZIkSYWzB48kSZIkSVLhxnWwrl19JEmSJEmSRl50uoE9eCRJkiRJkgrXdg+eiI6LR5IkSZIkSerQcMZLtgePJEmSJElS4ToZg4e894iRyiFJUpFi4+MBmDlzZkfbzZ49G4ALjrlwtWeSpNFm72P2Ajr7W9v3d9ZrGEml6Tu/7JQ9eCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHath6W5/wd89POW0+73jfrxpKI0kabU74xQmcedmZjz1///fezxd/8oXHnp/0yxM547ent7Wv93znPdx4+42rPaMkNcnzcY0WFngkSZJGsZ2mz2DewnkA9Pb28sAjf2XB3QseWz5v4Tx2nD5jlfvp6e0ZqYiSJGk1GNd0AEmDW3DbAxz2zvO5576lTNt4Mt/52j5svdUUDv2P85g8aRzXXHs3d93zCN/+yj5890fXc9mVd/LcZ23GKV/fF4DzfnUrHz32cpav6OEJ227Ad766D+utN6HhVyVJWpN2nD6DE395IgAL7l7Atptsy30P3seDSx9k4viJ3Hb3bTy8/GHeetJb6entYfsttueI/Y9gwrgJzDru9eyx0x5cdfNVvO4Fr3tsn729vXzhJ59n6pRpHLbXYU29NEkacZ6PqyT24JEatnTpSnZ+0amPPT5y7GWPLXvnUb/mTQfvwB8ueQOzDnwK7zrqoseW/eWvy7nslwdx3Cd35xWzZnPk25/BvN++kWuvv5c5197NPfcu5ZNf/B0XnPVqrv7V69ll50350onXNPESJUkNmjplKmPHjGXJ/UuYv3AeO241g6dstQPzF87npjtuYsuNt+JL536RD7/2Q5x8+Mn09PYw+8rZj20/ZfIUTnrbf/Pip+4JVD15PnPWp9ly460s7kgaFTwf12hhDx6pYZMnj2PORbMee37KafP5/ZwlAFx25Z2c9T8vB+CNBz2F9x1z6WPrzXzJdkQET91xKptuMpmn7jgVgBnbb8SC2x5g0R0PMv/G+3jBy34MwIoVvTzv2ZutqZclSeoiO06fwfyF85i3cB6vfd6B3PPAPcxbOI91J63LtClTmThuAltNnQ7Avjvvy7m/+wmved5rANhjpxf/3b6+/NPjeNGMPZi1+6x/+D6SVCLPxzVaWOCRCjVx4lgAxowJJk7426/ymDHByp5exo4dyz57bM0PvrlfUxElSV1ixvQZzFs4n1uW3MK2m2zLtCnTOOOy01ln4jo8fdunc8n8SwbddtL4SX/3fMfpM5hzyxwOfN6BTBjvbQaS1l6ej6vbeIuW1MWe/5zN+eFZNwFw6uk38sJdt2x721132YzfXHEHf/rz/QA8/PCj3PSnv4xITklSd5sxfQaX33Q560+ewtgxY5myzhQeWvYQ8xfO54U77M7i+5dw+723A3DB3PN52rZPG3Rf+z1jP577pOfwidM/Tk+PAy9LGt08H1dJ7MEjdbGvHrsH//qO8/n81656bFC3dk2bug6nfG1fDvn3n7N8RXUC/skPPJ8nP/FxIxVXktSlttt0Ox545K/sWY+jA7DdJtuxdMVSpm0wjfe+8r18/PSPPzbI8v67zBxyf699/oE8vPxhjj37Mxz96g8wZoz/M5Q0Onk+rpJEZra3YkTmvUeMcBxJksoSGx8PwMyZQ18Q9zd7djWI7QXHXLjaM0nSaLP3MXsBnf2t7fs76zWMpNLExseTmdHpdv67RZIkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcJGZ7a0Y0d6KkiRJkiRJGrbMjE63sQePJEmSJElS4ca1u2K7PX0kSZIkSZK0ZtmDR5IkSZIkqXBtF3gi4q1AlPgwu7nN3v2PUrOXmtvs5jZ7GY9Ss5ea2+zmNnv3P0rNbXazDyP3W+hQJz14Ot55FzH7mldqbjB7U0rNXmpuMHsTSs0NZm9KqdlLzQ1mb0KpucHsTSg1N5i9KaVmH9ECjyRJkiRJkrqQBR5JkiRJkqTCdVLg+caIpRh5Zl/zSs0NZm9KqdlLzQ1mb0KpucHsTSk1e6m5wexNKDU3mL0JpeYGszel1Owd5w4//lySJEmSJKls3qIlSZIkSZJUuLYKPBHx0oi4MSL+FBFHjXSo1SUivh0Rd0XEdU1n6URETI+IX0XE/IiYFxFHNJ2pXRExKSJ+FxFz6+wfazpTJyJibERcExE/bTpLJyJiQURcGxFzIuL3TefpRERsGBFnRMQNEXF9RDyv6UztiIjt6+Pd93ggIt7ddK52RMSR9e/ndRHxg4iY1HSmdkXEEXXued1+vAdqgyJio4g4PyL+WH99XJMZBzNI9gPr494bEbs0mW8og2T/fP035g8RcXZEbNhkxoEMkvsTdeY5EXFeRGzRZMbBDHW+FRH/GREZEVObyLYqgxz3YyLi9pa/7y9rMuNABjvmEfHO+r0+LyI+11S+oQxyzH/UcrwXRMScJjMOZpDsO0fE5X3nYBHxnCYzDmaQ7E+PiMvqc8jZETGlyYwDGey6qIT2dIjsXd2eDpG7hLZ0sOxd354Olr1leXvtaWYO+QDGAjcDjwcmAHOBHVe1XTc8gN2BZwLXNZ2lw9ybA8+sp9cHbiromAewXj09HrgC2LXpXB3kfw9wGvDTprN0mHsBMLXpHMPM/j/Av9XTE4ANm840jNcwFlgMbNN0ljaybgncAkyun/8YOLTpXG1m3wm4DlgHGAdcADyx6VxD5P2HNgj4HHBUPX0U8Nmmc3aQfQdge+DXwC5NZ+ww+77AuHr6s9143AfJPaVl+l3ASU3nbDd7PX868Evg1m5towY57scA/9V0tmHkfnH9d3Fi/XyTpnN28n5pWf5F4CNN5+zguJ8H7FdPvwz4ddM5O8h+JfCievow4BNN5xwg94DXRSW0p0Nk7+r2dIjcJbSlg2Xv+vZ0sOz187bb03Z68DwH+FNm/jkzVwA/BA5oY7vGZebFwH1N5+hUZt6ZmVfX0w8C11NdlHW9rDxUPx1fP4oY6CkitgJeDpzcdJa1RURsQHXC8S2AzFyRmfc3m2pY9gJuzsxbmw7SpnHA5IgYR1UsuaPhPO3aAbgiMx/JzJXARcCrG840qEHaoAOoiprUX1+5RkO1aaDsmXl9Zt7YUKS2DZL9vPo9A3A5sNUaD7YKg+R+oOXpunRpezrE+dZxwPvo0txQ9LniQLnfDhybmcvrde5a48HaMNQxj4gADgJ+sEZDtWmQ7An09XzZgC5tUwfJ/mTg4nr6fOA1azRUG4a4Lur69nSw7N3eng6Ru4S2dLDsXd+erqIG0HZ72k6BZ0tgYcvzRRRSbBgNImJb4BlUPWGKENVtTnOAu4DzM7OU7F+m+sXpbTrIMCRwXkRcFRFvaTpMB7YD7ga+E9WtcSdHxLpNhxqGg+nSk9H+MvN24AvAbcCdwF8z87xmU7XtOuCFEbFxRKxD9Z/S6Q1n6tSmmXlnPb0Y2LTJMGupw4CfNx2iXRHxqYhYCMwCPtJ0nnZFxAHA7Zk5t+ksw/SOujv/t7vx1o9BPJnqb+QVEXFRRDy76UDD8EJgSWb+sekgHXg38Pn69/QLwNEN5+nEPP72j/sD6fI2td91UVHtaYnXdDBk7q5vS/tnL6k9bc3eaXvqIMtdLCLWA84E3t2v6tjVMrMnM3emquo+JyJ2ajrTqkTE/sBdmXlV01mGabfMfCawH/AfEbF704HaNI6qu/CJmfkM4GGqbrbFiIgJwCuA05vO0o76QuUAquLaFsC6EfGGZlO1JzOvp+oSfB7wC2AO0NNoqH9CVn1uu+4/SKNZRHwQWAmc2nSWdmXmBzNzOlXmdzSdpx11AfYDdPkJ9BBOBJ4A7ExVCP9is3HaNg7YCNgVeC/w47pHTEkOoZB/mLR4O3Bk/Xt6JHWv5EIcBhweEVdR3RKyouE8gxrquqjb29NSr+kGy11CWzpQ9lLa09bsVMe5o/a0nQLP7fx9NXerep5GUESMp/rBnpqZZzWdZzjqW21+Bby06SxteAHwiohYQHUb4p4R8f1mI7Wv7pXR1x37bKpbK0uwCFjU0svrDKqCT0n2A67OzCVNB2nT3sAtmXl3Zj4KnAU8v+FMbcvMb2XmszJzd+AvVPcnl2RJRGwOUH/tylsoRqOIOBTYH5hVXwyU5lS68PaJQTyBqog8t25XtwKujojNGk3VpsxcUv+zqhf4JmW1qWfVt8v/jqpHclcObj2Q+rbhVwM/ajpLh95E1ZZC9c+eUt4vZOYNmblvZj6LqrB2c9OZBjLIdVER7Wmp13SD5S6hLW3jmHdtezpA9o7b03YKPFcCT4qI7er/VB8MnPvPhtfg6v+2fAu4PjO/1HSeTkTEtL4R1SNiMrAPcEOzqVYtM4/OzK0yc1uq9/j/ZWYRvRoiYt2IWL9vmmoAtCI+OS4zFwMLI2L7etZewPwGIw1Haf9tvA3YNSLWqf/W7EV1j28RImKT+uvWVBcCpzWbqGPnUl0MUH/9SYNZ1hoR8VKqW3BfkZmPNJ2nXRHxpJanB1BAewqQmddm5iaZuW3dri6iGjhyccPR2tJ30Vh7FYW0qcA5VAMtExFPpvrggnsaTdSZvYEbMnNR00E6dAfwonp6T6CY28ta2tQxwIeAk5pN9I+GuC7q+va01Gu6wXKX0JYOkb3r29OBsg+rPc32RnR+GdV/SW8GPtjONt3woLrouhN4tD4Yb246U5u5d6PqZvgHqlsQ5gAvazpXm9mfBlxTZ7+OLv0UhFW8hj0o6FO0qD7hbm79mFfS72idf2fg9/V75hzgcU1n6iD7usC9wAZNZ+kw98eoGrbrgO9Rf+JKCQ/gEqoi4Fxgr6bzrCLrP7RBwMbAhVQXABcAGzWds4Psr6qnlwNLgF82nbOD7H+iGk+wr03txk/PGCj3mfXv6R+A2VQDRTaetZ3s/ZYvoHs/RWug4/494Nr6uJ8LbN50zjZzTwC+X79nrgb2bDpnJ+8X4BTgbU3nG8Zx3w24qm6XrgCe1XTODrIfQXWNdxNwLBBN5xwg94DXRSW0p0Nk7+r2dIjcJbSlg2Xv+vZ0sOz91lllexr1ipIkSZIkSSqUgyxLkiRJkiQVzgKPJEmSJElS4SzwSJIkSZIkFc4CjyRJkiRJUuEs8EiSJEmSJBXOAo8kSZIkSVLhLPBIkiRJkiQVzgKPJEmSJElS4SzwSJIkSZIkFc4CjyRJkiRJUuEs8EiSJEmSJBXOAo8kSZIkSVLhLPBIkiRJkiQVzgKPJEmSJElS4SzwSJIkSZIkFc4CjyRJkiRJUuEs8EiSJEmSJBXOAo8kSZIkSVLhLPBIkiRJkiQVzgKPJEmSJElS4SzwSJIkSZIkFc4CjyRJkiRJUuEs8EiSJEmSJBXOAo8kSZIkSVLhLPBIkiRJkiQVzgKPJEmSJElS4SzwSJIkrQERsUdELGo6x2gREcdExPebziFJUrewwCNJUgMiYkFE7N1v3qERcWlTmUaziHio5dEbEUtbns9qOt9oFRFHR8TP+8374yDzDl6z6SRJGl3GNR1AkqQ1afLkcYuXLevZdKT2P2nS2CVLl67cbKT2X6KxY8cu7u3tHbFjPmbMmCU9PT1DHvPMXK9vOiIWAP+WmRf0Xy8ixmXmytWfcs2aOH7i4hUrV4zYMZ8wbsKS5Y8ub+d9fjFwVESMzcyeiNgcGA88o9+8J9brtiUiPIeVJKkfG0dJ0lpl2bKeTfPeI0Zs/7Hx8avlojoidgBOBHYGbgeOzsxz62WnAI8A2wEvBOYCrwGOAt4ELAEOycxr6vW3AL4K7A48BByXmV9ZHTnb0dvbu+nMmTNHbP+zZ88e9jGPiD2A71MdnyOB8yPiXcD3gOdSnSv9BnhbZi6KiNcB783MXVr2cSTw4sx8RURMBD4FHARMBM4GjszMpcPNOBwrVq7Y9IJjLhyx/e99zF7tHvMrqQo6OwNXUb1ffwU8vt+8mwEi4lxgN+A+4LOZ+c16/jHATsAy4BXAe1q/SUSMB74LTKB6768Y/quTJKlM3qIlSVKXqS9WZwPnAZsA7wROjYjtW1Y7CPgQMBVYDlwGXF0/PwP4Ur2vMfW+5gJbAnsB746Il6yRF1OGzYCNgG2At1CdH32nfr41sBT4Wr3ubGD7iHhSy/avB06rp48FnkxVvHgi1TH/yAjn71p1oeUKquIi9ddLgEv7zbsY+CGwCNgCeC3w6YjYs2V3B1C9tzcETu2bGRGTgXOofg8OsrgjSVpbWeCRJKk550TE/X0P4IR6/q7AesCxmbkiM/8P+ClwSMu2Z2fmVZm5jKqXyLLM/G5m9gA/Ap5Rr/dsYFpmfrze15+BbwKOd/I3vcBHM3N5Zi7NzHsz88zMfCQzH6TqkfMigMx8BPgJ9c+iLvQ8BTg3IoKqQHRkZt5Xb/tpPNYX8bdizgupCjyX9Jt3EfAC4P2ZuSwz5wAnA//Ssp/LMvOczOxt6RE1BfgFVQ+gf63f/5IkrZUs8EiS1JxXZuaGfQ/g8Hr+FsDCzOxtWfdWqt4gfZa0TC8d4HnfmDPbAFv0KyR9ABix8VkKdHddKAMgItaJiP+OiFsj4gGq3iUbRsTYepXT+Fux7fXAOXXhZxqwDnBVy7H+RT1/bXYxsFtEbERVbPwj8Fvg+fW8nYAbgL6iWJ/+7/mFA+x7V+BpVMXQHJH0kiQVwjF4JEnqPncA0yNiTEuRZ2vgpmHsayFwS2Y+aZVrrr36Fwb+E9geeG5mLo6InYFrgKiXnw9Mq+cfQjV2D8A9VMW1GZl5+8jHLsZlwAbAv1ONZ0RmPhARd9Tz7qgfG0XE+i1Fnq2pxp/qM1AB5zzgD8CFEbFHZi4ZYB1JktYK9uCRJKn7XEE1iPL7ImJ8PRDwTKoxSjr1O+DBiHh/REyOiLERsVNEPHs15h1t1qcq1Nxf9zD5aOvCzHwUOB34PNXYPefX83upbn87LiI2AYiILdf28Y7q26l+TzUw8iUtiy6t512cmQupevV8JiImRcTTgDdTDYC9qv1/jqpX1YURMXV155ckqRQWeCRJ6jL1ILEzgf2oeoWcAPxLZt4wjH31APtTDfp7S72/k6l6VGhgXwYmUx2ry6lus+rvNGBv4PR+H6v+fuBPwOX17V0XUPUGWttdRDVg+KUt8y6p5/V9PPohwLZUvXnOphoX6R8+yn4gmfkJqoGWL6iLcpIkrXXC25UlSWuTyZPHLV62rGfExp+ZNGnskqVLV242Uvsv0dixYxf39vaO2DEfM2bMkp6eHo95i4njJy5esXLFiB3zCeMmLFn+6HKPuSRJXcQCjyRJkiRJUuG8RUuSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlw/w+VIs/gaHbj+QAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAACkCAYAAADsQZkEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8qNh9FAAAACXBIWXMAAAsTAAALEwEAmpwYAAAdy0lEQVR4nO3dd5xdZZ3H8c8vPZSAkNBDsSEEFRUVFRFpihKxgWB0ZXHXwqqIuypYsWNFLMAqKquChSpxLZRVigIikAgJRZFAAiQ0kZZCZn77xzmD13Fmcu+YybnP5PN+ve5rzj1tvvfMnXnO+c1znhuZiSRJkiRJkso1pukAkiRJkiRJ+udY4JEkSZIkSSqcBR5JkiRJkqTCWeCRJEmSJEkqnAUeSZIkSZKkwlngkSRJkiRJKpwFHkmSJEmSpMJZ4JEkSZIkSSqcBR5JkkahiFgQEUsj4qGIWBIRp0TEek3nGkyd75P19LYRkXX2vvw/jYh9ms65JkXENyLixojojYhD+y17U0RcFREPRMSiiPhcRIxrWb5RRJwdEQ9HxK0R8fo1/gIkSdIaZYFHkqTRa2Zmrgc8E9gF+FAnG0elyXOFDev8TwfOB87uX+gY5eYChwNXD7BsHeDdwFTgucBewH+1LP86sALYFJgFnBgRM0YyrCRJapYFHkmSRrnMvB34ObATQETsGhG/jYj7I2JuROzRt25E/DoiPhURvwEeAR4fEYdGxJ8j4sGIuCUiZtXrjomID9U9RO6KiO9GxAb1sr5eOG+KiNsi4p6I+OAw8y/OzOOBY4DPtlt0iogZEXF+RNxX9wL6QEvuoyLi5oi4NyJ+HBEbtZM7Ip4TEb+ve84siYgv1fP3iIhF/b7/gojYe6jtVvG6v56ZFwLLBlh2YmZekpkr6p/vqcAL6u+1LvAa4MOZ+VBmXgqcC7yxneMmSZLKZIFHkqRRLiKmAy8DromILYH/BT4JbETV6+PMiJjWsskbgbcA6wN3A18B9svM9YHnA3Pq9Q6tHy8GHg+sB3yt37ffDdieqofJRyJih3/ipZwFbFLvj4g4ISJOGGjFiFgfuAD4BbAF8ETgwnrxO4FXAi+ql/2FqsdLO7mPB47PzCnAE4Aft5l9uNu1a3dgXj39ZGBlZt7UsnwuYA8eSZJGMQs8kiSNXudExP3ApcBFwKeBNwA/y8yfZWZvZp4P/J6qANTnlMycl5krgZVAL7BTREzOzDszs6+QMAv4Umb+OTMfAo4GDm4dCwb4WGYuzcy5VEWGp/8Tr+eO+utGAJl5eGYePsi6+wOLM/OLmbksMx/MzCvqZW8DPpiZizJzOVXPoNe2mftR4IkRMbXuHXN5m9mHu90qRcRhVLfgfaGetR7wQL/V/kpVsJMkSaOUBR5JkkavV2bmhpm5TV0MWQpsAxxY3551f10A2g3YvGW7hX0Tmfkw8DqqosidEfG/EfGUevEWwK0t290KjKMa96XP4pbpR6iKD8O1Zf31vjbWnQ7cPMiybajG8+l7/dcDPbSX+81UPWRuiIgrI2L/NrMPd7shRcQrgc9Q9bC6p579EDCl36pTgAdXx/eUJEndyQKPJElrl4XA9+rCT99j3cw8tmWdbN0gM3+ZmftQFYFuAL5ZL7qDqljSZ2uqHj9LRij7q4C7gBvbWHch1W1jgy3br98xmFSPZTOkzPxjZh5CdavYZ4Ez6jFvHqYa+BiAiBgLTGtju2GLiJdS/SxmZua1LYtuAsZFxJNa5j2dv93CJUmSRiELPJIkrV2+D8yMiJdExNiImFQPELzVQCtHxKYRcUBdjFhO1Tukt178A+DIiNguqo9g/zTwo/rWrtWmzvAO4KPA0ZnZu6ptgJ8Cm0fEuyNiYkSsHxHPrZedBHwqIrap9z8tIg5oM8sbImJaneH+enYvVVFlUkS8PCLGU31i2cQ2thvqe02IiElAAOPrn9WYetmeVAMrvyYzf9e6Xd3r6izg4xGxbkS8ADgA+F47r1GSJJXJAo8kSWuRzFxIdbH/AaoBlBcC72Xwc4IxwHuoeuvcRzUw8dvrZd+mKhpcDNxC9WlP71yNce+PiIeBa6nGCDowM7/dtzAiToqIkwbaMDMfBPYBZlLdbvVHqsGgoRrw+FzgvIh4ELic6qPG2/FSYF5EPFTv5+B6rJ6/Un2k+cnA7VQ9ehatartVfK/zgKVUA1t/o57evV72YWAD4GcR8VD9+HnLtocDk6l6PP0AeHvL2EmSJGkUisxc9VqSJEmSJEnqWvbgkSRJkiRJKpwFHkmSpAZExKyW26taH95KJUmSOuYtWpIkSZIkSYWzB48kSZIkSVLhxnWwrl19JEmSJEmSRl50uoE9eCRJkiRJkgrXdg+eiI6LR5IkSZIkSerQcMZLtgePJEmSJElS4ToZg4e894iRyiFJUpFi4+MBmDlzZkfbzZ49G4ALjrlwtWeSpNFm72P2Ajr7W9v3d9ZrGEml6Tu/7JQ9eCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHath6W5/wd89POW0+73jfrxpKI0kabU74xQmcedmZjz1///fezxd/8oXHnp/0yxM547ent7Wv93znPdx4+42rPaMkNcnzcY0WFngkSZJGsZ2mz2DewnkA9Pb28sAjf2XB3QseWz5v4Tx2nD5jlfvp6e0ZqYiSJGk1GNd0AEmDW3DbAxz2zvO5576lTNt4Mt/52j5svdUUDv2P85g8aRzXXHs3d93zCN/+yj5890fXc9mVd/LcZ23GKV/fF4DzfnUrHz32cpav6OEJ227Ad766D+utN6HhVyVJWpN2nD6DE395IgAL7l7Atptsy30P3seDSx9k4viJ3Hb3bTy8/GHeetJb6entYfsttueI/Y9gwrgJzDru9eyx0x5cdfNVvO4Fr3tsn729vXzhJ59n6pRpHLbXYU29NEkacZ6PqyT24JEatnTpSnZ+0amPPT5y7GWPLXvnUb/mTQfvwB8ueQOzDnwK7zrqoseW/eWvy7nslwdx3Cd35xWzZnPk25/BvN++kWuvv5c5197NPfcu5ZNf/B0XnPVqrv7V69ll50350onXNPESJUkNmjplKmPHjGXJ/UuYv3AeO241g6dstQPzF87npjtuYsuNt+JL536RD7/2Q5x8+Mn09PYw+8rZj20/ZfIUTnrbf/Pip+4JVD15PnPWp9ly460s7kgaFTwf12hhDx6pYZMnj2PORbMee37KafP5/ZwlAFx25Z2c9T8vB+CNBz2F9x1z6WPrzXzJdkQET91xKptuMpmn7jgVgBnbb8SC2x5g0R0PMv/G+3jBy34MwIoVvTzv2ZutqZclSeoiO06fwfyF85i3cB6vfd6B3PPAPcxbOI91J63LtClTmThuAltNnQ7Avjvvy7m/+wmved5rANhjpxf/3b6+/NPjeNGMPZi1+6x/+D6SVCLPxzVaWOCRCjVx4lgAxowJJk7426/ymDHByp5exo4dyz57bM0PvrlfUxElSV1ixvQZzFs4n1uW3MK2m2zLtCnTOOOy01ln4jo8fdunc8n8SwbddtL4SX/3fMfpM5hzyxwOfN6BTBjvbQaS1l6ej6vbeIuW1MWe/5zN+eFZNwFw6uk38sJdt2x721132YzfXHEHf/rz/QA8/PCj3PSnv4xETElSl5sxfQaX33Q560+ewtgxY5myzhQeWvYQ8xfO54U77M7i+5dw+723A3DB3PN52rZPG3Rf+z1jP577pOfwidM/Tk+PAy9LGt08H1dJ7MEjdbGvHrsH//qO8/n81656bFC3dk2bug6nfG1fDvn3n7N8RXUC/skPPJ8nP/FxIxVXktSlttt0Ox545K/sWY+jA7DdJtuxdMVSpm0wjfe+8r18/PSPPzbI8v67zBxyf699/oE8vPxhjj37Mxz96g8wZoz/M5Q0Onk+rpJEZra3YkTmvUeMcBxJksoSGx8PwMyZQ18Q9zd7djWI7QXHXLjaM0nSaLP3MXsBnf2t7fs76zWMpNLExseTmdHpdv67RZIkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcJGZ7a0Y0d6KkiRJkiRJGrbMjE63sQePJEmSJElS4ca1u2K7PX0kSZIkSZK0ZtmDR5IkSZIkqXBtF3gi4q1AlPgwu7nN3v2PUrOXmtvs5jZ7GY9Ss5ea2+zmNnv3P0rNbXazDyP3W+hQJz14Ot55FzH7mldqbjB7U0rNXmpuMHsTSs0NZm9KqdlLzQ1mb0KpucHsTSg1N5i9KaVmH9ECjyRJkiRJkrqQBR5JkiRJkqTCdVLg+caIpRh5Zl/zSs0NZm9KqdlLzQ1mb0KpucHsTSk1e6m5wexNKDU3mL0JpeYGszel1Owd5w4//lySJEmSJKls3qIlSZIkSZJUuLYKPBHx0oi4MSL+FBFHjXSo1SUivh0Rd0XEdU1n6URETI+IX0XE/IiYFxFHNJ2pXRExKSJ+FxFz6+wfazpTJyJibERcExE/bTpLJyJiQURcGxFzIuL3TefpRERsGBFnRMQNEXF9RDyv6UztiIjt6+Pd93ggIt7ddK52RMSR9e/ndRHxg4iY1HSmdkXEEXXued1+vAdqgyJio4g4PyL+WH99XJMZBzNI9gPr494bEbs0mW8og2T/fP035g8RcXZEbNhgxAENkvsTdeY5EXFeRGzRZMbBDHW+FRH/GREZEVObyLYqgxz3YyLi9pa/7y9rMuNABjvmEfHO+r0+LyI+11S+oQxyzH/UcrwXRMScBiMOapDsO0fE5X3nYBHxnCYzDmaQ7E+PiMvqc8jZETGlyYwDGey6qIT2dIjsXd2eDpG7hLZ0sOxd354Olr1leXvtaWYO+QDGAjcDjwcmAHOBHVe1XTc8gN2BZwLXNZ2lw9ybA8+sp9cHbiromAewXj09HrgC2LXpXB3kfw9wGvDTprN0mHsBMLXpHMPM/j/Av9XTE4ANm840jNcwFlgMbNN0ljaybgncAkyun/8YOLTpXG1m3wm4DlgHGAdcADyx6VxD5P2HNgj4HHBUPX0U8Nmmc3aQfQdge+DXwC5NZ+ww+77AuHr6s9143AfJPaVl+l3ASU3nbDd7PX868Evg1m5towY57scA/9V0tmHkfnH9d3Fi/XyTpnN28n5pWf5F4CNN5+zguJ8H7FdPvwz4ddM5O8h+JfCievow4BNN5xwg94DXRSW0p0Nk7+r2dIjcJbSlg2Xv+vZ0sOz187bb03Z68DwH+FNm/jkzVwA/BA5oY7vGZebFwH1N5+hUZt6ZmVfX0w8C11NdlHW9rDxUPx1fP4oY6CkitgJeDpzcdJa1RURsQHXC8S2AzFyRmfc3Gmp49gJuzsxbmw7SpnHA5IgYR1UsuaPhPO3aAbgiMx/JzJXARcCrG840qEHaoAOoiprUX1+5JjO1a6DsmXl9Zt7YUKS2DZL9vPo9A3A5sNUaD7YKg+R+oOXpunRpezrE+dZxwPvo0txQ9LniQLnfDhybmcvrde5a48HaMNQxj4gADgJ+sEZDtWmQ7An09XzZgC5tUwfJ/mTg4nr6fOA1azRUG4a4Lur69nSw7N3eng6Ru4S2dLDsXd+erqIG0HZ72k6BZ0tgYcvzRRRSbBgNImJb4BlUPWGKENVtTnOAu4DzM7OU7F+m+sXpbTjHcCRwXkRcFRFvaTpMB7YD7ga+E9WtcSdHxLpNhxqGg+nSk9H+MvN24AvAbcCdwF8z87xmU7XtOuCFEbFxRKxD9Z/S6Q1n6tSmmXlnPb0Y2LTJMGupw4CfNx2iXRHxqYhYCMwCPtJ0nnZFxAHA7Zk5t+ksw/SOujv/t7vx1o9BPJnqb+QVEXFRRDy76UDD8EJgSWb+sekgHXg38Pn69/QLwNHNxunIPP72j/sD6fI2td91UVHtaYnXdDBk7q5vS/tnL6k9bc3eaXvqIMtdLCLWA84E3t2v6tjVMrMnM3emquo+JyJ2ajjSKkXE/sBdmXlV01mGabfMfCawH/AfEbF704HaNI6qu/CJmfkM4GGqbrbFiIgJwCuA05vO0o76QuUAquLaFsC6EfGGZlO1JzOvp+oSfB7wC2AO0NNkpn9GVn1uu+4/SKNZRHwQWAmc2nSWdmXmBzNzOlXmdzSdpx11AfYDdPkJ9BBOBJ4A7ExVCP9io2naNw7YCNgVeC/w47pHTEkOoZB/mLR4O3Bk/Xt6JHWv5EIcBhweEVdR3RKyouE8gxrquqjb29NSr+kGy11CWzpQ9lLa09bsVMe5o/a0nQLP7fx9NXerep5GUESMp/rBnpqZZzWdZzjqW21+Bby04SjteAHwiohYQHUb4p4R8f1mI7Wv7pXR1x37bKpbK0uwCFjU0svrDKqCT0n2A67OzCVNB2nT3sAtmXl3Zj4KnAU8v+FMbcvMb2XmszJzd+AvVPcnl2RJRGwOUH/tylsoRqOIOBTYH5hVXwyU5lS68PaJQTyBqog8t25XtwKujojNGk3VpsxcUv+zqhf4JmW1qWfVt8v/jqpHclcObj2Q+rbhVwM/ajpLh95E1ZZC9c+eUt4vZOYNmblvZj6LqrB2c9OZBjLIdVER7Wmp13SD5S6hLW3jmHdtezpA9o7b03YKPFcCT4qI7er/VB8MnPvPhtfg6v+2fAu4PjO/1HSeTkTEtL4R1SNiMrAPcEOjodqQmUdn5laZuS3Ve/z/MrOIXg0RsW5ErN83TTUAWhGfHJeZi4GFEbF9PWsvYH6DkYajtP823gbsGhHr1H9r9qK6x7cIEbFJ/XVrqguB05pN1LFzqS4GqL/+pMEsa42IeCnVLbivyMxHms7Troh4UsvTAyigPQXIzGszc5PM3LZuVxdRDRy5uOFobem7aKy9ikLaVOAcqoGWiYgnU31wwT1NBurQ3sANmbmo6SAdugN4UT29J1DM7WUtbeoY4EPASc0m+kdDXBd1fXta6jXdYLlLaEuHyN717elA2YfVnmZ7Izq/jOq/pDcDH2xnm254UF103Qk8Wh+MNzedqc3cu1F1M/wD1S0Ic4CXNZ2rzexPA66ps19Hl34Kwipewx4U9ClaVJ9wN7d+zCvpd7TOvzPw+/o9cw7wuKYzdZB9XeBeYIOms3SY+2NUDdt1wPeoP3GlhAdwCVURcC6wV9N5VpH1H9ogYGPgQqoLgAuAjZrO2UH2V9XTy4ElwC+bztlB9j9RjSfY16Z246dnDJT7zPr39A/AbKqBIhvP2k72fssX0L2fojXQcf8ecG193M8FNm86Z5u5JwDfr98zVwN7Np2zk/cLcArwtqbzDeO47wZcVbdLVwDPajpnB9mPoLrGuwk4Foimcw6Qe8DrohLa0yGyd3V7OkTuEtrSwbJ3fXs6WPZ+66yyPY16RUmSJEmSJBXKQZYlSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmSJEmSCmeBR5IkSZIkqXAWeCRJkiRJkgpngUeSJEmSJKlwFngkSZIkSZIKZ4FHkiRJkiSpcBZ4JEmS1oCI2CMiFjWdY7SIiGMi4vtN55AkqVtY4JEkqQERsSAi9u4379CIuLSpTKNZRDzU8uiNiKUtz2c1nW+0ioijI+Ln/eb9cZB5B6/ZdJIkjS7jmg4gSdKaNHnyuMXLlvVsOlL7nzRp7JKlS1duNlL7L9HYsWMX9/b2jtgxHzNmzJKenp4hj3lmrtc3HRELgH/LzAv6rxcR4zJz5epPuWZNHD9x8YqVK0bsmE8YN2HJ8keXt/M+vxg4KiLGZmZPRGwOjAee0W/eE+t12xIRnsNKktSPjaMkaa2ybFnPpnnvESO2/9j4+NVyUR0ROwAnAjsDtwNHZ+a59bJTgEeA7YAXAnOB1wBHAW8ClgCHZOY19fpbAF8FdgceAo7LzK+sjpzt6O3t3XTmzJkjtv/Zs2cP+5hHxB7A96mOz5HA+RHxLuB7wHOpzpV+A7wtMxdFxOuA92bmLi37OBJ4cWa+IiImAp8CDgImAmcDR2bm0uFmHI4VK1dsesExF47Y/vc+Zq92j/mVVAWdnYGrqN6vvwIe32/ezQARcS6wG3Af8NnM/GY9/xhgJ2AZ8ArgPa3fJCLGA98FJlC991cM97VJklQqb9GSJKnL1Bers4HzgE2AdwKnRsT2LasdBHwImAosBy4Drq6fnwF8qd7XmHpfc4Etgb2Ad0fES9bIiynDZsBGwDbAW6jOj75TP98aWAp8rV53NrB9RDypZfvXA6fV08cCT6YqXjyR6ph/ZGTjd6+60HIFVXGR+uslwKX95l0M/BBYBGwBvBb4dETs2bK7A6je2xsCp/bNjIjJwDlUvwcHWdyRJK2tLPBIktSccyLi/r4HcEI9f1dgPeDYzFyRmf8H/BQ4pGXbszPzqsxcRtVLZFlmfjcze4AfAc+o13s2MC0zP17v68/ANwHHO/mbXuCjmbk8M5dm5r2ZeWZmPpKZD1L1yHkRQGY+AvyE+mdRF3qeApwbEUFVIDoyM++rt/00HuuL+Fsx54VUBZ5L+s27CHgB8P7MXJaZc4CTgX9p2c9lmXlOZva29IiaAvyCqgfQv9bvf0mS1koWeCRJas4rM3PDvgdweD1/C2BhZva2rHsrVW+QPktappcO8LxvzJltgC36FZI+AIzY+CwFursulAEQEetExH9HxK0R8QBV75INI2Jsvcpp/K3Y9nrgnLrwMw1YB7iq5Vj/op6/NrsY2C0iNqIqNv4R+C3w/HreTsANQF9RrE//9/zCAfa9K/A0qmJojkh6SZIK4Rg8kiR1nzuA6RExpqXIszVw0zD2tRC4JTOftMo11179CwP/CWwPPDczF0fEzsA1QNTLzwem1fMPoRq7B+AequLajMy8faRDF+QyYAPg36nGMyIzH4iIO+p5d9SPjSJi/ZYiz9ZU40/1GaiAcx7wB+DCiNgjM5cMsI4kSWsFe/BIktR9rqAaRPl9ETG+Hgh4JtUYJZ36HfBgRLw/IiZHxNiI2Ckinr364o4661MVau6ve5h8tHVhZj4KnA58nmrsnvPr+b1Ut78dFxGbAETElmv7eEf17VS/pxoY+ZKWRZfW8y7OzIVUvXo+ExGTIuJpwJupBsBe1f4/R9Wr6sKImLq680uSVAoLPJIkdZl6kNiZwH5UvUJOAP4lM28Yxr56gP2pBv29pd7fyVQ9KjSwLwOTqY7V5VS3WfV3GrA3cHq/j1V/P/An4PL69q4LqHoDre0uohow/NKWeZfU8/o+Hv0QYFuq3jxnU42L9A8fZT+QzPwE1UDLF9RFOUmS1jrh7cqSpLXJ5MnjFi9b1jNi489MmjR2ydKlKzcbqf2XaOzYsYt7e3tH7JiPGTNmSU9Pj8e8xcTxExevWLlixI75hHETlix/dLnHXJKkLmKBR5IkSZIkqXDeoiVJkiRJklQ4CzySJEmSJEmFs8AjSZIkSZJUOAs8kiRJkiRJhbPAI0mSJEmSVDgLPJIkSZIkSYWzwCNJkiRJklQ4CzySJEmSJEmFs8AjSZIkSZJUOAs8kiRJkiRJhbPAI0mSJEmSVDgLPJIkSZIkSYWzwCNJkiRJklS4/weVIs/g4cNT8QAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1152x216 with 1 Axes>"
       ]
      },
      "metadata": {
       "needs_background": "light"
-     }
+     },
+     "output_type": "display_data"
     }
    ],
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-04-15T14:23:58.041512Z",
-     "start_time": "2020-04-15T14:23:58.002047Z"
-    }
-   }
+   "source": [
+    "household = population.households['census_120']\n",
+    "person = household.people['census_120']\n",
+    "person.print()\n",
+    "person.plot()"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "source": [
-    "person.attributes"
-   ],
-   "outputs": [
-    {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "{'gender': 'other', 'job': 'work', 'occ': 'white', 'inc': 'low'}"
-      ]
-     },
-     "metadata": {},
-     "execution_count": 13
-    }
-   ],
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-04-15T14:25:01.086381Z",
      "start_time": "2020-04-15T14:25:01.053633Z"
     }
-   }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'gender': 'other',\n",
+       " 'job': 'work',\n",
+       " 'occ': 'white',\n",
+       " 'inc': 'low',\n",
+       " 'hzone': 'Bexley'}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "person.attributes"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "### Output Matsim XML"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "source": [
-    "from pam.write import write_matsim_plans, write_matsim_attributes\n",
-    "\n",
-    "write_matsim_plans(population, \"./outputs/example_output_plans.xml\")\n",
-    "write_matsim_attributes(population, \"./outputs/example_output_attributes.xml\")"
-   ],
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [],
-   "metadata": {}
+   "source": [
+    "from pam.write import write_matsim\n",
+    "\n",
+    "write_matsim(population, \"./outputs/example_output_plans.xml\")"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pam",
    "language": "python",
-   "name": "python3"
+   "name": "pam"
   },
   "language_info": {
    "codemirror_mode": {
@@ -638,7 +661,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,
@@ -657,6 +680,11 @@
    },
    "toc_section_display": true,
    "toc_window_display": false
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "c2a90f01ee7329c0dc072323d04ab57047490a620cb7d1fe86527d3a3edaf28c"
+   }
   }
  },
  "nbformat": 4,

--- a/pam/__init__.py
+++ b/pam/__init__.py
@@ -36,3 +36,10 @@ class PAMVehicleIdError(PAMValidationError):
     """
 
     pass
+
+class InvalidMATSimError(PAMValidationError):
+    """
+    Custom exception raised for invalid MATSim
+    """
+
+    pass

--- a/pam/activity.py
+++ b/pam/activity.py
@@ -10,7 +10,7 @@ from pam.location import Location
 from pam.plot import plans as plot
 import pam.utils as utils
 import pam.variables
-from pam import PAMSequenceValidationError, PAMTimesValidationError, PAMValidationLocationsError
+from pam import PAMSequenceValidationError, PAMTimesValidationError, PAMValidationLocationsError, InvalidMATSimError
 from pam.variables import END_OF_DAY
 
 
@@ -971,7 +971,10 @@ class Activity(PlanComponent):
                f"duration:{self.duration})"
 
     def __eq__(self, other):
-        return (self.location == other.location) and (self.act == other.act)
+        """
+        Check for equality with activity type and location. Ignoring times and duration.
+        """
+        return (self.location == other.location) and (self.act == other.act) \
 
     def is_exact(self, other):
         return (self.location == other.location) and (self.act == other.act) \
@@ -982,6 +985,15 @@ class Activity(PlanComponent):
             if self.is_exact(other):
                 return True
         return False
+
+    def validate_matsim(self) -> None:
+        """Checks if activity has required fields for a valid matsim plan."""
+        if self.act is None:
+            raise InvalidMATSimError("Activity requires a type.")
+        if self.start_time is None and self.end_time is None:
+            raise InvalidMATSimError("Activity requires either start time or end_time.")
+        if self.location.loc is None and self.location.link is None:
+            raise InvalidMATSimError("Activity requires link id or x,y coordinates.")
 
 
 class Leg(PlanComponent):

--- a/pam/activity.py
+++ b/pam/activity.py
@@ -974,7 +974,7 @@ class Activity(PlanComponent):
         """
         Check for equality with activity type and location. Ignoring times and duration.
         """
-        return (self.location == other.location) and (self.act == other.act) \
+        return (self.location == other.location) and (self.act == other.act)
 
     def is_exact(self, other):
         return (self.location == other.location) and (self.act == other.act) \

--- a/pam/cli.py
+++ b/pam/cli.py
@@ -367,7 +367,8 @@ def crop(
             plans_path=os.path.join(dir_population_output, 'plans.xml'),
             attributes_path=os.path.join(dir_population_output, 'attributes.xml'),
             version=matsim_version,
-            comment=comment
+            comment=comment,
+            keep_non_selected=keep_non_selected,
         )
     logger.info(f'Output saved at {dir_population_output}/plan.xml')
 
@@ -445,7 +446,8 @@ def combine(
             population = combined_population,
             version=matsim_version,
             plans_path=population_output,
-            comment=comment
+            comment=comment,
+            keep_non_selected=keep_non_selected,
         )
     logger.info('Population combiner complete')
     logger.info(f'Output saved at {population_output}')
@@ -544,7 +546,8 @@ def sample(
             plans_path=os.path.join(dir_population_output, 'plans.xml'),
             attributes_path=os.path.join(dir_population_output, 'attributes.xml'),
             version=matsim_version,
-            comment=comment
+            comment=comment,
+            keep_non_selected=keep_non_selected
         )
 
     logger.info('Population sampling complete')

--- a/pam/cli.py
+++ b/pam/cli.py
@@ -69,6 +69,11 @@ def common_matsim_options(func):
         default=True,
         help="Optionally turn off reading of leg_route."
     )(func)
+    func = click.option(
+        "--keep_non_selected/--selected_only",
+        default=False,
+        help="Optionally keep (read and write) non selected plans."
+    )(func)
     return func
 
 
@@ -131,6 +136,7 @@ def summary(
     crop: bool,
     leg_attributes: bool,
     leg_route: bool,
+    keep_non_selected: bool,
     debug: bool,
     rich: bool,
     ):
@@ -152,6 +158,7 @@ def summary(
     logger.debug(f"Crop = {crop}")
     logger.debug(f"Leg attributes (required for warm starting) = {leg_attributes}")
     logger.debug(f"Leg route (required for warm starting) = {leg_route}")
+    logger.debug(f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
     with Console().status("[bold green]Loading population...", spinner='aesthetic') as _:
         population = read.read_matsim(
@@ -164,6 +171,7 @@ def summary(
             crop=crop,
             leg_attributes=leg_attributes,
             leg_route=leg_route,
+            keep_non_selected=keep_non_selected,
         )
     logger.info("Loading complete.")
     if rich:
@@ -299,6 +307,7 @@ def crop(
     crop: bool,
     leg_attributes: bool,
     leg_route: bool,
+    keep_non_selected: bool,
     comment,
     buffer,
     debug
@@ -321,6 +330,7 @@ def crop(
     logger.debug(f"Crop = {crop}")
     logger.debug(f"Leg attributes (required for warm starting) = {leg_attributes}")
     logger.debug(f"Leg route (required for warm starting) = {leg_route}")
+    logger.debug(f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
     # core area geometry
     with Console().status("[bold green]Loading boundary...", spinner='aesthetic') as _:
@@ -341,6 +351,7 @@ def crop(
             crop=crop,
             leg_attributes=leg_attributes,
             leg_route=leg_route,
+            keep_non_selected=keep_non_selected,
         )
 
     with Console().status("[bold green]Applying simplification...", spinner='aesthetic') as _:
@@ -386,6 +397,7 @@ def combine(
     crop: bool,
     leg_attributes: bool,
     leg_route: bool,
+    keep_non_selected: bool,
     comment: str,
     force: bool,
     debug: bool
@@ -405,6 +417,7 @@ def combine(
     logger.debug(f"Crop = {crop}")
     logger.debug(f"Leg attributes (required for warm starting) = {leg_attributes}")
     logger.debug(f"Leg route (required for warm starting) = {leg_route}")
+    logger.debug(f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
     if not force and os.path.exists(population_output):
         if input(f"{population_output} exists, overwrite? [y/n]:") .lower() in ["y", "yes", "ok"]:
@@ -422,6 +435,7 @@ def combine(
             crop=crop,
             leg_attributes=leg_attributes,
             leg_route=leg_route,
+            keep_non_selected=keep_non_selected,
             )
 
     logger.debug(f"Writing combinined population to {population_output}.")
@@ -470,6 +484,7 @@ def sample(
     crop: bool,
     leg_attributes: bool,
     leg_route: bool,
+    keep_non_selected: bool,
     comment: str,
     seed: Optional[int],
     debug: bool,
@@ -492,6 +507,7 @@ def sample(
     logger.debug(f"Crop = {crop}")
     logger.debug(f"Leg attributes (required for warm starting) = {leg_attributes}")
     logger.debug(f"Leg route (required for warm starting) = {leg_route}")
+    logger.debug(f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
     # read
     with Console().status("[bold green]Loading population...", spinner='aesthetic') as _:
@@ -505,6 +521,7 @@ def sample(
             crop=crop,
             leg_attributes=leg_attributes,
             leg_route=leg_route,
+            keep_non_selected=keep_non_selected,
         )
     logger.info(f'Initial population size (number of agents): {len(population_input)}')
 

--- a/pam/core.py
+++ b/pam/core.py
@@ -992,7 +992,6 @@ class Person:
     def __eq__(self, other):
         """
         Check for equality of two persons, equality is based on equal attributes and activity plans.
-        Identifiers (eg pid) are disregarded unless they are included in attributes.
         """
         if not isinstance(other, Person):
             self.logger.warning(f"Cannot compare person to non person: ({type(other)})")
@@ -1001,6 +1000,11 @@ class Person:
             return False
         if not self.plan == other.plan:
             return False
+        if not len(self.plans_non_selected) == len(other.plans_non_selected):
+            return False
+        for plana, planb in zip(self.plans_non_selected, other.plans_non_selected):
+            if not plana == planb:
+                return False
         return True
 
     @property

--- a/pam/location.py
+++ b/pam/location.py
@@ -5,6 +5,18 @@ class Location:
         self.area = area
 
     @property
+    def x(self):
+        if self.loc:
+            return self.loc.x
+        return None
+
+    @property
+    def y(self):
+        if self.loc:
+            return self.loc.y
+        return None
+
+    @property
     def min(self):
         if self.loc is not None:
             return self.loc

--- a/pam/operations/combine.py
+++ b/pam/operations/combine.py
@@ -9,6 +9,7 @@ def pop_combine(
     crop: bool = False,
     leg_attributes: bool = True,
     leg_route: bool = True,
+    keep_non_selected = True,
     ):
 
     """
@@ -32,6 +33,7 @@ def pop_combine(
             crop=crop,
             leg_attributes=leg_attributes,
             leg_route=leg_route,
+            keep_non_selected=keep_non_selected
             )
         print(f"population: {population.stats}")
 

--- a/pam/utils.py
+++ b/pam/utils.py
@@ -7,6 +7,8 @@ import os
 from shapely.geometry import Point, LineString
 from s2sphere import CellId
 
+from pam.variables import START_OF_DAY
+
 
 def parse_time(time):
     if isinstance(time, int) or isinstance(time, np.int64):
@@ -48,8 +50,10 @@ def datetime_string_to_datetime(string: str):
 def datetime_to_matsim_time(dt):
     """
     Convert datetime to matsim format time (08:27:33)
-    """
     return dt.strftime("%H:%M:%S")
+    # todo how does this deal with times greater than 24 hours?
+    """
+    return timedelta_to_matsim_time(dt - START_OF_DAY)
 
 
 def matsim_time_to_datetime(string : str) -> datetime:
@@ -83,6 +87,24 @@ def td_to_s(td):
     Convert timedelta to seconds since start of day.
     """
     return (td.days * 86400) + td.seconds
+
+
+def safe_strptime(mt):
+    """
+    safely parse string into datetime, can cope with time strings in format hh:mm:ss
+    if hh > 23 then adds a day
+    """
+    h, m, s = mt.split(":")
+    return START_OF_DAY + timedelta(hours = int(h), minutes = int(m), seconds = int(s))
+
+
+def timedelta_to_hours(td):
+    return td.total_seconds() / 3600
+
+
+def matsim_duration_to_hours(mt):
+    mt = mt.split(":")
+    return int(mt.pop()) / 3600 + int(mt.pop()) / 60 + int(mt.pop())
 
 
 def get_linestring(from_point, to_point):
@@ -233,24 +255,3 @@ def xml_content(content, matsim_DOCTYPE, matsim_filename):
     doc_type = f'<!DOCTYPE {matsim_DOCTYPE} SYSTEM "http://matsim.org/files/dtd/{matsim_filename}.dtd">'.encode()
     tree = xml_tree(content)
     return xml_version+doc_type+tree
-
-
-def safe_strptime(s):
-    """
-    safely parse string into datatime, can cope with time strings in format hh:mm:ss
-    if hh > 23 then adds a day
-    """
-    if int(s.split(':')[0]) > 23:
-        days, hours = divmod(int(s.split(':')[0]),24)
-        string = f"{days+1}-{hours:02d}" + s[-6:]
-        return datetime.strptime(string, '%d-%H:%M:%S')
-    return datetime.strptime(s, '%H:%M:%S')
-
-
-def timedelta_to_hours(td):
-    return td.total_seconds() / 3600
-
-
-def matsim_duration_to_hours(mt):
-    mt = mt.split(":")
-    return int(mt.pop()) / 3600 + int(mt.pop()) / 60 + int(mt.pop())

--- a/pam/utils.py
+++ b/pam/utils.py
@@ -50,8 +50,8 @@ def datetime_string_to_datetime(string: str):
 def datetime_to_matsim_time(dt):
     """
     Convert datetime to matsim format time (08:27:33)
+    Datetimes beyond 1 day will be converted to hours, eg 25:00:00, for 1am the next day.
     return dt.strftime("%H:%M:%S")
-    # todo how does this deal with times greater than 24 hours?
     """
     return timedelta_to_matsim_time(dt - START_OF_DAY)
 

--- a/pam/write/matsim.py
+++ b/pam/write/matsim.py
@@ -18,7 +18,8 @@ def write_matsim(
         vehicles_dir : Optional[str] = None,
         version : int = 12,
         comment : Optional[str] = None,
-        household_key : Optional[str] = 'hid'
+        household_key : Optional[str] = 'hid',
+        keep_non_selected : bool = False,
     ) -> None:
     """
     Write a core population object to matsim xml formats (either version 11 or 12).
@@ -32,6 +33,7 @@ def write_matsim(
     :param version: int {11,12}, matsim version, default 12
     :param comment: {str, None}, default None, optionally add a comment string to the xml outputs
     :param household_key: {str,None}, optionally add household id to person attributes, default 'hid'
+    :param keep_non_selected: bool, default False
     :return: None
     """
     if version == 12:
@@ -39,13 +41,20 @@ def write_matsim(
             population=population,
             path=plans_path,
             comment=comment,
-            household_key=household_key
+            household_key=household_key,
+            keep_non_selected=keep_non_selected,
             )
     elif version == 11:
+        logging.info(
+            """Support for old format plans (pre MATSim version 12) will not be maintained.
+            Please consider moving to the latest format (version = 12)."""
+            )
         if attributes_path is None:
             raise UserWarning("Please provide an attributes_path for a (default) v11 write.")
-        write_matsim_plans(population, plans_path, comment)
-        write_matsim_attributes(population, attributes_path, comment, household_key=household_key)
+        if keep_non_selected:
+            raise UserWarning("Read write of non selected plans is not supported for old formats (pre 12).")
+        write_v11_matsim_plans(population, plans_path, comment)
+        write_matsim_v11_attributes(population, attributes_path, comment, household_key=household_key)
     else:
         raise UserWarning("Version must be 11 or 12.")
     # write vehicles
@@ -168,7 +177,7 @@ def write_plan(
                 leg.append(component.route.xml)
 
 
-def write_matsim_plans(
+def write_v11_matsim_plans(
     population,
     path : str,
     comment : Optional[str] = None
@@ -218,7 +227,7 @@ def write_matsim_plans(
     # todo assuming v5?
 
 
-def write_matsim_attributes(
+def write_matsim_v11_attributes(
     population,
     location : str,
     comment : Optional[str] = None,

--- a/pam/write/matsim.py
+++ b/pam/write/matsim.py
@@ -4,7 +4,7 @@ import logging
 from lxml import etree as et
 from typing import Optional, Set
 
-from pam.activity import Activity, Leg
+from pam.activity import Plan, Activity, Leg
 from pam.vehicle import Vehicle, ElectricVehicle, VehicleType
 from pam.utils import datetime_to_matsim_time as dttm
 from pam.utils import timedelta_to_matsim_time as tdtm
@@ -62,7 +62,8 @@ def write_matsim_v12(
     population,
     path : str,
     household_key : Optional[str] = 'hid',
-    comment : Optional[str] = None
+    comment : Optional[str] = None,
+    keep_non_selected: bool = False,
     ) -> None:
     """
     Write a matsim version 12 output (persons plans and attributes combined).
@@ -71,6 +72,7 @@ def write_matsim_v12(
     :param path: str, output path (.xml or .xml.gz)
     :param comment: {str, None}, default None, optionally add a comment string to the xml outputs
     :param household_key: {str, None}, default 'hid'
+    :param keep_non_selected: bool, default False
     """
 
     population_xml = et.Element('population')
@@ -98,47 +100,72 @@ def write_matsim_v12(
                         )
                 attribute.text = str(v)
 
-            plan_xml = et.SubElement(person_xml, 'plan', {'selected': 'yes'})
-            for component in person[:-1]:
-                if isinstance(component, Activity):
-                    et.SubElement(plan_xml, 'activity', {
-                        'type': component.act,
-                        'x': str(float(component.location.loc.x)),
-                        'y': str(float(component.location.loc.y)),
-                        'end_time': dttm(component.end_time)
-                    }
-                                  )
-                if isinstance(component, Leg):
-                    leg = et.SubElement(plan_xml, 'leg', {
-                        'mode': component.mode,
-                        'trav_time': tdtm(component.duration)})
-
-                    if component.attributes:
-                        attributes = et.SubElement(leg, 'attributes')
-                        for k, v in component.attributes.items():
-                            if k == 'enterVehicleTime':  # todo make something more robust for future 'special' classes
-                                attribute = et.SubElement(
-                                attributes, 'attribute', {'class': 'java.lang.Double', 'name': str(k)}
-                                )
-                            else:
-                                attribute = et.SubElement(
-                                    attributes, 'attribute', {'class': 'java.lang.String', 'name': str(k)}
-                                    )
-                            attribute.text = str(v)
-
-                    if component.route.exists:
-                        leg.append(component.route.xml)
-
-            component = person[-1]  # write the last activity without an end time
-            et.SubElement(plan_xml, 'activity', {
-                'type': component.act,
-                'x': str(float(component.location.loc.x)),
-                'y': str(float(component.location.loc.y)),
-                }
+            write_plan(
+                person_xml,
+                person.plan,
+                selected=True,
             )
-
+            if keep_non_selected:
+                for plan in person.plans_non_selected:
+                    write_plan(
+                        person_xml,
+                        plan,
+                        selected=False,
+                    )
     write_xml(population_xml, path, matsim_DOCTYPE='population', matsim_filename='population_v6')
     # todo assuming v5?
+
+
+def write_plan(
+    person_xml: et.SubElement,
+    plan: Plan,
+    selected: Optional[bool] = None,
+):
+    plan_attributes = {}
+    if selected is not None:
+        plan_attributes['selected'] = {True:'yes', False:'no'}[selected]
+    if plan.score is not None:
+        plan_attributes['score'] = str(plan.score)
+
+    plan_xml = et.SubElement(person_xml, 'plan', plan_attributes)
+    for component in plan:
+        if isinstance(component, Activity):
+            component.validate_matsim()
+            act_data = {
+                'type': component.act,
+            }
+            if component.start_time is not None:
+                act_data['start_time'] = dttm(component.start_time)
+            if component.end_time is not None:
+                act_data['end_time'] = dttm(component.end_time)
+            if component.location.link is not None:
+                act_data['link'] = str(component.location.link)
+            if component.location.x is not None:
+                act_data['x'] = str(component.location.x)
+            if component.location.y is not None:
+                act_data['y'] = str(component.location.y)
+            et.SubElement(plan_xml, 'activity', act_data)
+
+        if isinstance(component, Leg):
+            leg = et.SubElement(plan_xml, 'leg', {
+                'mode': component.mode,
+                'trav_time': tdtm(component.duration)})
+
+            if component.attributes:
+                attributes = et.SubElement(leg, 'attributes')
+                for k, v in component.attributes.items():
+                    if k == 'enterVehicleTime':  # todo make something more robust for future 'special' classes
+                        attribute = et.SubElement(
+                        attributes, 'attribute', {'class': 'java.lang.Double', 'name': str(k)}
+                        )
+                    else:
+                        attribute = et.SubElement(
+                            attributes, 'attribute', {'class': 'java.lang.String', 'name': str(k)}
+                            )
+                    attribute.text = str(v)
+
+            if component.route.exists:
+                leg.append(component.route.xml)
 
 
 def write_matsim_plans(

--- a/tests/test_02_activity.py
+++ b/tests/test_02_activity.py
@@ -64,7 +64,7 @@ def test_activity_with_different_times_not_in_list_exact(list_of_acts):
     assert not different_times_act.isin_exact(list_of_acts)
 
 
-def test_activity_with_different_times_not_in_list(list_of_acts):
+def test_activity_with_different_times_in_list(list_of_acts):
     different_times_act = Activity(2, 'act_2', 'loc', start_time=mtdt(18 * 60 + 999), end_time=mtdt(19 * 60 + 999))
     assert different_times_act in list_of_acts
 

--- a/tests/test_03_read_matsim.py
+++ b/tests/test_03_read_matsim.py
@@ -162,6 +162,7 @@ def test_parse_simple_matsim_non_selected():
    assert len(person1.plans_non_selected) == 1
    assert len(person2.plans_non_selected) == 0
    assert isinstance(person1.plans_non_selected[0], Plan)
+   assert person1.plans_non_selected[0].score == 0
 
 
 # test stream matsim

--- a/tests/test_08_write.py
+++ b/tests/test_08_write.py
@@ -256,6 +256,28 @@ def test_read_write_v12_consistent(tmp_path):
     assert population == population2
 
 
+def test_read_write_v12_non_selected_plans_consistently(tmp_path):
+    test_tripsv12_path = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "test_data/test_matsim_experienced_plans_v12.xml")
+    )
+    population = read_matsim(
+        test_tripsv12_path,
+        version=12,
+        keep_non_selected=True
+        )
+    location = str(tmp_path / "test.xml.gz")
+    write_matsim(
+        population=population,
+        version=12,
+        plans_path=location,
+        comment="test",
+        household_key=None,
+        )
+    expected_file = "{}/test.xml.gz".format(tmp_path)
+    population2 = read_matsim(expected_file, version=12)
+    assert population == population2
+
+
 def test_writes_od_matrix_to_expected_file(tmpdir):
     population = Population()
 

--- a/tests/test_17_vehicles.py
+++ b/tests/test_17_vehicles.py
@@ -185,7 +185,7 @@ def test_writing_all_vehicles_results_in_valid_xml_file(tmpdir, population_with_
 
     generated_file_path = os.path.join(tmpdir, 'all_vehicles.xml')
     xml_obj = lxml.etree.parse(generated_file_path)
-    vehicles_v2_xsd.assertValid(xml_obj)
+    vehicles_v2_xsd.assertValid(xml_obj)  # this needs internet?    
 
 
 def test_generates_matsim_vehicles_xml_file_containing_expected_vehicle_types(tmpdir,

--- a/tests/test_data/test_matsim_experienced_plans_v12.xml
+++ b/tests/test_data/test_matsim_experienced_plans_v12.xml
@@ -101,7 +101,7 @@
 				</attributes>
 				<route type="generic" start_link="5221366343808222067_5221366343808222067" end_link="4155" trav_time="00:02:00" distance="101.14333765284941"></route>
 			</leg>
-			<activity type="home" link="4155" x="528634.2579046559" y="176896.66392752415" start_time="14:56:01" >
+			<activity type="home" link="4155" x="528634.2579046559" y="176896.66392752415" start_time="24:56:01" >
 			</activity>
 		</plan>
 
@@ -1542,7 +1542,7 @@
 		</plan>
 
 	</person>
-	
+
 	<person id="Jim" selected = "yes">
 		<attributes>
 			<attribute name="subpopulation" class="java.lang.String">electric</attribute>

--- a/tests/test_data/test_matsim_plansv12.xml
+++ b/tests/test_data/test_matsim_plansv12.xml
@@ -37,6 +37,27 @@
 			<activity type="home" link="1-2" x="0.0" y="0.0" >
 			</activity>
 		</plan>
+		<plan score="130" selected="no">
+			<activity type="home" link="1-2" x="0.0" y="0.0" end_time="07:00:00" >
+			</activity>
+			<leg mode="car" dep_time="07:00:00" trav_time="00:07:34">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="1-2" end_link="3-4" trav_time="00:07:34" distance="10100.0" vehicleRefId="chris">1-2 2-3 3-4</route>
+			</leg>
+			<activity type="work" link="3-4" x="10100.0" y="0.0" end_time="16:30:00" >
+			</activity>
+			<leg mode="car" dep_time="16:30:00" trav_time="00:07:43">
+				<attributes>
+					<attribute name="routingMode" class="java.lang.String">car</attribute>
+				</attributes>
+				<route type="links" start_link="3-4" end_link="1-2" trav_time="00:07:43" distance="10300.0" vehicleRefId="chris">3-4 4-3 3-2 2-1 1-2</route>
+			</leg>
+			<activity type="home" link="1-2" x="0.0" y="0.0" >
+			</activity>
+		</plan>
+
 
 	</person>
 


### PR DESCRIPTION
Changes intended to ensure no data is lost from MATSim plans when read/writing. This mainly includes the unchosen plans, but also other attributes such as link ids and pt interactions with durations (as recently spotted and fixed for elara).

Loosing the unselected plans from bitsim was increasing runs times by 30% (after a pam read/write). I am fairly sure this is caused by matsim loosing the info gained from the top N plans in agent memory.

The cli exposes a flag called `--keep_non_selected/selected_only` which defaults to `keep`. I've made this optional because there will be pretty chonky memory implications.

There's bits and other bobs (this was a long lived branch) - but nothing major and no breaks.