### PR TITLE
Make the notebooks smoke test faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ outputs/
 michael-local-requirements.txt
 dev
 venv
+examples/all_vehicles.xml
+examples/electric_vehicles.xml
+examples/plans.xml


### PR DESCRIPTION
As per [LAB-1905](https://arupdigital.atlassian.net/browse/LAB-1905); the smoke test is more than 3 times faster now when running locally. The speed improvement when running inside the CI build is smaller (more like 2 X), probably because there are fewer CPU cores available inside the container running the GitHub Action.

### Before this change

Running the smoke test locally took around 150 seconds
<img width="1440" alt="Screen Shot 2022-10-12 at 15 54 32" src="https://user-images.githubusercontent.com/250899/195377005-2702a8af-08d4-4921-a828-11077d14bf4c.png">

### After this change

Running the smoke test locally takes around 45 seconds
 
 <img width="1440" alt="Screen Shot 2022-10-12 at 15 46 03" src="https://user-images.githubusercontent.com/250899/195377272-d669b2e3-a693-403f-8b2f-7ddc682fdceb.png">
 
 ### Verifying failure functionality
 
 Just to make sure that failed processes are still detected, and that the parent process still produces the correct shell return code when one or more notebooks fail, I deliberately broke one of the notebooks. The failure is still detected, and the process return code is non-zero as it should be (which would break the CI build, as desired).
 
<img width="626" alt="Screen Shot 2022-10-12 at 16 41 46" src="https://user-images.githubusercontent.com/250899/195388320-f0c13c46-5418-4aa0-8316-ca28dd9d5e25.png">
