### PR TITLE
read - write person streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,10 +241,13 @@ Options:
   --help  Show this message and exit.
 
 Commands:
-  crop    Crop a population's plans outside a core area.
-  report  Various reporting for MATSim formatted plans.
-  sample  Down- or up-sample a PAM population.
-  combine Combine multiple populations into one xml file.
+  combine         Combine multiple populations (e.g.
+  crop            Crop a population's plans outside a core area.
+  report          Various reporting for MATSim formatted plans.
+  sample          Down- or up-sample a PAM population.
+  wipe-all-links  Clear all link information from agent plans.
+  wipe-links      Clear selected link information from agent plans.
+  wipe-routes     Clear all network route information from agent plans.
 ```
 
 For example:

--- a/pam/activity.py
+++ b/pam/activity.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from datetime import timedelta
 import logging
 from copy import copy
-from turtle import distance
 from typing import Optional
 import json
 

--- a/pam/cli.py
+++ b/pam/cli.py
@@ -761,7 +761,6 @@ def wipe_links(
     logger.debug(f"Crop = {crop}")
     logger.debug(
         f"Leg attributes (recommended for warm starting) = {leg_attributes}")
-    logger.debug(f"Leg routes will be removed")
     logger.debug(
         f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
@@ -790,7 +789,6 @@ def wipe_links(
         for act in plan.activities:
             if act.location.link in links:
                 return True
-
 
     with Console().status("[bold orange]Wiping selected links from population...", spinner='aesthetic') as _:
         with write.Writer(

--- a/pam/cli.py
+++ b/pam/cli.py
@@ -570,7 +570,7 @@ def sample(
 @click.argument(
     "path_population_output", type=click.Path(exists=False, writable=True),
 )
-def wipe_routes(
+def wipe_all_routes(
     path_population_input: str,
     path_population_output: str,
     matsim_version: int,

--- a/pam/cli.py
+++ b/pam/cli.py
@@ -708,6 +708,9 @@ def wipe_all_links(
             ):
                 for activity in person.activities:
                     activity.location.link = None
+                for plan in person.plans_non_selected:
+                    for activity in plan.activities:
+                        activity.location.link = None
                 outfile.add_person(person)
 
     logger.info('Population wipe complete')
@@ -770,8 +773,8 @@ def wipe_links(
         logger.debug(f"Loading attributes from {path_population_input}")
         attributes = read.matsim.load_attributes_map(path_population_input)
 
-    def link_filter(person):
-        for leg in person.legs:
+    def link_filter(plan):
+        for leg in plan.legs:
             for link in links:
                 if link in leg.route.network_route:
                     return True
@@ -795,11 +798,17 @@ def wipe_links(
                 leg_attributes=leg_attributes,
                 leg_route=True,
             ):
-                if link_filter(person):
+                if link_filter(person.plan):
                     for leg in person.legs:
                         leg.route.xml = {}
                     for activity in person.activities:
                         activity.location.link = None
+                    for plan in person.plans_non_selected:
+                        if link_filter(plan):
+                            for leg in plan.legs:
+                                leg.route.xml = {}
+                            for activity in plan.activities:
+                                activity.location.link = None
                 outfile.add_person(person)
 
     logger.info('Population wipe complete')

--- a/pam/cli.py
+++ b/pam/cli.py
@@ -57,7 +57,7 @@ def common_matsim_options(func):
     func = click.option(
         "--crop/--no_crop",
         default=False,
-        help="Crop or don't crop plans to 24 hours, defaults to crop."
+        help="Crop or don't crop plans to 24 hours, defaults to no_crop."
     )(func)
     func = click.option(
         "--leg_attributes/--no_leg_attributes",
@@ -107,24 +107,24 @@ def report():
 @click.argument(
     "path_population_input",
     type=click.Path(exists=True)
-    )
+)
 @click.option(
     "--sample_size",
     "-s",
     type=float,
     default=1,
     help="Input sample size. Default 1. For example, use 0.1 to apply a 10% weighting to the input population."
-    )
+)
 @click.option(
     "--attribute_key",
     "-k",
     help="Optional population attribute key to segment output, eg 'subpopulation'."
-    )
+)
 @click.option(
     "--rich/--text",
     default=True,
     help="Formatted (for terminal) or regular text output (for .txt)."
-    )
+)
 def summary(
     path_population_input: str,
     sample_size: float,
@@ -132,14 +132,14 @@ def summary(
     attribute_key: str,
     household_key: str,
     simplify_pt_trips: bool,
-    autocomplete : bool,
+    autocomplete: bool,
     crop: bool,
     leg_attributes: bool,
     leg_route: bool,
     keep_non_selected: bool,
     debug: bool,
     rich: bool,
-    ):
+):
     """
     Summarise a population.
     """
@@ -153,12 +153,13 @@ def summary(
     logger.debug(f"MATSim version set to {matsim_version}.")
     logger.debug(f"'household_key' set to {household_key}.")
     logger.debug(f"Simplify PT trips = {simplify_pt_trips}")
-    print(f"Simplify PT trips = {simplify_pt_trips}")
     logger.debug(f"Autocomplete MATSim plans (recommended) = {autocomplete}")
     logger.debug(f"Crop = {crop}")
-    logger.debug(f"Leg attributes (required for warm starting) = {leg_attributes}")
+    logger.debug(
+        f"Leg attributes (required for warm starting) = {leg_attributes}")
     logger.debug(f"Leg route (required for warm starting) = {leg_route}")
-    logger.debug(f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
+    logger.debug(
+        f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
     with Console().status("[bold green]Loading population...", spinner='aesthetic') as _:
         population = read.read_matsim(
@@ -189,7 +190,7 @@ def summary(
     type=float,
     default=1,
     help="Input sample size. Default 1. Required for downsampled populations. eg, use 0.1 for a 10% input population."
-    )
+)
 @common_options
 def benchmarks(
     population_input_path: str,
@@ -197,7 +198,7 @@ def benchmarks(
     sample_size: float = 1.,
     matsim_version: int = 12,
     debug: bool = False,
-    ):
+):
     """
     Write batch of benchmarks to directory
     """
@@ -232,7 +233,8 @@ def benchmarks(
             elif name.lower().endswith('.json'):
                 bm.to_json(path, orient='records')
             else:
-                raise UserWarning('Please specify a valid csv or json file path.')
+                raise UserWarning(
+                    'Please specify a valid csv or json file path.')
             console.log(f"{name} written to disk.")
     logger.info("Done.")
 
@@ -242,29 +244,29 @@ def benchmarks(
 @click.option(
     "--colour/--bw", default=True,
     help="Choose a colour or grey-scale (bw) output, default 'colour'"
-    )
+)
 @click.option(
     "--width", "-w", type=int, default=72,
     help="Target character width for plot, default 72"
-    )
+)
 @click.option(
     "--simplify_pt_trips",
     is_flag=True,
     default=False,
     help="Optionally simplify transit legs into single trip."
-    )
+)
 @click.option(
     "--crop/--no_crop",
     default=True,
     help="Crop or don't crop plans to 24 hours, defaults to crop."
-    )
+)
 def stringify(
     path_population_input: str,
     colour: bool,
     width: int,
     simplify_pt_trips: bool,
     crop: bool,
-    ):
+):
     """
     ASCII plot activity plans to terminal.
     """
@@ -275,8 +277,7 @@ def stringify(
         path_population_input,
         colour,
         width
-        )
-
+    )
 
 
 @cli.command()
@@ -285,17 +286,17 @@ def stringify(
 @comment_option
 @click.argument(
     "path_population_input", type=click.Path(exists=True),
-    )
+)
 @click.argument(
     "path_boundary", type=click.Path(exists=True),
-    )
+)
 @click.argument(
     "dir_population_output", type=click.Path(exists=False, writable=True),
-    )
+)
 @click.option(
     "--buffer", "-b", default=0,
     help="A buffer distance to (optionally) apply to the core area shapefile."
-    )
+)
 def crop(
     path_population_input,
     path_boundary,
@@ -303,7 +304,7 @@ def crop(
     matsim_version,
     household_key,
     simplify_pt_trips: bool,
-    autocomplete : bool,
+    autocomplete: bool,
     crop: bool,
     leg_attributes: bool,
     leg_route: bool,
@@ -311,7 +312,7 @@ def crop(
     comment,
     buffer,
     debug
-    ):
+):
     """
     Crop a population's plans outside a core area.
     """
@@ -328,9 +329,11 @@ def crop(
     logger.debug(f"Simplify PT trips = {simplify_pt_trips}")
     logger.debug(f"Autocomplete MATSim plans (recommended) = {autocomplete}")
     logger.debug(f"Crop = {crop}")
-    logger.debug(f"Leg attributes (required for warm starting) = {leg_attributes}")
+    logger.debug(
+        f"Leg attributes (required for warm starting) = {leg_attributes}")
     logger.debug(f"Leg route (required for warm starting) = {leg_route}")
-    logger.debug(f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
+    logger.debug(
+        f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
     # core area geometry
     with Console().status("[bold green]Loading boundary...", spinner='aesthetic') as _:
@@ -377,22 +380,22 @@ def crop(
 @comment_option
 @click.argument(
     "population_paths", type=click.Path(exists=True), nargs=-1
-    )
+)
 @click.option(
-    "--population_output", "-o", type=click.Path(exists=False, writable=True), default=os.getcwd()+"\combined_population.xml",
+    "--population_output", "-o", type=click.Path(exists=False, writable=True), default="combined_population.xml",
     help="Specify outpath for combined_population.xml, default is cwd"
-    )
+)
 @click.option(
     "--force", "-f", is_flag=True,
     help="Forces overwrite of existing file."
-    )
+)
 def combine(
     population_paths: str,
     population_output: str,
     matsim_version: int,
     household_key,
     simplify_pt_trips: bool,
-    autocomplete : bool,
+    autocomplete: bool,
     crop: bool,
     leg_attributes: bool,
     leg_route: bool,
@@ -400,7 +403,7 @@ def combine(
     comment: str,
     force: bool,
     debug: bool
-    ):
+):
     """
     Combine multiple populations (e.g. household, freight.. etc).
     """
@@ -414,15 +417,18 @@ def combine(
     logger.debug(f"Simplify PT trips = {simplify_pt_trips}")
     logger.debug(f"Autocomplete MATSim plans (recommended) = {autocomplete}")
     logger.debug(f"Crop = {crop}")
-    logger.debug(f"Leg attributes (required for warm starting) = {leg_attributes}")
+    logger.debug(
+        f"Leg attributes (required for warm starting) = {leg_attributes}")
     logger.debug(f"Leg route (required for warm starting) = {leg_route}")
-    logger.debug(f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
+    logger.debug(
+        f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
     if not force and os.path.exists(population_output):
         if input(f"{population_output} exists, overwrite? [y/n]:") .lower() in ["y", "yes", "ok"]:
-           pass
+            pass
         else:
-            raise UserWarning(f"Aborting to avoid overwrite of {population_output}")
+            raise UserWarning(
+                f"Aborting to avoid overwrite of {population_output}")
 
     with Console().status("[bold green]Loading and combining populations...", spinner='aesthetic') as _:
         combined_population = pop_combine(
@@ -435,13 +441,13 @@ def combine(
             leg_attributes=leg_attributes,
             leg_route=leg_route,
             keep_non_selected=keep_non_selected,
-            )
+        )
 
     logger.debug(f"Writing combinined population to {population_output}.")
 
     with Console().status("[bold green]Writing population...", spinner='aesthetic') as _:
         write.write_matsim(
-            population = combined_population,
+            population=combined_population,
             plans_path=population_output,
             comment=comment,
             keep_non_selected=keep_non_selected,
@@ -456,22 +462,22 @@ def combine(
 @comment_option
 @click.argument(
     "path_population_input", type=click.Path(exists=True),
-    )
+)
 @click.argument(
     "dir_population_output", type=click.Path(exists=False, writable=True),
-    )
+)
 @click.option(
     "--sample_size", "-s",
     help="The sample size, eg, use 0.1 to produce a 10% version of the input population."
-    )
+)
 @click.option(
     "--household_key", "-h", type=str, default="hid",
     help="Household key, defaults to 'hid'."
-    )
+)
 @click.option(
     "--seed", default=None,
     help="Random seed."
-    )
+)
 def sample(
     path_population_input: str,
     dir_population_output: str,
@@ -479,7 +485,7 @@ def sample(
     matsim_version: int,
     household_key: str,
     simplify_pt_trips: bool,
-    autocomplete : bool,
+    autocomplete: bool,
     crop: bool,
     leg_attributes: bool,
     leg_route: bool,
@@ -487,7 +493,7 @@ def sample(
     comment: str,
     seed: Optional[int],
     debug: bool,
-    ):
+):
     """
     Down- or up-sample a PAM population.
     """
@@ -498,15 +504,17 @@ def sample(
     logger.debug(f"Loading plans from {path_population_input}.")
     logger.debug(f"Sample size = {sample_size}.")
     logger.debug(f"Seed = {seed}")
-    logger.debug(f"Writing cropped plans to {dir_population_output}.")
+    logger.debug(f"Writing sampled plans to {dir_population_output}.")
     logger.debug(f"MATSim version set to {matsim_version}.")
     logger.debug(f"'household_key' set to {household_key}.")
     logger.debug(f"Simplify PT trips = {simplify_pt_trips}")
     logger.debug(f"Autocomplete MATSim plans (recommended) = {autocomplete}")
     logger.debug(f"Crop = {crop}")
-    logger.debug(f"Leg attributes (required for warm starting) = {leg_attributes}")
+    logger.debug(
+        f"Leg attributes (required for warm starting) = {leg_attributes}")
     logger.debug(f"Leg route (required for warm starting) = {leg_route}")
-    logger.debug(f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
+    logger.debug(
+        f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
 
     # read
     with Console().status("[bold green]Loading population...", spinner='aesthetic') as _:
@@ -522,7 +530,8 @@ def sample(
             leg_route=leg_route,
             keep_non_selected=keep_non_selected,
         )
-    logger.info(f'Initial population size (number of agents): {len(population_input)}')
+    logger.info(
+        f'Initial population size (number of agents): {len(population_input)}')
 
     # sample
     sample_size = float(sample_size)
@@ -546,5 +555,252 @@ def sample(
         )
 
     logger.info('Population sampling complete')
-    logger.info(f'Output population size (number of agents): {len(population_output)}')
+    logger.info(
+        f'Output population size (number of agents): {len(population_output)}')
     logger.info(f'Output saved at {dir_population_output}/plans.xml')
+
+
+@cli.command()
+@common_options
+@common_matsim_options
+@comment_option
+@click.argument(
+    "path_population_input", type=click.Path(exists=True),
+)
+@click.argument(
+    "path_population_output", type=click.Path(exists=False, writable=True),
+)
+def wipe_routes(
+    path_population_input: str,
+    path_population_output: str,
+    matsim_version: int,
+    household_key: str,
+    simplify_pt_trips: bool,
+    autocomplete: bool,
+    crop: bool,
+    leg_attributes: bool,
+    leg_route: bool,
+    keep_non_selected: bool,
+    comment: str,
+    debug: bool,
+):
+    """
+    Clear all network route information from agent plans. Required for significant network changes.
+    """
+    if debug:
+        logger.setLevel(logging.DEBUG)
+
+    logger.info('Starting wipe')
+    logger.debug(f"Loading plans from {path_population_input}.")
+    logger.debug(f"Writing wiped plans to {path_population_output}.")
+    logger.debug(f"MATSim version set to {matsim_version}.")
+    logger.debug(f"Simplify PT trips = {simplify_pt_trips}")
+    logger.debug(f"Autocomplete MATSim plans (recommended) = {autocomplete}")
+    logger.debug(f"Crop = {crop}")
+    logger.debug(
+        f"Leg attributes (recommended for warm starting) = {leg_attributes}")
+    logger.debug(f"Leg routes will be removed")
+    logger.debug(
+        f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
+
+    with Console().status("[bold green]Loading population attributes...", spinner='aesthetic') as _:
+
+        if not matsim_version == 12:
+            logger.warning(
+                "This handler is not intended to work with v11 plans")
+        logger.debug(f"Loading attributes from {path_population_input}")
+        attributes = read.matsim.load_attributes_map(path_population_input)
+
+    with Console().status("[bold orange]Wiping population routes...", spinner='aesthetic') as _:
+        with write.Writer(
+            path=path_population_output,
+            household_key=None,
+            comment=comment,
+            keep_non_selected=keep_non_selected,
+        ) as outfile:
+            for person in read.matsim.stream_matsim_persons(
+                path_population_input,
+                attributes=attributes,
+                weight=1,
+                version=matsim_version,
+                simplify_pt_trips=simplify_pt_trips,
+                autocomplete=autocomplete,
+                crop=crop,
+                keep_non_selected=keep_non_selected,
+                leg_attributes=leg_attributes,
+                leg_route=False,
+            ):
+                outfile.add_person(person)
+
+    logger.info('Population wipe complete')
+    logger.info(f'Output saved at {path_population_output}')
+
+
+@cli.command()
+@common_options
+@common_matsim_options
+@comment_option
+@click.argument(
+    "path_population_input", type=click.Path(exists=True),
+)
+@click.argument(
+    "path_population_output", type=click.Path(exists=False, writable=True),
+)
+def wipe_all_links(
+    path_population_input: str,
+    path_population_output: str,
+    matsim_version: int,
+    household_key: str,
+    simplify_pt_trips: bool,
+    autocomplete: bool,
+    crop: bool,
+    leg_attributes: bool,
+    leg_route: bool,
+    keep_non_selected: bool,
+    comment: str,
+    debug: bool,
+):
+    """
+    Clear all link information from agent plans.
+    """
+    if debug:
+        logger.setLevel(logging.DEBUG)
+
+    logger.warning(f"Clearing links from all plans.")
+    logger.debug(f"Loading plans from {path_population_input}.")
+    logger.debug(f"Writing wiped plans to {path_population_output}.")
+    logger.debug(f"MATSim version set to {matsim_version}.")
+    logger.debug(f"Simplify PT trips = {simplify_pt_trips}")
+    logger.debug(f"Autocomplete MATSim plans (recommended) = {autocomplete}")
+    logger.debug(f"Crop = {crop}")
+    logger.debug(
+        f"Leg attributes (recommended for warm starting) = {leg_attributes}")
+    logger.debug(f"Leg routes will be removed")
+    logger.debug(
+        f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
+
+    with Console().status("[bold green]Loading population attributes...", spinner='aesthetic') as _:
+
+        if not matsim_version == 12:
+            logger.warning(
+                "This handler is not intended to work with v11 plans")
+        logger.debug(f"Loading attributes from {path_population_input}")
+        attributes = read.matsim.load_attributes_map(path_population_input)
+
+    with Console().status("[bold orange]Wiping all links from population...", spinner='aesthetic') as _:
+        with write.Writer(
+            path=path_population_output,
+            household_key=None,
+            comment=comment,
+            keep_non_selected=keep_non_selected,
+        ) as outfile:
+            for person in read.matsim.stream_matsim_persons(
+                path_population_input,
+                attributes=attributes,
+                weight=1,
+                version=matsim_version,
+                simplify_pt_trips=simplify_pt_trips,
+                autocomplete=autocomplete,
+                crop=crop,
+                keep_non_selected=keep_non_selected,
+                leg_attributes=leg_attributes,
+                leg_route=False,
+            ):
+                for activity in person.activities:
+                    activity.location.link = None
+                outfile.add_person(person)
+
+    logger.info('Population wipe complete')
+    logger.info(f'Output saved at {path_population_output}')
+
+
+@cli.command()
+@common_options
+@common_matsim_options
+@comment_option
+@click.argument(
+    "path_population_input", type=click.Path(exists=True),
+)
+@click.argument(
+    "path_population_output", type=click.Path(exists=False, writable=True),
+)
+@click.argument(
+    "links", nargs=-1,
+)
+def wipe_links(
+    path_population_input: str,
+    path_population_output: str,
+    links,
+    matsim_version: int,
+    household_key: str,
+    simplify_pt_trips: bool,
+    autocomplete: bool,
+    crop: bool,
+    leg_attributes: bool,
+    leg_route: bool,
+    keep_non_selected: bool,
+    comment: str,
+    debug: bool,
+):
+    """
+    Clear selected link information from agent plans.
+    """
+    if debug:
+        logger.setLevel(logging.DEBUG)
+
+    logger.warning(
+        f"Clearing links from plans that contain links: {', '.join(links)}.")
+    logger.debug(f"Loading plans from {path_population_input}.")
+    logger.debug(f"Writing wiped plans to {path_population_output}.")
+    logger.debug(f"MATSim version set to {matsim_version}.")
+    logger.debug(f"Simplify PT trips = {simplify_pt_trips}")
+    logger.debug(f"Autocomplete MATSim plans (recommended) = {autocomplete}")
+    logger.debug(f"Crop = {crop}")
+    logger.debug(
+        f"Leg attributes (recommended for warm starting) = {leg_attributes}")
+    logger.debug(f"Leg routes will be removed")
+    logger.debug(
+        f"Keep non selected plans (recommended for warm starting) = {keep_non_selected}")
+
+    with Console().status("[bold green]Loading population attributes...", spinner='aesthetic') as _:
+
+        if not matsim_version == 12:
+            logger.warning(
+                "This handler is not intended to work with v11 plans")
+        logger.debug(f"Loading attributes from {path_population_input}")
+        attributes = read.matsim.load_attributes_map(path_population_input)
+
+    def link_filter(person):
+        for leg in person.legs:
+            for link in links:
+                if link in leg.route.network_route:
+                    return True
+
+    with Console().status("[bold orange]Wiping selected links from population...", spinner='aesthetic') as _:
+        with write.Writer(
+            path=path_population_output,
+            household_key=None,
+            comment=comment,
+            keep_non_selected=keep_non_selected,
+        ) as outfile:
+            for person in read.matsim.stream_matsim_persons(
+                path_population_input,
+                attributes=attributes,
+                weight=1,
+                version=matsim_version,
+                simplify_pt_trips=simplify_pt_trips,
+                autocomplete=autocomplete,
+                crop=crop,
+                keep_non_selected=keep_non_selected,
+                leg_attributes=leg_attributes,
+                leg_route=True,
+            ):
+                if link_filter(person):
+                    for leg in person.legs:
+                        leg.route.xml = {}
+                    for activity in person.activities:
+                        activity.location.link = None
+                outfile.add_person(person)
+
+    logger.info('Population wipe complete')
+    logger.info(f'Output saved at {path_population_output}')

--- a/pam/core.py
+++ b/pam/core.py
@@ -36,7 +36,8 @@ class Population:
             self.add(Household(hid=target.pid))
             self.households[target.pid].add(target)
         else:
-            raise UserWarning(f"Expected instance of Household, list or Person, not: {type(target)}")
+            raise UserWarning(
+                f"Expected instance of Household, list or Person, not: {type(target)}")
 
     def get(self, hid, default=None):
         return self.households.get(hid, default)
@@ -75,7 +76,8 @@ class Population:
                 if other == person:
                     return True
             return False
-        raise UserWarning(f"Cannot check if population contains object type: {type(other)}, please provide a Household or Person.")
+        raise UserWarning(
+            f"Cannot check if population contains object type: {type(other)}, please provide a Household or Person.")
 
     def __eq__(self, other):
         """
@@ -83,7 +85,8 @@ class Population:
         of all household and household members. Identifiers (eg hid and pid) are disregarded.
         """
         if not isinstance(other, Population):
-            self.logger.warning(f"Cannot compare population to non population: ({type(other)}), please provide a Population.")
+            self.logger.warning(
+                f"Cannot compare population to non population: ({type(other)}), please provide a Population.")
             return False
         if not len(self) == len(other):
             return False
@@ -137,7 +140,7 @@ class Population:
         return subpopulations
 
     @property
-    def attributes(self, show:int = 10) -> dict:
+    def attributes(self, show: int = 10) -> dict:
         attributes = defaultdict(set)
         for _, hh in self.households.items():
 
@@ -179,7 +182,8 @@ class Population:
                 yield v
 
     def vehicle_types(self):
-        v_types = {p.vehicle.vehicle_type for _, _, p in self.people() if p.vehicle is not None}
+        v_types = {p.vehicle.vehicle_type for _, _,
+                   p in self.people() if p.vehicle is not None}
         for vt in v_types:
             yield vt
 
@@ -224,28 +228,29 @@ class Population:
         for hid, pid, person in self.people():
             for seq, leg in enumerate(person.legs):
                 record = {
-                        'pid': pid,
-                        'hid': hid,
-                        'hzone': person.home,
-                        'ozone': leg.start_location.area,
-                        'dzone': leg.end_location.area,
-                        'oloc': leg.start_location,
-                        'dloc': leg.end_location,
-                        'seq': seq,
-                        'purp': leg.purp,
-                        'mode': leg.mode,
-                        'tst': leg.start_time.time(),
-                        'tet': leg.end_time.time(),
-                        'duration': leg.duration / pd.Timedelta(minutes = 1), #duration in minutes
-                        'euclidean_distance': leg.euclidean_distance,
-                        'freq': person.freq,
-                    }
-                record = {**record, **dict(person.attributes)} # add person attributes
+                    'pid': pid,
+                    'hid': hid,
+                    'hzone': person.home,
+                    'ozone': leg.start_location.area,
+                    'dzone': leg.end_location.area,
+                    'oloc': leg.start_location,
+                    'dloc': leg.end_location,
+                    'seq': seq,
+                    'purp': leg.purp,
+                    'mode': leg.mode,
+                    'tst': leg.start_time.time(),
+                    'tet': leg.end_time.time(),
+                    # duration in minutes
+                    'duration': leg.duration / pd.Timedelta(minutes=1),
+                    'euclidean_distance': leg.euclidean_distance,
+                    'freq': person.freq,
+                }
+                # add person attributes
+                record = {**record, **dict(person.attributes)}
                 df.append(record)
         df = pd.DataFrame(df)
         self.add_fields(df)
         return df
-
 
     def trips_df(self) -> pd.DataFrame:
         """
@@ -256,23 +261,25 @@ class Population:
         for hid, pid, person in self.people():
             for seq, trip in enumerate(person.plan.trips()):
                 record = {
-                        'pid': pid,
-                        'hid': hid,
-                        'hzone': person.home,
-                        'ozone': trip.start_location.area,
-                        'dzone': trip.end_location.area,
-                        'oloc': trip.start_location,
-                        'dloc': trip.end_location,
-                        'seq': seq,
-                        'purp': trip.purp,
-                        'mode': trip.mode,
-                        'tst': trip.start_time.time(),
-                        'tet': trip.end_time.time(),
-                        'duration': trip.duration / pd.Timedelta(minutes = 1), #duration in minutes
-                        'euclidean_distance': trip.euclidean_distance,
-                        'freq': person.freq,
-                    }
-                record = {**record, **dict(person.attributes)} # add person attributes
+                    'pid': pid,
+                    'hid': hid,
+                    'hzone': person.home,
+                    'ozone': trip.start_location.area,
+                    'dzone': trip.end_location.area,
+                    'oloc': trip.start_location,
+                    'dloc': trip.end_location,
+                    'seq': seq,
+                    'purp': trip.purp,
+                    'mode': trip.mode,
+                    'tst': trip.start_time.time(),
+                    'tet': trip.end_time.time(),
+                    # duration in minutes
+                    'duration': trip.duration / pd.Timedelta(minutes=1),
+                    'euclidean_distance': trip.euclidean_distance,
+                    'freq': person.freq,
+                }
+                # add person attributes
+                record = {**record, **dict(person.attributes)}
                 df.append(record)
 
         df = pd.DataFrame(df)
@@ -281,19 +288,21 @@ class Population:
 
     @staticmethod
     def add_fields(df):
-        ## add extra fields used for benchmarking
+        # add extra fields used for benchmarking
         df['personhrs'] = df['freq'] * df['duration'] / 60
-        df['departure_hour'] = df.tst.apply(lambda x:x.hour)
-        df['arrival_hour'] = df.tet.apply(lambda x:x.hour)
+        df['departure_hour'] = df.tst.apply(lambda x: x.hour)
+        df['arrival_hour'] = df.tet.apply(lambda x: x.hour)
         df['euclidean_distance_category'] = pd.cut(
             df.euclidean_distance,
-            bins =[0,1,5,10,25,50,100,200,999999],
-            labels = ['0 to 1 km', '1 to 5 km', '5 to 10 km', '10 to 25 km', '25 to 50 km', '50 to 100 km', '100 to 200 km', '200+ km']
+            bins=[0, 1, 5, 10, 25, 50, 100, 200, 999999],
+            labels=['0 to 1 km', '1 to 5 km', '5 to 10 km', '10 to 25 km',
+                    '25 to 50 km', '50 to 100 km', '100 to 200 km', '200+ km']
         )
         df['duration_category'] = pd.cut(
             df.duration,
-            bins =[0,5,10,15,30,45,60,90,120,999999],
-            labels = ['0 to 5 min', '5 to 10 min', '10 to 15 min', '15 to 30 min', '30 to 45 min', '45 to 60 min', '60 to 90 min', '90 to 120 min', '120+ min']
+            bins=[0, 5, 10, 15, 30, 45, 60, 90, 120, 999999],
+            labels=['0 to 5 min', '5 to 10 min', '10 to 15 min', '15 to 30 min',
+                    '30 to 45 min', '45 to 60 min', '60 to 90 min', '90 to 120 min', '120+ min']
         )
 
     def build_travel_geodataframe(self, **kwargs):
@@ -332,16 +341,17 @@ class Population:
         :return:
         """
         return plot.plot_travel_plans(
-            gdf=self.build_travel_geodataframe(from_epsg=epsg, to_epsg="epsg:4326"),
+            gdf=self.build_travel_geodataframe(
+                from_epsg=epsg, to_epsg="epsg:4326"),
             **kwargs
         )
 
     def fix_plans(
         self,
         crop: bool = True,
-        times = True,
-        locations = True
-        ):
+        times=True,
+        locations=True
+    ):
         for _, _, person in self.people():
             if crop:
                 person.plan.crop()
@@ -366,9 +376,9 @@ class Population:
     def to_csv(
         self,
         dir: str,
-        crs = None,
+        crs=None,
         to_crs: str = "EPSG:4326"
-        ):
+    ):
         write.to_csv(self, dir, crs, to_crs)
 
     def __str__(self):
@@ -378,7 +388,8 @@ class Population:
         """
         Unsafe addition with assignment (no guarantee of unique ids).
         """
-        self.logger.debug("Note that this method requires all identifiers from populations being combined to be unique.")
+        self.logger.debug(
+            "Note that this method requires all identifiers from populations being combined to be unique.")
         if isinstance(other, Population):
             for hid, hh in other.households.items():
                 self.households[hid] = copy.deepcopy(hh)
@@ -390,7 +401,8 @@ class Population:
             self.households[other.pid] = Household(other.pid)
             self.households[other.pid].people[other.pid] = copy.deepcopy(other)
             return self
-        raise TypeError(f"Object for addition must be a Population Household or Person object, not {type(other)}")
+        raise TypeError(
+            f"Object for addition must be a Population Household or Person object, not {type(other)}")
 
     def reindex(self, prefix: str):
         """
@@ -400,7 +412,8 @@ class Population:
             hh = self.households[hid]
             new_hid = prefix + str(hid)
             if new_hid in self.households:
-                raise KeyError(f"Duplicate household identifier (hid): {new_hid}")
+                raise KeyError(
+                    f"Duplicate household identifier (hid): {new_hid}")
 
             hh.reindex(prefix)
 
@@ -422,15 +435,15 @@ class Population:
             self += other
             return None
         if isinstance(other, Person):
-            hh = Household(other.pid) # we create a new hh for single person
+            hh = Household(other.pid)  # we create a new hh for single person
             hh.add(other)
             hh.reindex(prefix)
             self += hh
             return None
-        raise TypeError(f"Object for addition must be a Population Household or Person object, not {type(other)}")
+        raise TypeError(
+            f"Object for addition must be a Population Household or Person object, not {type(other)}")
 
-
-    def sample_locs(self, sampler, long_term_activities = None, joint_trips_prefix = 'escort_'):
+    def sample_locs(self, sampler, long_term_activities=None, joint_trips_prefix='escort_'):
         """
         WIP Sample household plan locs using a sampler.
 
@@ -477,7 +490,8 @@ class Population:
                         target_act = act.act
 
                     if (act.location.area, target_act) in unique_locations:
-                        location = unique_locations[(act.location.area, target_act)]
+                        location = unique_locations[(
+                            act.location.area, target_act)]
                         act.location = location
 
                     else:
@@ -488,7 +502,8 @@ class Population:
                         if target_act in long_term_activities:
                             # one location per zone for long-term choices (only)
                             # short-term activities, such as shopping can visit multiple locations in the same zone
-                            unique_locations[(act.location.area, target_act)] = location
+                            unique_locations[(
+                                act.location.area, target_act)] = location
                         act.location = location
 
                 # complete the alotting activity locations to the trip starts and ends.
@@ -498,8 +513,7 @@ class Population:
                         component.start_location = person.plan[idx-1].location
                         component.end_location = person.plan[idx+1].location
 
-
-    def sample_locs_complex(self, sampler, long_term_activities = None, joint_trips_prefix = 'escort_'):
+    def sample_locs_complex(self, sampler, long_term_activities=None, joint_trips_prefix='escort_'):
         """
         Extends sample_locs method to enable more complex and rules-based sampling.
         Keeps track of the last location and transport mode, to apply distance- and mode-based sampling rules.
@@ -510,11 +524,11 @@ class Population:
         if long_term_activities is None:
             long_term_activities = variables.LONG_TERM_ACTIVITIES
 
-
         for _, household in self.households.items():
             home_loc = activity.Location(
                 area=household.location.area,
-                loc=sampler.sample(household.location.area, 'home', mode = None, previous_duration=None, previous_loc = None)
+                loc=sampler.sample(household.location.area, 'home',
+                                   mode=None, previous_duration=None, previous_loc=None)
             )
             mode = None
 
@@ -529,7 +543,7 @@ class Population:
                     # loop through all plan elements
 
                     if isinstance(component, activity.Leg):
-                        mode = component.mode # keep track of last mode
+                        mode = component.mode  # keep track of last mode
                         previous_duration = component.duration
 
                     elif isinstance(component, activity.Activity):
@@ -543,19 +557,22 @@ class Population:
                             target_act = act.act
 
                         if (act.location.area, target_act) in unique_locations:
-                            location = unique_locations[(act.location.area, target_act)]
+                            location = unique_locations[(
+                                act.location.area, target_act)]
                             act.location = location
 
                         else:
                             location = activity.Location(
                                 area=act.location.area,
-                                loc=sampler.sample(act.location.area, target_act, mode = mode, previous_duration = previous_duration, previous_loc = previous_loc)
+                                loc=sampler.sample(act.location.area, target_act, mode=mode,
+                                                   previous_duration=previous_duration, previous_loc=previous_loc)
                             )
                             if target_act in long_term_activities:
-                                unique_locations[(act.location.area, target_act)] = location
+                                unique_locations[(
+                                    act.location.area, target_act)] = location
                             act.location = location
 
-                        previous_loc = location.loc # keep track of previous location
+                        previous_loc = location.loc  # keep track of previous location
 
                 # complete the alotting activity locations to the trip starts and ends.
                 for idx in range(person.plan.length):
@@ -563,7 +580,6 @@ class Population:
                     if isinstance(component, activity.Leg):
                         component.start_location = person.plan[idx-1].location
                         component.end_location = person.plan[idx+1].location
-
 
 
 class Household:
@@ -577,11 +593,11 @@ class Household:
         location: Optional[Location] = None,
         area=None,
         loc=None
-        ):
+    ):
         self.hid = hid
         self.people = {}
         self.attributes = attributes
-        self.hh_freq=freq
+        self.hh_freq = freq
         if location:
             self._location = location
         else:
@@ -598,7 +614,8 @@ class Household:
         elif isinstance(person, Person):
             self.people[person.pid] = person
         else:
-            raise UserWarning(f"Expected instance of Person, not: {type(person)}")
+            raise UserWarning(
+                f"Expected instance of Person, not: {type(person)}")
 
     def get(self, pid, default=None):
         return self.people.get(pid, default)
@@ -618,7 +635,8 @@ class Household:
 
     def __contains__(self, other_person):
         if not isinstance(other_person, Person):
-            raise UserWarning(f"Cannot check if household contains object type: {type(other_person)}, please provide Person.")
+            raise UserWarning(
+                f"Cannot check if household contains object type: {type(other_person)}, please provide Person.")
         for _, person in self:
             if other_person == person:
                 return True
@@ -631,7 +649,8 @@ class Household:
         are included in attributes.
         """
         if not isinstance(other, Household):
-            self.logger.warning(f"Cannot compare household to non household: ({type(other)}).")
+            self.logger.warning(
+                f"Cannot compare household to non household: ({type(other)}).")
             return False
         if not self.attributes == other.attributes:
             return False
@@ -655,10 +674,11 @@ class Household:
         for person in self.people.values():
             if person.home.exists:
                 return person.home
-        self.logger.warning(f"Failed to find location for household: {self.hid}")
+        self.logger.warning(
+            f"Failed to find location for household: {self.hid}")
         return self._location
 
-    def set_location(self, location:Location):
+    def set_location(self, location: Location):
         """
         Set both hh and person home_location, but note that hhs and
         their persons do not share location object.
@@ -725,7 +745,8 @@ class Household:
             return self.hh_freq
 
         if not self.people:
-            self.logger.warning(f"Unknown hh weight for empty hh {self.hid}, returning None.")
+            self.logger.warning(
+                f"Unknown hh weight for empty hh {self.hid}, returning None.")
             return None
 
         return self.av_person_freq
@@ -736,11 +757,13 @@ class Household:
     @property
     def av_person_freq(self):
         if not self.people:
-            self.logger.warning(f"Unknown hh weight for empty hh {self.hid}, returning None.")
+            self.logger.warning(
+                f"Unknown hh weight for empty hh {self.hid}, returning None.")
             return None
         frequencies = [person.freq for person in self.people.values()]
         if None in frequencies:
-            self.logger.warning(f"Missing person weight in hh {self.hid}, returning None.")
+            self.logger.warning(
+                f"Missing person weight in hh {self.hid}, returning None.")
             return None
         return sum(frequencies) / len(frequencies)
 
@@ -813,7 +836,8 @@ class Household:
         :return:
         """
         return plot.plot_travel_plans(
-            gdf=self.build_travel_geodataframe(from_epsg=epsg, to_epsg="epsg:4326"),
+            gdf=self.build_travel_geodataframe(
+                from_epsg=epsg, to_epsg="epsg:4326"),
             **kwargs
         )
 
@@ -824,7 +848,8 @@ class Household:
         """
         Unsafe addition with assignment (no guarantee of unique ids).
         """
-        self.logger.debug("Note that this method requires all identifiers from populations being combined to be unique.")
+        self.logger.debug(
+            "Note that this method requires all identifiers from populations being combined to be unique.")
         if isinstance(other, Household):
             for pid, person in other.people.items():
                 self.people[pid] = copy.deepcopy(person)
@@ -832,7 +857,8 @@ class Household:
         if isinstance(other, Person):
             self.people[other.pid] = copy.deepcopy(other)
             return self
-        raise TypeError(f"Object for addition must be a Household or Person object, not {type(other)}")
+        raise TypeError(
+            f"Object for addition must be a Household or Person object, not {type(other)}")
 
     def reindex(self, prefix: str):
         """
@@ -865,7 +891,7 @@ class Person:
         home_area=None,
         home_loc=None,
         vehicle: Vehicle = None
-        ):
+    ):
         self.pid = pid
         self.person_freq = freq
         self.attributes = attributes
@@ -877,7 +903,8 @@ class Person:
             self.home_location.area = home_area
         if home_loc:
             self.home_location.loc = home_loc
-        self.plan = activity.Plan(home_location=self.home_location)  # person and their plan share Location
+        # person and their plan share Location
+        self.plan = activity.Plan(home_location=self.home_location)
         self.plans_non_selected = []
         self.vehicle = None
         if vehicle:
@@ -903,7 +930,8 @@ class Person:
         :return:
         """
         if vehicle.id != self.pid:
-            raise PAMVehicleIdError(f'Vehicle with ID: {vehicle.id} does not match Person ID: {self.pid}')
+            raise PAMVehicleIdError(
+                f'Vehicle with ID: {vehicle.id} does not match Person ID: {self.pid}')
         self.vehicle = vehicle
 
     @property
@@ -933,7 +961,7 @@ class Person:
     def subpopulation(self):
         return self.attributes.get("subpopulation")
 
-    def set_location(self, location:Location):
+    def set_location(self, location: Location):
         self.home_location = location
         self.plan.home_location = location
 
@@ -947,6 +975,12 @@ class Person:
 
     @property
     def activities(self):
+        if self.plan:
+            for act in self.plan.activities:
+                yield act
+
+    @property
+    def acts(self):
         if self.plan:
             for act in self.plan.activities:
                 yield act
@@ -1008,7 +1042,8 @@ class Person:
         Check for equality of two persons, equality is based on equal attributes and activity plans.
         """
         if not isinstance(other, Person):
-            self.logger.warning(f"Cannot compare person to non person: ({type(other)})")
+            self.logger.warning(
+                f"Cannot compare person to non person: ({type(other)})")
             return False
         if not self.attributes == other.attributes:
             return False
@@ -1050,7 +1085,8 @@ class Person:
         :return: True
         """
         if not self.plan.valid_sequence:
-            raise PAMSequenceValidationError(f"Person {self.pid} has invalid plan sequence")
+            raise PAMSequenceValidationError(
+                f"Person {self.pid} has invalid plan sequence")
 
         return True
 
@@ -1060,7 +1096,8 @@ class Person:
         :return: True
         """
         if not self.plan.valid_time_sequence:
-            raise PAMInvalidTimeSequenceError(f"Person {self.pid} has invalid plan times")
+            raise PAMInvalidTimeSequenceError(
+                f"Person {self.pid} has invalid plan times")
 
         return True
 
@@ -1070,7 +1107,8 @@ class Person:
         :return: True
         """
         if not self.plan.valid_locations:
-            raise PAMValidationLocationsError(f"Person {self.pid} has invalid plan locations")
+            raise PAMValidationLocationsError(
+                f"Person {self.pid} has invalid plan locations")
 
         return True
 
@@ -1154,7 +1192,8 @@ class Person:
         :return:
         """
         return plot.plot_travel_plans(
-            gdf=self.build_travel_geodataframe(from_epsg=epsg, to_epsg="epsg:4326"),
+            gdf=self.build_travel_geodataframe(
+                from_epsg=epsg, to_epsg="epsg:4326"),
             **kwargs
         )
 

--- a/pam/write/matsim.py
+++ b/pam/write/matsim.py
@@ -91,7 +91,8 @@ class Writer:
         coordinate_reference_system: str = None
     ) -> None:
 
-        create_local_dir(os.path.dirname(path))
+        if os.path.dirname(path):
+            create_local_dir(os.path.dirname(path))
         self.path = path
         self.household_key = household_key
         self.comment = comment

--- a/pam/write/matsim.py
+++ b/pam/write/matsim.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import os
 from datetime import datetime
 import logging
@@ -12,16 +13,16 @@ from pam.utils import create_local_dir, is_gzip, DEFAULT_GZIP_COMPRESSION
 
 
 def write_matsim(
-        population,
-        plans_path : str,
-        attributes_path : Optional[str] = None,
-        vehicles_dir : Optional[str] = None,
-        version : int = None,
-        comment : Optional[str] = None,
-        household_key : Optional[str] = 'hid',
-        keep_non_selected : bool = False,
-        coordinate_reference_system: str = None,
-    ) -> None:
+    population,
+    plans_path: str,
+    attributes_path: Optional[str] = None,
+    vehicles_dir: Optional[str] = None,
+    version: int = None,
+    comment: Optional[str] = None,
+    household_key: Optional[str] = 'hid',
+    keep_non_selected: bool = False,
+    coordinate_reference_system: str = None,
+) -> None:
     """
     Write a core population to matsim population v6 xml format.
     Note that this requires activity locs to be set (shapely.geometry.Point).
@@ -39,9 +40,11 @@ def write_matsim(
     """
 
     if version is not None:
-        logging.warning('parameter "version" is no longer supported by write_matsim()')
+        logging.warning(
+            'parameter "version" is no longer supported by write_matsim()')
     if attributes_path is not None:
-        logging.warning('parameter "attributes_path" is no longer supported by write_matsim()')
+        logging.warning(
+            'parameter "attributes_path" is no longer supported by write_matsim()')
 
     write_matsim_population_v6(
         population=population,
@@ -49,27 +52,103 @@ def write_matsim(
         comment=comment,
         household_key=household_key,
         keep_non_selected=keep_non_selected,
-        coordinate_reference_system = coordinate_reference_system,
+        coordinate_reference_system=coordinate_reference_system,
     )
-    
+
     # write vehicles
     if population.has_vehicles:
         logging.info('Population includes vehicles')
         if vehicles_dir is None:
-            raise UserWarning("Please provide a vehicles_dir to write vehicle files")
+            raise UserWarning(
+                "Please provide a vehicles_dir to write vehicle files")
         else:
             logging.info(f'Saving vehicles to {vehicles_dir}')
             write_vehicles(output_dir=vehicles_dir, population=population)
 
 
+class Writer:
+    """
+    Context Manager for writing to xml. Designed to handle the boilerplate xml.
+    For example:
+    `with pam.write.matsim.Writer(PATH) as writer:
+        for hid, household in population:
+            writer.add_hh(household)
+    `
+    For example:
+    `with pam.write.matsim.Writer(OUT_PATH) as writer:
+        for person in pam.read.matsim.stream_matsim_persons(IN_PATH):
+            pam.samplers.time.apply_jitter_to_plan(person.plan)
+            writer.add_person(household)
+    `
+    """
+
+    def __init__(
+        self,
+        path: str,
+        household_key: Optional[str] = 'hid',
+        comment: Optional[str] = None,
+        keep_non_selected: bool = False,
+        coordinate_reference_system: str = None
+    ) -> None:
+
+        create_local_dir(os.path.dirname(path))
+        self.path = path
+        self.household_key = household_key
+        self.comment = comment
+        self.keep_non_selected = keep_non_selected
+        self.coordinate_reference_system = coordinate_reference_system
+        self.compression = DEFAULT_GZIP_COMPRESSION if is_gzip(path) else 0
+        self.xmlfile = None
+        self.writer = None
+        self.population_writer = None
+
+    def __enter__(self) -> Writer:
+        self.xmlfile = et.xmlfile(
+            self.path, encoding="utf-8", compression=self.compression
+        )
+        self.writer = self.xmlfile.__enter__()  # enter into lxml file writer
+        self.writer.write_declaration()
+        self.writer.write_doctype(
+            '<!DOCTYPE population SYSTEM "http://matsim.org/files/dtd/population_v6.dtd">'
+        )
+        if self.comment:
+            self.writer.write(
+                et.Comment(self.comment), pretty_print=True)
+        self.writer.write(et.Comment(
+            f"Created {datetime.today()}"), pretty_print=True)
+
+        self.population_writer = self.writer.element("population")
+        self.population_writer.__enter__()   # enter into lxml element writer
+        if self.coordinate_reference_system is not None:
+            self.writer.write(create_crs_attribute(
+                self.coordinate_reference_system), pretty_print=True)
+        return self
+
+    def add_hh(self, household) -> None:
+        for _, person in household:
+            if self.household_key is not None:
+                person.attributes[
+                    self.household_key
+                ] = household.hid  # force add hid as an attribute
+            self.add_person(person)
+
+    def add_person(self, person) -> None:
+        e = create_person_element(person.pid, person, self.keep_non_selected)
+        self.writer.write(e, pretty_print=True)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.population_writer.__exit__(exc_type, exc_value, traceback)
+        self.xmlfile.__exit__(exc_type, exc_value, traceback)
+
+
 def write_matsim_population_v6(
     population,
-    path : str,
-    household_key : Optional[str] = 'hid',
-    comment : Optional[str] = None,
+    path: str,
+    household_key: Optional[str] = 'hid',
+    comment: Optional[str] = None,
     keep_non_selected: bool = False,
     coordinate_reference_system: str = None,
-    ) -> None:
+) -> None:
     """
     Write matsim population v6 xml (persons plans and attributes combined).
     :param population: core.Population, population to be writen to disk
@@ -79,31 +158,15 @@ def write_matsim_population_v6(
     :param keep_non_selected: bool, default False
     """
 
-    create_local_dir(os.path.dirname(path))
-    
-    compression = DEFAULT_GZIP_COMPRESSION if is_gzip(path) else 0
-    with et.xmlfile(path, encoding="utf-8", compression=compression) as xf:
-        xf.write_declaration()
-        xf.write_doctype(
-            '<!DOCTYPE population SYSTEM "http://matsim.org/files/dtd/population_v6.dtd">'
-        )
-
-        with xf.element("population"):
-            if comment:
-                xf.write(et.Comment(comment), pretty_print=True)
-            xf.write(et.Comment(f"Created {datetime.today()}"), pretty_print=True)
-
-            if coordinate_reference_system is not None:
-                xf.write(create_crs_attribute(coordinate_reference_system), pretty_print=True)
-
-            for hid, household in population:
-                for pid, person in household:
-                    if household_key is not None:
-                        person.attributes[
-                            household_key
-                        ] = hid  # force add hid as an attribute
-                    e = create_person_element(pid, person, keep_non_selected)
-                    xf.write(e, pretty_print=True)
+    with Writer(
+        path=path,
+        household_key=household_key,
+        comment=comment,
+        keep_non_selected=keep_non_selected,
+        coordinate_reference_system=coordinate_reference_system,
+    ) as writer:
+        for _, household in population:
+            writer.add_hh(household)
 
 
 def create_person_element(pid, person, keep_non_selected: bool = False):
@@ -113,8 +176,9 @@ def create_person_element(pid, person, keep_non_selected: bool = False):
     for k, v in person.attributes.items():
         if k == "vehicles":  # todo make something more robust for future 'special' classes
             attribute = et.SubElement(
-                attributes, 'attribute', {'class': 'org.matsim.vehicles.PersonVehicles', 'name': str(k)}
-                )
+                attributes, 'attribute', {
+                    'class': 'org.matsim.vehicles.PersonVehicles', 'name': str(k)}
+            )
             attribute.text = str(v)
         else:
             add_attribute(attributes, k, v)
@@ -141,7 +205,7 @@ def write_plan(
 ):
     plan_attributes = {}
     if selected is not None:
-        plan_attributes['selected'] = {True:'yes', False:'no'}[selected]
+        plan_attributes['selected'] = {True: 'yes', False: 'no'}[selected]
     if plan.score is not None:
         plan_attributes['score'] = str(plan.score)
 
@@ -174,7 +238,8 @@ def write_plan(
                 for k, v in component.attributes.items():
                     if k == 'enterVehicleTime':  # todo make something more robust for future 'special' classes
                         attribute = et.SubElement(
-                        attributes, 'attribute', {'class': 'java.lang.Double', 'name': str(k)}
+                            attributes, 'attribute', {
+                                'class': 'java.lang.Double', 'name': str(k)}
                         )
                         attribute.text = str(v)
                     else:
@@ -186,13 +251,17 @@ def write_plan(
 
 def add_attribute(attributes, k, v):
     if type(v) == bool:
-        attribute = et.SubElement(attributes, 'attribute', {'class': 'java.lang.Boolean', 'name': str(k)})
+        attribute = et.SubElement(attributes, 'attribute', {
+                                  'class': 'java.lang.Boolean', 'name': str(k)})
     elif type(v) == int:
-        attribute = et.SubElement(attributes, 'attribute', {'class': 'java.lang.Integer', 'name': str(k)})
+        attribute = et.SubElement(attributes, 'attribute', {
+                                  'class': 'java.lang.Integer', 'name': str(k)})
     elif type(v) == float:
-        attribute = et.SubElement(attributes, 'attribute', {'class': 'java.lang.Double', 'name': str(k)})
+        attribute = et.SubElement(attributes, 'attribute', {
+                                  'class': 'java.lang.Double', 'name': str(k)})
     else:
-        attribute = et.SubElement(attributes, 'attribute', {'class': 'java.lang.String', 'name': str(k)})
+        attribute = et.SubElement(attributes, 'attribute', {
+                                  'class': 'java.lang.String', 'name': str(k)})
     attribute.text = str(v)
 
 
@@ -201,8 +270,8 @@ def object_attributes_dtd():
         os.path.join(
             os.path.dirname(__file__),
             "..", "fixtures", "dtd", "objectattributes_v1.dtd"
-            )
         )
+    )
     return et.DTD(dtd_path)
 
 
@@ -211,8 +280,8 @@ def population_v6_dtd():
         os.path.join(
             os.path.dirname(__file__),
             "..", "fixtures", "dtd", "population_v6.dtd"
-            )
         )
+    )
     return et.DTD(dtd_path)
 
 
@@ -252,7 +321,8 @@ def write_vehicles(output_dir,
                              "Ensure you generate a chargers xml file: https://www.matsim.org/files/dtd/chargers_v1.dtd "
                              "if you're running a simulation using org.matsim.contrib.ev")
             else:
-                logging.info('Provided population does not have electric vehicles')
+                logging.info(
+                    'Provided population does not have electric vehicles')
         else:
             logging.warning('The vehicle types in provided population do not have unique indices. Current Vehicle '
                             f'Type IDs: {[vt.id for vt in population.vehicle_types()]}')

--- a/tests/test_08_write.py
+++ b/tests/test_08_write.py
@@ -18,24 +18,95 @@ from pam.utils import minutes_to_datetime as mtdt
 from pam.variables import END_OF_DAY
 
 
-def test_write_plans_xml(tmp_path, population_heh):
-    location = str(tmp_path / "test.xml")
-    write_matsim_population_v6(population=population_heh, path=location, comment="test")
-    expected_file = "{}/test.xml".format(tmp_path)
-    assert os.path.exists(expected_file)
-    xml_obj = lxml.etree.parse(expected_file)
+def test_writer_enters(tmp_path):
+    path = str(tmp_path / "test.xml")
+    with Writer(path) as writer:
+        assert os.path.exists(os.path.dirname(path))
+        assert os.path.exists(path)
+
+
+def test_writer_closes(tmp_path):
+    path = str(tmp_path / "test.xml")
+    with Writer(path) as writer:
+        assert os.path.exists(path)
+    xml_obj = lxml.etree.parse(path)
+    dtd = write.population_v6_dtd()
+    assert dtd.validate(xml_obj), dtd.error_log.filter_from_errors()
+    with open(path) as f:
+        txt = f.read()
+        assert "<?xml version='1.0' encoding='utf-8'?>" in txt
+        assert '<!DOCTYPE population SYSTEM "http://matsim.org/files/dtd/population_v6.dtd' in txt
+
+
+def test_writer_add_person(tmp_path):
+    path = str(tmp_path / "test.xml")
+    with Writer(path) as writer:
+        p = Person('a', attributes={'1': '1'})
+        p.add(Activity(
+            act="home",
+            loc=Point((0, 0)),
+            start_time=datetime(1900, 1, 1, 0, 0, 0),
+            end_time=datetime(1900, 1, 1, 8, 0, 0)
+        ))
+        p.add(Leg(
+            mode='car',
+            start_loc=Point((0, 0)),
+            end_loc=Point((0, 1000)),
+            start_time=datetime(1900, 1, 1, 8, 0, 0),
+            end_time=datetime(1900, 1, 1, 9, 0, 0)
+        ))
+        p.add(Activity(
+            act="work",
+            loc=Point((0, 1000)),
+            start_time=datetime(1900, 1, 1, 9, 0, 0),
+            end_time=datetime(1900, 1, 1, 18, 0, 0)
+        ))
+        writer.add_person(p)
+    xml_obj = lxml.etree.parse(path)
+    dtd = write.population_v6_dtd()
+    assert dtd.validate(xml_obj), dtd.error_log.filter_from_errors()
+    with open(path) as f:
+        txt = f.read()
+        assert '<population><person id="a">' in txt
+        assert '<attribute class="java.lang.String" name="1">1</attribute>' in txt
+        assert '<activity type="home" start_time="00:00:00" end_time="08:00:00" x="0.0" y="0.0"/>' in txt
+
+
+def test_writer_add_hh(tmp_path):
+    path = str(tmp_path / "test.xml")
+    with Writer(path) as writer:
+        p = Person('a', attributes={'1': '1'})
+        p.add(Activity(
+            act="home",
+            loc=Point((0, 0)),
+            start_time=datetime(1900, 1, 1, 0, 0, 0),
+            end_time=datetime(1900, 1, 1, 8, 0, 0)
+        ))
+        p.add(Leg(
+            mode='car',
+            start_loc=Point((0, 0)),
+            end_loc=Point((0, 1000)),
+            start_time=datetime(1900, 1, 1, 8, 0, 0),
+            end_time=datetime(1900, 1, 1, 9, 0, 0)
+        ))
+        p.add(Activity(
+            act="work",
+            loc=Point((0, 1000)),
+            start_time=datetime(1900, 1, 1, 9, 0, 0),
+            end_time=datetime(1900, 1, 1, 18, 0, 0)
+        ))
+        hh = Household('A')
+        hh.add(p)
+        writer.add_hh(hh)
+    xml_obj = lxml.etree.parse(path)
     dtd = write.population_v6_dtd()
     assert dtd.validate(xml_obj), dtd.error_log.filter_from_errors()
 
 
-def test_context_write_xml(tmp_path, population_heh):
+def test_write_plans_xml(tmp_path, population_heh):
     location = str(tmp_path / "test.xml")
-    with Writer(
-        location,
-        comment="test"
-        ) as w:
-        for _, hh in population_heh:
-            w.add_hh(hh)
+    write_matsim_population_v6(
+        population=population_heh, path=location, comment="test")
     expected_file = "{}/test.xml".format(tmp_path)
     assert os.path.exists(expected_file)
     xml_obj = lxml.etree.parse(expected_file)
@@ -45,30 +116,16 @@ def test_context_write_xml(tmp_path, population_heh):
 
 def test_write_plans_xml_gzip(tmp_path, population_heh):
     location = str(tmp_path / "test.xml.gz")
-    write_matsim_population_v6(population=population_heh, path=location, comment="test")
+    write_matsim_population_v6(
+        population=population_heh, path=location, comment="test")
     expected_file = "{}/test.xml.gz".format(tmp_path)
     assert os.path.exists(expected_file)
-    # TODO make assertions about the content of the created file
-
-
-def test_context_write_gzip(tmp_path, population_heh):
-    location = str(tmp_path / "test.xml.gz")
-    with Writer(
-        location,
-        comment="test"
-    ) as w:
-        for _, hh in population_heh:
-            w.add_hh(hh)
-    expected_file = "{}/test.xml.gz".format(tmp_path)
-    assert os.path.exists(expected_file)
-    xml_obj = lxml.etree.parse(expected_file)
-    dtd = write.population_v6_dtd()
-    assert dtd.validate(xml_obj), dtd.error_log.filter_from_errors()
 
 
 def test_write_matsim_xml(tmp_path, population_heh):
     location = str(tmp_path / "test.xml")
-    write_matsim(population=population_heh, plans_path=location, comment="test")
+    write_matsim(population=population_heh,
+                 plans_path=location, comment="test")
     expected_file = "{}/test.xml".format(tmp_path)
     assert os.path.exists(expected_file)
     xml_obj = lxml.etree.parse(expected_file)
@@ -78,7 +135,8 @@ def test_write_matsim_xml(tmp_path, population_heh):
 
 def test_write_matsim_xml_pathlib_path(tmp_path, population_heh):
     location = tmp_path / "test.xml"
-    write_matsim(population=population_heh, plans_path=location, comment="test")
+    write_matsim(population=population_heh,
+                 plans_path=location, comment="test")
     expected_file = "{}/test.xml".format(tmp_path)
     assert os.path.exists(expected_file)
     xml_obj = lxml.etree.parse(expected_file)
@@ -88,7 +146,8 @@ def test_write_matsim_xml_pathlib_path(tmp_path, population_heh):
 
 def test_write_matsim_xml_gzip(tmp_path, population_heh):
     location = str(tmp_path / "test.xml.gz")
-    write_matsim(population=population_heh, plans_path=location, comment="test")
+    write_matsim(population=population_heh,
+                 plans_path=location, comment="test")
     expected_file = "{}/test.xml.gz".format(tmp_path)
     assert os.path.exists(expected_file)
     # TODO make assertions about the content of the created file
@@ -97,39 +156,39 @@ def test_write_matsim_xml_gzip(tmp_path, population_heh):
 def test_write_plans_xml_assert_contents(tmp_path):
     population = Population()
     hh = Household('a')
-    p = Person('a', attributes={'1':'1'})
+    p = Person('a', attributes={'1': '1'})
     p.add(Activity(
         act="home",
-        loc=Point((0,0)),
-        start_time=datetime(1900,1,1,0,0,0),
-        end_time=datetime(1900,1,1,8,0,0)
-        ))
+        loc=Point((0, 0)),
+        start_time=datetime(1900, 1, 1, 0, 0, 0),
+        end_time=datetime(1900, 1, 1, 8, 0, 0)
+    ))
     p.add(Leg(
         mode='car',
-        start_loc=Point((0,0)),
-        end_loc=Point((0,1000)),
-        start_time=datetime(1900,1,1,8,0,0),
-        end_time=datetime(1900,1,1,9,0,0)
+        start_loc=Point((0, 0)),
+        end_loc=Point((0, 1000)),
+        start_time=datetime(1900, 1, 1, 8, 0, 0),
+        end_time=datetime(1900, 1, 1, 9, 0, 0)
     ))
     p.add(Activity(
         act="work",
-        loc=Point((0,1000)),
-        start_time=datetime(1900,1,1,9,0,0),
-        end_time=datetime(1900,1,1,18,0,0)
-        ))
+        loc=Point((0, 1000)),
+        start_time=datetime(1900, 1, 1, 9, 0, 0),
+        end_time=datetime(1900, 1, 1, 18, 0, 0)
+    ))
     p.add(Leg(
         mode='car',
-        start_loc=Point((0,1000)),
-        end_loc=Point((0,0)),
-        start_time=datetime(1900,1,1,18,0,0),
-        end_time=datetime(1900,1,1,19,0,0)
+        start_loc=Point((0, 1000)),
+        end_loc=Point((0, 0)),
+        start_time=datetime(1900, 1, 1, 18, 0, 0),
+        end_time=datetime(1900, 1, 1, 19, 0, 0)
     ))
     p.add(Activity(
         act="home",
-        loc=Point((0,0)),
-        start_time=datetime(1900,1,1,19,0,0),
+        loc=Point((0, 0)),
+        start_time=datetime(1900, 1, 1, 19, 0, 0),
         end_time=END_OF_DAY
-        ))
+    ))
     hh.add(p)
     population.add(hh)
     plans_location = str(tmp_path / "test_plans.xml")
@@ -138,19 +197,20 @@ def test_write_plans_xml_assert_contents(tmp_path):
         plans_path=plans_location,
         comment="test",
         household_key=None
-        )
+    )
     new = read_matsim(
         plans_location,
         version=12
-        )
+    )
     assert new == population
-    assert new['a']['a'].attributes == {'1':'1'}
+    assert new['a']['a'].attributes == {'1': '1'}
     assert new['a']['a'].plan.day[1].distance == 1000
 
 
 def test_read_write_consistent(tmp_path):
     test_tripsv12_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "test_data/test_matsim_plansv12.xml")
+        os.path.join(os.path.dirname(__file__),
+                     "test_data/test_matsim_plansv12.xml")
     )
     population = read_matsim(test_tripsv12_path, version=12)
     location = str(tmp_path / "test.xml.gz")
@@ -159,7 +219,7 @@ def test_read_write_consistent(tmp_path):
         plans_path=location,
         comment="test",
         household_key=None,
-        )
+    )
     expected_file = "{}/test.xml.gz".format(tmp_path)
     population2 = read_matsim(expected_file, version=12)
     assert population == population2
@@ -167,14 +227,15 @@ def test_read_write_consistent(tmp_path):
 
 def test_read_write_non_selected_plans_inconsistently(tmp_path):
     test_tripsv12_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "test_data/test_matsim_plansv12.xml")
+        os.path.join(os.path.dirname(__file__),
+                     "test_data/test_matsim_plansv12.xml")
     )
     population = read_matsim(
         test_tripsv12_path,
         version=12,
         crop=False,
         keep_non_selected=True
-        )
+    )
     location = str(tmp_path / "test.xml.gz")
     write_matsim(
         population=population,
@@ -182,22 +243,24 @@ def test_read_write_non_selected_plans_inconsistently(tmp_path):
         comment="test",
         household_key=None,
         keep_non_selected=False,
-        )
+    )
     expected_file = "{}/test.xml.gz".format(tmp_path)
-    population2 = read_matsim(expected_file, version=12, crop=False, keep_non_selected=False)
+    population2 = read_matsim(
+        expected_file, version=12, crop=False, keep_non_selected=False)
     assert not population == population2
 
 
 def test_read_write_non_selected_plans_consistently(tmp_path):
     test_tripsv12_path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "test_data/test_matsim_plansv12.xml")
+        os.path.join(os.path.dirname(__file__),
+                     "test_data/test_matsim_plansv12.xml")
     )
     population = read_matsim(
         test_tripsv12_path,
         version=12,
         crop=False,
         keep_non_selected=True
-        )
+    )
     location = str(tmp_path / "test.xml.gz")
     write_matsim(
         population=population,
@@ -205,145 +268,164 @@ def test_read_write_non_selected_plans_consistently(tmp_path):
         comment="test",
         household_key=None,
         keep_non_selected=True,
-        )
+    )
     expected_file = "{}/test.xml.gz".format(tmp_path)
-    population2 = read_matsim(expected_file, version=12, crop=False, keep_non_selected=True)
+    population2 = read_matsim(
+        expected_file, version=12, crop=False, keep_non_selected=True)
     assert population == population2
 
 
 def test_writes_od_matrix_to_expected_file(tmpdir):
     population = Population()
 
-    household = Household(hid = '0')
-    person = Person(pid='0',  home_area='Barnet', attributes = {'occ':'white'})
-    person.add(Activity(1, 'home','Barnet', start_time=mtdt(0)))
-    person.add(Leg(1, mode='car', start_area='Barnet', end_area='Southwark', start_time=mtdt(400), purp='work'))
-    person.add(Activity(2,'work', 'Southwark', start_time=mtdt(420)))
-    person.add(Leg(2,'car', start_area='Southwark', end_area='Barnet', start_time=mtdt(1020), purp='work'))
-    person.add(Activity(3,'home','Barnet',start_time=mtdt(1040), end_time=mtdt(1439)))
+    household = Household(hid='0')
+    person = Person(pid='0',  home_area='Barnet', attributes={'occ': 'white'})
+    person.add(Activity(1, 'home', 'Barnet', start_time=mtdt(0)))
+    person.add(Leg(1, mode='car', start_area='Barnet',
+               end_area='Southwark', start_time=mtdt(400), purp='work'))
+    person.add(Activity(2, 'work', 'Southwark', start_time=mtdt(420)))
+    person.add(Leg(2, 'car', start_area='Southwark',
+               end_area='Barnet', start_time=mtdt(1020), purp='work'))
+    person.add(Activity(3, 'home', 'Barnet',
+               start_time=mtdt(1040), end_time=mtdt(1439)))
     household.add(person)
     population.add(household)
 
-    household = Household(hid = '1')
-    person = Person(pid='1', home_area='Ealing', attributes = {'occ':'white'})
-    person.add(Activity(1, 'home','Ealing',start_time=mtdt(0)))
-    person.add(Leg(1, mode='cycle', start_area='Ealing', end_area='Westminster,City of London', start_time=mtdt(500), purp='education'))
-    person.add(Activity(2,'education', 'Westminster,City of London',start_time=mtdt(550)))
-    person.add(Leg(2,'cycle', start_area='Westminster,City of London', end_area='Ealing', start_time=mtdt(700), purp='education'))
-    person.add(Activity(3,'home','Ealing',start_time=mtdt(750), end_time=mtdt(1439)))
+    household = Household(hid='1')
+    person = Person(pid='1', home_area='Ealing', attributes={'occ': 'white'})
+    person.add(Activity(1, 'home', 'Ealing', start_time=mtdt(0)))
+    person.add(Leg(1, mode='cycle', start_area='Ealing',
+               end_area='Westminster,City of London', start_time=mtdt(500), purp='education'))
+    person.add(Activity(2, 'education',
+               'Westminster,City of London', start_time=mtdt(550)))
+    person.add(Leg(2, 'cycle', start_area='Westminster,City of London',
+               end_area='Ealing', start_time=mtdt(700), purp='education'))
+    person.add(Activity(3, 'home', 'Ealing',
+               start_time=mtdt(750), end_time=mtdt(1439)))
     household.add(person)
     population.add(household)
 
-    household = Household(hid = '2')
-    person = Person(pid='2', home_area='Ealing',attributes = {'occ':'white'})
-    person.add(Activity(1, 'home','Ealing', start_time=mtdt(0)))
-    person.add(Leg(1, mode='car', start_area='Ealing', end_area='Westminster,City of London', start_time=mtdt(450), purp='work'))
-    person.add(Activity(2,'work', 'Westminster,City of London',start_time=mtdt(480)))
-    person.add(Leg(2,'car', start_area='Westminster,City of London', end_area='Ealing', start_time=mtdt(1050), purp='work'))
-    person.add(Activity(3,'home','Ealing',start_time=mtdt(1080), end_time=mtdt(1439)))
+    household = Household(hid='2')
+    person = Person(pid='2', home_area='Ealing', attributes={'occ': 'white'})
+    person.add(Activity(1, 'home', 'Ealing', start_time=mtdt(0)))
+    person.add(Leg(1, mode='car', start_area='Ealing',
+               end_area='Westminster,City of London', start_time=mtdt(450), purp='work'))
+    person.add(
+        Activity(2, 'work', 'Westminster,City of London', start_time=mtdt(480)))
+    person.add(Leg(2, 'car', start_area='Westminster,City of London',
+               end_area='Ealing', start_time=mtdt(1050), purp='work'))
+    person.add(Activity(3, 'home', 'Ealing',
+               start_time=mtdt(1080), end_time=mtdt(1439)))
     household.add(person)
     population.add(household)
 
-    household = Household(hid = '3')
-    person = Person(pid='3', home_area='Barnet',attributes = {'occ':'blue'})
-    person.add(Activity(1, 'home','Barnet', start_time = mtdt(0)))
-    person.add(Leg(1, mode='walk', start_area='Barnet', end_area='Barnet', start_time=mtdt(450), purp='shop'))
-    person.add(Activity(2,'shop', 'Barnet',start_time=mtdt(470)))
-    person.add(Leg(2,'walk', start_area='Barnet', end_area='Barnet', start_time=mtdt(600), purp='shop'))
-    person.add(Activity(3,'home','Barnet',start_time=mtdt(620), end_time=mtdt(1439)))
+    household = Household(hid='3')
+    person = Person(pid='3', home_area='Barnet', attributes={'occ': 'blue'})
+    person.add(Activity(1, 'home', 'Barnet', start_time=mtdt(0)))
+    person.add(Leg(1, mode='walk', start_area='Barnet',
+               end_area='Barnet', start_time=mtdt(450), purp='shop'))
+    person.add(Activity(2, 'shop', 'Barnet', start_time=mtdt(470)))
+    person.add(Leg(2, 'walk', start_area='Barnet',
+               end_area='Barnet', start_time=mtdt(600), purp='shop'))
+    person.add(Activity(3, 'home', 'Barnet',
+               start_time=mtdt(620), end_time=mtdt(1439)))
     household.add(person)
     population.add(household)
 
-    household = Household(hid = '4')
-    person = Person(pid='4', home_area='Ealing',attributes = {'occ':'blue'})
-    person.add(Activity(1, 'home','Ealing', start_time = mtdt(0)))
-    person.add(Leg(1, mode='cycle', start_area='Ealing', end_area='Ealing', start_time=mtdt(400), purp='work'))
-    person.add(Activity(2,'work', 'Ealing',start_time=mtdt(420)))
-    person.add(Leg(2,'cycle', start_area='Ealing', end_area='Ealing', start_time=mtdt(1030), purp='work'))
-    person.add(Activity(3,'home','Ealing',start_time=mtdt(1050), end_time=mtdt(1439)))
+    household = Household(hid='4')
+    person = Person(pid='4', home_area='Ealing', attributes={'occ': 'blue'})
+    person.add(Activity(1, 'home', 'Ealing', start_time=mtdt(0)))
+    person.add(Leg(1, mode='cycle', start_area='Ealing',
+               end_area='Ealing', start_time=mtdt(400), purp='work'))
+    person.add(Activity(2, 'work', 'Ealing', start_time=mtdt(420)))
+    person.add(Leg(2, 'cycle', start_area='Ealing',
+               end_area='Ealing', start_time=mtdt(1030), purp='work'))
+    person.add(Activity(3, 'home', 'Ealing',
+               start_time=mtdt(1050), end_time=mtdt(1439)))
     household.add(person)
     population.add(household)
 
     attribute_list = ['white', 'blue', 'total']
-    mode_list = ['car', 'cycle','walk', 'total']
+    mode_list = ['car', 'cycle', 'walk', 'total']
     time_slice = [(400, 500), (1020, 1060)]
 
-    write_od_matrices(population, tmpdir, leg_filter = 'Mode')
+    write_od_matrices(population, tmpdir, leg_filter='Mode')
     for m in mode_list:
         od_matrix_file = os.path.join(tmpdir, m+"_od.csv")
         od_matrix_csv_string = open(od_matrix_file).read()
         if m == 'car':
             expected_od_matrix = \
-                    'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
-                    'Barnet,0,0,1,0\n' \
-                    'Ealing,0,0,0,1\n' \
-                    'Southwark,1,0,0,0\n' \
-                    '"Westminster,City of London",0,1,0,0\n'
+                'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
+                'Barnet,0,0,1,0\n' \
+                'Ealing,0,0,0,1\n' \
+                'Southwark,1,0,0,0\n' \
+                '"Westminster,City of London",0,1,0,0\n'
             assert od_matrix_csv_string == expected_od_matrix
         if m == 'cycle':
             expected_od_matrix = \
-                    'Origin,Ealing,"Westminster,City of London"\n' \
-                    'Ealing,2,1\n' \
-                    '"Westminster,City of London",1,0\n'
+                'Origin,Ealing,"Westminster,City of London"\n' \
+                'Ealing,2,1\n' \
+                '"Westminster,City of London",1,0\n'
             assert od_matrix_csv_string == expected_od_matrix
         if m == 'walk':
             expected_od_matrix = \
-                    'Origin,Barnet\n' \
-                    'Barnet,2\n'
+                'Origin,Barnet\n' \
+                'Barnet,2\n'
             assert od_matrix_csv_string == expected_od_matrix
         if m == 'total':
             expected_od_matrix = \
-                    'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
-                    'Barnet,2,0,1,0\n' \
-                    'Ealing,0,2,0,2\n' \
-                    'Southwark,1,0,0,0\n' \
-                    '"Westminster,City of London",0,2,0,0\n'
+                'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
+                'Barnet,2,0,1,0\n' \
+                'Ealing,0,2,0,2\n' \
+                'Southwark,1,0,0,0\n' \
+                '"Westminster,City of London",0,2,0,0\n'
             assert od_matrix_csv_string == expected_od_matrix
 
-    write_od_matrices(population, tmpdir, person_filter = 'occ')
+    write_od_matrices(population, tmpdir, person_filter='occ')
     for a in attribute_list:
         od_matrix_file = os.path.join(tmpdir, a+"_od.csv")
         od_matrix_csv_string = open(od_matrix_file).read()
         if a == 'white':
             expected_od_matrix = \
-                    'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
-                    'Barnet,0,0,1,0\n' \
-                    'Ealing,0,0,0,2\n' \
-                    'Southwark,1,0,0,0\n' \
-                    '"Westminster,City of London",0,2,0,0\n'
+                'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
+                'Barnet,0,0,1,0\n' \
+                'Ealing,0,0,0,2\n' \
+                'Southwark,1,0,0,0\n' \
+                '"Westminster,City of London",0,2,0,0\n'
             assert od_matrix_csv_string == expected_od_matrix
         if a == 'blue':
             expected_od_matrix = \
-                    'Origin,Barnet,Ealing\n' \
-                    'Barnet,2,0\n' \
-                    'Ealing,0,2\n'
+                'Origin,Barnet,Ealing\n' \
+                'Barnet,2,0\n' \
+                'Ealing,0,2\n'
             assert od_matrix_csv_string == expected_od_matrix
         if a == 'total':
             expected_od_matrix = \
-                    'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
-                    'Barnet,2,0,1,0\n' \
-                    'Ealing,0,2,0,2\n' \
-                    'Southwark,1,0,0,0\n' \
-                    '"Westminster,City of London",0,2,0,0\n'
+                'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
+                'Barnet,2,0,1,0\n' \
+                'Ealing,0,2,0,2\n' \
+                'Southwark,1,0,0,0\n' \
+                '"Westminster,City of London",0,2,0,0\n'
             assert od_matrix_csv_string == expected_od_matrix
 
-    write_od_matrices(population, tmpdir, time_minutes_filter = [(400,500),(1020,1060)])
+    write_od_matrices(population, tmpdir, time_minutes_filter=[
+                      (400, 500), (1020, 1060)])
     for start_time, end_time in time_slice:
-        file_name = str(start_time) +'_to_'+ str(end_time)
-        od_matrix_file = os.path.join(tmpdir,'time_'+file_name+'_od.csv' )
+        file_name = str(start_time) + '_to_' + str(end_time)
+        od_matrix_file = os.path.join(tmpdir, 'time_'+file_name+'_od.csv')
         od_matrix_csv_string = open(od_matrix_file).read()
         if (start_time, end_time) == (400, 500):
             expected_od_matrix = \
-                    'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
-                    'Barnet,1,0,1,0\n' \
-                    'Ealing,0,1,0,1\n'
+                'Origin,Barnet,Ealing,Southwark,"Westminster,City of London"\n' \
+                'Barnet,1,0,1,0\n' \
+                'Ealing,0,1,0,1\n'
             assert od_matrix_csv_string == expected_od_matrix
         if (start_time, end_time) == (1020, 1060):
             expected_od_matrix = \
-                    'Origin,Barnet,Ealing\n' \
-                    'Ealing,0,1\n' \
-                    'Southwark,1,0\n' \
-                    '"Westminster,City of London",0,1\n'
+                'Origin,Barnet,Ealing\n' \
+                'Ealing,0,1\n' \
+                'Southwark,1,0\n' \
+                '"Westminster,City of London",0,1\n'
             assert od_matrix_csv_string == expected_od_matrix
 
 
@@ -365,22 +447,23 @@ def test_write_to_csv_no_locs(population_heh, tmpdir):
     assert len(hh_df) == 1
 
     people_df = pd.read_csv(os.path.join(tmpdir, "people.csv"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
+    assert list(people_df.columns) == [
+        'pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
     assert len(people_df) == 1
 
     legs_df = pd.read_csv(os.path.join(tmpdir, "legs.csv"), index_col=0)
     assert list(legs_df.columns) == [
         'pid', 'hid', 'freq', 'ozone', 'dzone', 'purp', 'origin activity',
-       'destination activity', 'mode', 'seq', 'tst', 'tet',
-       'duration'
-       ]
+        'destination activity', 'mode', 'seq', 'tst', 'tet',
+        'duration'
+    ]
     assert len(legs_df) == 2
 
     acts_df = pd.read_csv(os.path.join(tmpdir, "activities.csv"), index_col=0)
     assert list(acts_df.columns) == [
         'pid', 'hid', 'freq', 'activity', 'seq', 'start time', 'end time',
-       'duration', 'zone'
-       ]
+        'duration', 'zone'
+    ]
     assert len(acts_df) == 3
 
     # check geojson
@@ -400,22 +483,23 @@ def test_write_to_csv_locs(population_heh, tmpdir):
     assert len(hh_df) == 1
 
     people_df = pd.read_csv(os.path.join(tmpdir, "people.csv"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
+    assert list(people_df.columns) == [
+        'pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
     assert len(people_df) == 1
 
     legs_df = pd.read_csv(os.path.join(tmpdir, "legs.csv"), index_col=0)
     assert list(legs_df.columns) == [
         'pid', 'hid', 'freq', 'ozone', 'dzone', 'purp', 'origin activity',
-       'destination activity', 'mode', 'seq', 'tst', 'tet',
-       'duration'
-       ]
+        'destination activity', 'mode', 'seq', 'tst', 'tet',
+        'duration'
+    ]
     assert len(legs_df) == 2
 
     acts_df = pd.read_csv(os.path.join(tmpdir, "activities.csv"), index_col=0)
     assert list(acts_df.columns) == [
         'pid', 'hid', 'freq', 'activity', 'seq', 'start time', 'end time',
-       'duration', 'zone'
-       ]
+        'duration', 'zone'
+    ]
     assert len(acts_df) == 3
 
     # check geojsons
@@ -427,22 +511,24 @@ def test_write_to_csv_locs(population_heh, tmpdir):
     assert len(hh_df) == 1
 
     people_df = gp.read_file(os.path.join(tmpdir, "people.geojson"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
+    assert list(people_df.columns) == [
+        'pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
     assert len(people_df) == 1
 
     legs_df = gp.read_file(os.path.join(tmpdir, "legs.geojson"), index_col=0)
     assert list(legs_df.columns) == [
         'pid', 'hid', 'freq', 'ozone', 'dzone', 'purp', 'origin activity',
-       'destination activity', 'mode', 'seq', 'tst', 'tet',
-       'duration', 'geometry'
-       ]
+        'destination activity', 'mode', 'seq', 'tst', 'tet',
+        'duration', 'geometry'
+    ]
     assert len(legs_df) == 2
 
-    acts_df = gp.read_file(os.path.join(tmpdir, "activities.geojson"), index_col=0)
+    acts_df = gp.read_file(os.path.join(
+        tmpdir, "activities.geojson"), index_col=0)
     assert list(acts_df.columns) == [
         'pid', 'hid', 'freq', 'activity', 'seq', 'start time', 'end time',
-       'duration', 'zone', 'geometry'
-       ]
+        'duration', 'zone', 'geometry'
+    ]
     assert len(acts_df) == 3
 
 
@@ -469,22 +555,23 @@ def test_write_to_csv_some_locs(population_heh, tmpdir):
     assert len(hh_df) == 2
 
     people_df = pd.read_csv(os.path.join(tmpdir, "people.csv"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
+    assert list(people_df.columns) == [
+        'pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
     assert len(people_df) == 2
 
     legs_df = pd.read_csv(os.path.join(tmpdir, "legs.csv"), index_col=0)
     assert list(legs_df.columns) == [
         'pid', 'hid', 'freq', 'ozone', 'dzone', 'purp', 'origin activity',
-       'destination activity', 'mode', 'seq', 'tst', 'tet',
-       'duration'
-       ]
+        'destination activity', 'mode', 'seq', 'tst', 'tet',
+        'duration'
+    ]
     assert len(legs_df) == 4
 
     acts_df = pd.read_csv(os.path.join(tmpdir, "activities.csv"), index_col=0)
     assert list(acts_df.columns) == [
         'pid', 'hid', 'freq', 'activity', 'seq', 'start time', 'end time',
-       'duration', 'zone'
-       ]
+        'duration', 'zone'
+    ]
     assert len(acts_df) == 6
 
     # check geojsons
@@ -496,22 +583,24 @@ def test_write_to_csv_some_locs(population_heh, tmpdir):
     assert len(hh_df) == 2
 
     people_df = gp.read_file(os.path.join(tmpdir, "people.geojson"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
+    assert list(people_df.columns) == [
+        'pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
     assert len(people_df) == 2
 
     legs_df = gp.read_file(os.path.join(tmpdir, "legs.geojson"), index_col=0)
     assert list(legs_df.columns) == [
         'pid', 'hid', 'freq', 'ozone', 'dzone', 'purp', 'origin activity',
-       'destination activity', 'mode', 'seq', 'tst', 'tet',
-       'duration', 'geometry'
-       ]
+        'destination activity', 'mode', 'seq', 'tst', 'tet',
+        'duration', 'geometry'
+    ]
     assert len(legs_df) == 4
 
-    acts_df = gp.read_file(os.path.join(tmpdir, "activities.geojson"), index_col=0)
+    acts_df = gp.read_file(os.path.join(
+        tmpdir, "activities.geojson"), index_col=0)
     assert list(acts_df.columns) == [
         'pid', 'hid', 'freq', 'activity', 'seq', 'start time', 'end time',
-       'duration', 'zone', 'geometry'
-       ]
+        'duration', 'zone', 'geometry'
+    ]
     assert len(acts_df) == 6
 
 
@@ -527,22 +616,23 @@ def test_write_to_csv_convert_locs(population_heh, tmpdir):
     assert len(hh_df) == 1
 
     people_df = pd.read_csv(os.path.join(tmpdir, "people.csv"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
+    assert list(people_df.columns) == [
+        'pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc']
     assert len(people_df) == 1
 
     legs_df = pd.read_csv(os.path.join(tmpdir, "legs.csv"), index_col=0)
     assert list(legs_df.columns) == [
         'pid', 'hid', 'freq', 'ozone', 'dzone', 'purp', 'origin activity',
-       'destination activity', 'mode', 'seq', 'tst', 'tet',
-       'duration'
-       ]
+        'destination activity', 'mode', 'seq', 'tst', 'tet',
+        'duration'
+    ]
     assert len(legs_df) == 2
 
     acts_df = pd.read_csv(os.path.join(tmpdir, "activities.csv"), index_col=0)
     assert list(acts_df.columns) == [
         'pid', 'hid', 'freq', 'activity', 'seq', 'start time', 'end time',
-       'duration', 'zone'
-       ]
+        'duration', 'zone'
+    ]
     assert len(acts_df) == 3
 
     # check geojsons
@@ -554,22 +644,24 @@ def test_write_to_csv_convert_locs(population_heh, tmpdir):
     assert len(hh_df) == 1
 
     people_df = gp.read_file(os.path.join(tmpdir, "people.geojson"))
-    assert list(people_df.columns) == ['pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
+    assert list(people_df.columns) == [
+        'pid', 'hid', 'freq', 'hzone', 'hh_size', 'inc', 'geometry']
     assert len(people_df) == 1
 
     legs_df = gp.read_file(os.path.join(tmpdir, "legs.geojson"), index_col=0)
     assert list(legs_df.columns) == [
         'pid', 'hid', 'freq', 'ozone', 'dzone', 'purp', 'origin activity',
-       'destination activity', 'mode', 'seq', 'tst', 'tet',
-       'duration', 'geometry'
-       ]
+        'destination activity', 'mode', 'seq', 'tst', 'tet',
+        'duration', 'geometry'
+    ]
     assert len(legs_df) == 2
 
-    acts_df = gp.read_file(os.path.join(tmpdir, "activities.geojson"), index_col=0)
+    acts_df = gp.read_file(os.path.join(
+        tmpdir, "activities.geojson"), index_col=0)
     assert list(acts_df.columns) == [
         'pid', 'hid', 'freq', 'activity', 'seq', 'start time', 'end time',
-       'duration', 'zone', 'geometry'
-       ]
+        'duration', 'zone', 'geometry'
+    ]
     assert len(acts_df) == 3
 
 

--- a/tests/test_99_cli.py
+++ b/tests/test_99_cli.py
@@ -35,15 +35,17 @@ def test_test_cli_summary(path_test_plan):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["report", "summary", path_test_plan, "-k", "subpopulation", "-s", "0.1", "-d", "--no_crop", "-h", "hid", "--simplify_pt_trips"]
-        )
+        ["report", "summary", path_test_plan, "-k", "subpopulation", "-s",
+            "0.1", "-d", "--no_crop", "-h", "hid", "--simplify_pt_trips"]
+    )
     if result.exit_code != 0:
         print(result.output)
     assert result.exit_code == 0
     result = runner.invoke(
         cli,
-        ["report", "summary", path_test_plan, "-k", "subpopulation", "-s", "0.1", "-d", "--text", "--no_crop", "-h", "hid"]
-        )
+        ["report", "summary", path_test_plan, "-k", "subpopulation",
+            "-s", "0.1", "-d", "--text", "--no_crop", "-h", "hid"]
+    )
     if result.exit_code != 0:
         print(result.output)
     assert result.exit_code == 0
@@ -77,7 +79,7 @@ def test_cli_cropping(path_test_plan, path_boundary, tmp_path):
     result = runner.invoke(
         cli,
         ["crop", path_test_plan, path_boundary, path_output_dir]
-        )
+    )
     if result.exit_code != 0:
         print(result.output)
     assert result.exit_code == 0
@@ -90,12 +92,12 @@ def test_combine(path_test_plans_A, path_test_plans_B, tmp_path):
     result = runner.invoke(
         cli,
         ["combine", path_test_plans_A, path_test_plans_B, "-o", path_output_dir]
-        )
+    )
     assert result.exit_code == 0
     assert os.path.exists(path_output_dir)
 
 
-@pytest.mark.parametrize('sample_percentage', ['1','2'])
+@pytest.mark.parametrize('sample_percentage', ['1', '2'])
 def test_cli_sample(path_test_plan, tmp_path, sample_percentage):
     """ Double the population of 5 agents """
     path_output_dir = str(tmp_path)
@@ -103,7 +105,7 @@ def test_cli_sample(path_test_plan, tmp_path, sample_percentage):
     result = runner.invoke(
         cli,
         ["sample", path_test_plan, path_output_dir, '-s', sample_percentage]
-        )
+    )
     if result.exit_code != 0:
         print(result.output)
     assert result.exit_code == 0
@@ -120,4 +122,96 @@ def test_cli_sample(path_test_plan, tmp_path, sample_percentage):
         household_key="hid",
         version=12
     )
-    assert len(population) == (len(population_input) * float(sample_percentage))
+    assert len(population) == (
+        len(population_input) * float(sample_percentage))
+
+
+def test_cli_route_wipe(path_test_plan, tmp_path):
+    population_input = read.read_matsim(
+        path_test_plan,
+        household_key="hid",
+        version=12
+    )
+    path_output_dir = str(tmp_path)
+    path_output = os.path.join(path_output_dir, "test_out.xml")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["wipe-routes", path_test_plan, path_output]
+    )
+    if result.exit_code != 0:
+        print(result.output)
+    assert result.exit_code == 0
+    assert os.path.exists(path_output)
+
+    population = read.read_matsim(
+        path_output,
+        household_key="hid",
+        version=12
+    )
+    assert len(population) == len(population_input)
+
+
+def test_cli_wipe_all_links(path_test_plan, tmp_path):
+    population_input = read.read_matsim(
+        path_test_plan,
+        household_key="hid",
+        version=12
+    )
+    path_output_dir = str(tmp_path)
+    path_output = os.path.join(path_output_dir, "test_out.xml")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["wipe-all-links", path_test_plan, path_output]
+    )
+    if result.exit_code != 0:
+        print(result.output)
+    assert result.exit_code == 0
+    assert os.path.exists(path_output)
+
+    population = read.read_matsim(
+        path_output,
+        household_key="hid",
+        version=12,
+        leg_route=True
+    )
+    assert len(population) == len(population_input)
+    for _, _, person in population.people():
+        for leg in person.legs:
+            assert not leg.route.exists
+
+
+def test_cli_link_wipe_selected_only(path_test_plan, tmp_path):
+    population_input = read.read_matsim(
+        path_test_plan,
+        household_key="hid",
+        version=12
+    )
+    path_output_dir = str(tmp_path)
+    path_output = os.path.join(path_output_dir, "test_out.xml")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["wipe-links", path_test_plan, path_output, "1-5"]
+    )
+    if result.exit_code != 0:
+        print(result.output)
+    assert result.exit_code == 0
+    assert os.path.exists(path_output)
+
+    population = read.read_matsim(
+        path_output,
+        household_key="hid",
+        version=12,
+        leg_route=True
+    )
+    assert len(population) == len(population_input)
+    for leg in population["A"]["nick"].legs:
+        assert not leg.route.exists
+    for act in population["A"]["nick"].activities:
+        assert act.location.link is None
+    for leg in population["A"]["chris"].legs:
+        assert leg.route.exists
+    for act in population["A"]["chris"].activities:
+        assert act.location.link is not None

--- a/tests/test_99_cli.py
+++ b/tests/test_99_cli.py
@@ -138,7 +138,7 @@ def test_cli_route_wipe(path_test_plan, tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["wipe-routes", path_test_plan, path_output]
+        ["wipe-all-routes", path_test_plan, path_output]
     )
     if result.exit_code != 0:
         print(result.output)

--- a/tests/test_99_cli.py
+++ b/tests/test_99_cli.py
@@ -195,7 +195,7 @@ def test_cli_link_wipe_selected_only(path_test_plan, tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["wipe-links", path_test_plan, path_output, "1-5", "--keep_non_selected"]
+        ["wipe-links", path_test_plan, path_output, "3-4", "--keep_non_selected"]
     )
     if result.exit_code != 0:
         print(result.output)
@@ -210,11 +210,50 @@ def test_cli_link_wipe_selected_only(path_test_plan, tmp_path):
         keep_non_selected=True
     )
     assert len(population) == len(population_input)
+
+    # nick
     for leg in population["A"]["nick"].legs:
-        assert not leg.route.exists
-    for act in population["A"]["nick"].activities:
-        assert act.location.link is None
-    for leg in population["A"]["chris"].legs:
         assert leg.route.exists
-    for act in population["A"]["chris"].activities:
+    for act in population["A"]["nick"].activities:
         assert act.location.link is not None
+
+    for plan in population["A"]["nick"].plans_non_selected:
+        for leg in plan.legs:
+            assert not leg.route.exists
+        for act in plan.activities:
+            assert act.location.link is None
+    # chris
+    for leg in population["A"]["chris"].legs:
+        assert not leg.route.exists
+    for act in population["A"]["chris"].activities:
+        assert act.location.link is None
+
+    for plan in population["A"]["chris"].plans_non_selected:
+        for leg in plan.legs:
+            assert not leg.route.exists
+        for act in plan.activities:
+            assert act.location.link is None
+
+    # fatema
+    for leg in population["B"]["fatema"].legs:
+        assert not leg.route.exists
+    for act in population["B"]["fatema"].activities:
+        assert act.location.link is None
+
+    for plan in population["B"]["fatema"].plans_non_selected:
+        for leg in plan.legs:
+            assert not leg.route.exists
+        for act in plan.activities:
+            assert act.location.link is None
+
+    # fred
+    for leg in population["B"]["fred"].legs:
+        assert not leg.route.exists
+    for act in population["B"]["fred"].activities:
+        assert act.location.link is None
+
+    for plan in population["B"]["fred"].plans_non_selected:
+        for leg in plan.legs:
+            assert not leg.route.exists
+        for act in plan.activities:
+            assert act.location.link is None

--- a/tests/test_99_cli.py
+++ b/tests/test_99_cli.py
@@ -133,7 +133,8 @@ def test_cli_route_wipe(path_test_plan, tmp_path):
         version=12
     )
     path_output_dir = str(tmp_path)
-    path_output = os.path.join(path_output_dir, "test_out.xml")
+    path_output = os.path.join(
+        path_output_dir, "test_out.xml", "--keep_non_selected")
     runner = CliRunner()
     result = runner.invoke(
         cli,
@@ -159,7 +160,8 @@ def test_cli_wipe_all_links(path_test_plan, tmp_path):
         version=12
     )
     path_output_dir = str(tmp_path)
-    path_output = os.path.join(path_output_dir, "test_out.xml")
+    path_output = os.path.join(
+        path_output_dir, "test_out.xml", "--keep_non_selected")
     runner = CliRunner()
     result = runner.invoke(
         cli,
@@ -193,7 +195,7 @@ def test_cli_link_wipe_selected_only(path_test_plan, tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["wipe-links", path_test_plan, path_output, "1-5"]
+        ["wipe-links", path_test_plan, path_output, "1-5", "--keep_non_selected"]
     )
     if result.exit_code != 0:
         print(result.output)
@@ -204,7 +206,8 @@ def test_cli_link_wipe_selected_only(path_test_plan, tmp_path):
         path_output,
         household_key="hid",
         version=12,
-        leg_route=True
+        leg_route=True,
+        keep_non_selected=True
     )
     assert len(population) == len(population_input)
     for leg in population["A"]["nick"].legs:


### PR DESCRIPTION
I've wrapped the recent stream writer in a "context manager" so that it handles the boring xml shenanigans and allows the following low memory functionality:
```
with pam.write.matsim.Writer(path_population_output) as outfile:
    for person in pam.read.matsim.stream_matsim_persons(path_population_input, attributes=attributes ):
        some_modification(person)
        outfile.add_person(person)
```

Hopefully this allows low memory read writing for the cli. However please note that we still require the population attributes to be loaded fully into memory as we are still supporting v11 and, more importantly, experienced plans, which have their attributes in a separate file.

Note that streaming is at the person not household level. I am nervous to extend to a household streamer because i am not sure if we can guarantee the household structure within xml. This limits the application to person level modifications (eg plan jitter).

I've added 3 new commands using this to the cli:

```
  wipe-all-links  Clear all link information from agent plans.
  wipe-links      Clear selected link information from agent plans.
  wipe-routes     Clear all network route information from agent plans.
```

These are intended for preparing "warm" plans for network alterations. They are maybe bad examples because they are so lightweight and could be done with some simple xml parsing (similar functionality already in peep for example). But i put them here for safe keeping.

I am going to test in anger shortly.