### PR TITLE
Tkinter install in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM python:3.7-slim-stretch
 RUN apt-get update \
 && apt-get upgrade -y \
 && apt-get -y install libspatialindex-dev --no-install-recommends \
+&& apt-get -y install tk-dev \
 && rm -rf /var/lib/apt/lists/* \
-&& /usr/local/bin/python -m pip install --upgrade pip \
-&& apt-get install python3-tk
+&& /usr/local/bin/python -m pip install --upgrade pip
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.7-slim-stretch
 
 RUN apt-get update \
 && apt-get upgrade -y \
-&& apt-get -y install libspatialindex-dev --no-install-recommends \
-&& apt-get -y install tk-dev \
+&& apt-get -y install libspatialindex-dev tk-dev --no-install-recommends \
 && rm -rf /var/lib/apt/lists/* \
 && /usr/local/bin/python -m pip install --upgrade pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apt-get update \
 && apt-get upgrade -y \
 && apt-get -y install libspatialindex-dev --no-install-recommends \
 && rm -rf /var/lib/apt/lists/* \
-&& /usr/local/bin/python -m pip install --upgrade pip
+&& /usr/local/bin/python -m pip install --upgrade pip \
+&& apt-get install python3-tk
 
 COPY . .
 


### PR DESCRIPTION
This PR fixes the following problem:

Using the docker image built from current Dockerimage gives:

![Screenshot 2022-11-01 at 11 19 55](https://user-images.githubusercontent.com/36536946/199226365-f51d7901-81f9-4375-b20d-dde93c53e47f.png)

when importing `read_matsim` from `pam.read`


