### PR TITLE
fix bug

### DIFF
--- a/pam/utils.py
+++ b/pam/utils.py
@@ -154,7 +154,8 @@ def parse_elems(target, tag):
     for _, element in doc:
         yield element
         element.clear()
-        del element.getparent()[0]
+        while element.getprevious() is not None:
+            del element.getparent()[0]
     del doc
 
 

--- a/tests/test_00_utils.py
+++ b/tests/test_00_utils.py
@@ -13,6 +13,9 @@ from datetime import datetime
 test_trips_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "test_data/test_matsim_plans.xml")
 )
+test_tripsv12_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "test_data/test_matsim_plansv12.xml")
+)
 
 
 @pytest.fixture()
@@ -221,3 +224,15 @@ def test_matsim_time_day_three():
     """ Day-three matsim timestamp """
     dt = utils.matsim_time_to_datetime('49:01:02')
     assert dt == datetime(1900, 1, 3, 1, 1, 2)
+
+def test_parser_does_not_delete_current_element():
+    """
+    The xml iterparse should not delete the current element, 
+        as this leads to memory errors.
+    See https://lxml.de/3.2/parsing.html#iterparse-and-iterwalk , 
+        section 'Modifying the tree'
+    """
+    elements = utils.parse_elems(test_tripsv12_path, 'person')
+    for i, element in enumerate(elements):
+        if i > 0: 
+            assert element.getparent()[0] != element

--- a/tests/test_data/test_matsim_plansv12.xml
+++ b/tests/test_data/test_matsim_plansv12.xml
@@ -3,12 +3,6 @@
 
 <population>
 
-	<attributes>
-		<attribute name="coordinateReferenceSystem" class="java.lang.String">EPSG:27700</attribute>
-	</attributes>
-
-
-<!-- ====================================================================== -->
 
 	<person id="chris">
 		<attributes>
@@ -61,7 +55,6 @@
 
 	</person>
 
-<!-- ====================================================================== -->
 
 	<person id="fatema">
 		<attributes>
@@ -92,7 +85,6 @@
 
 	</person>
 
-<!-- ====================================================================== -->
 
 	<person id="fred">
 		<attributes>
@@ -159,7 +151,6 @@
 
 	</person>
 
-<!-- ====================================================================== -->
 
 	<person id="gerry">
 		<attributes>
@@ -226,7 +217,6 @@
 
 	</person>
 
-<!-- ====================================================================== -->
 
 	<person id="nick">
 		<attributes>
@@ -258,6 +248,10 @@
 
 	</person>
 
-<!-- ====================================================================== -->
+
+	<attributes>
+		<attribute name="coordinateReferenceSystem" class="java.lang.String">EPSG:27700</attribute>
+	</attributes>
+
 
 </population>


### PR DESCRIPTION
Fixes the mysterious xml parsing bug. 

After [this](https://github.com/arup-group/pam/commit/06e0dbc87954079ee763f2a442a6842378c57516) commit, we were getting strange memory errors when trying to read a population created with the same version. However, the only thing that the commit was changing in the xml structure was some rearranging of the comments structure, which shouldn't be creating any errors. 

However, our element parser had a bug, which was not showing itself as long as we were keeping an implicit assumption that the first nodes of the population xml tree were comments. If they were not, the parser was ending up deleting the same element it was streaming, eventually leading to a memory error.

As documented in the relevant [lxml documentation](https://lxml.de/3.2/parsing.html#iterparse-and-iterwalk) (section "Modifying the tree"), we "must not modify or move the ancestors (parents) of the current element. You should also avoid moving or discarding the element itself. ".

This PR fixes the error, changes some of the test fixture data to the "unhappy-path" version, and adds a test.