### PR TITLE
Plan clustering

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -28,7 +28,7 @@ jobs:
         sudo apt-get install ca-certificates
         export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
         pip install GDAL==3.0.2
-        pip install -e .
+        pip install -e .[full]
     - name: Lint with flake8
       run: |
         pip install flake8

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ cd pam
 pip install -e .
 ```
 
+### Optional dependencies
+We have kept some of the dependencies (such as scikit-learn) optional. 
+To install the full version use `pip install -e .[full]` instead.
+
 ### Developing PAM
 If you plan to make changes to the code then please make regular use of the following tools to verify the codebase
 while you work:

--- a/pam/core.py
+++ b/pam/core.py
@@ -3,7 +3,7 @@ import random
 import pickle
 import copy
 from collections import defaultdict
-from typing import Optional
+from typing import Optional, Generator
 import pandas as pd
 
 from pam.location import Location
@@ -56,6 +56,14 @@ class Population:
         for hid, household in self.households.items():
             for pid, person in household.people.items():
                 yield hid, pid, person
+
+    def plans(self) -> Generator[activity.Plan, None, None]:
+        """
+        Iterator for plans in poulation
+        """
+        for hid, household in self.households.items():
+            for pid, person in household.people.items():
+                yield person.plan
 
     @property
     def population(self):

--- a/pam/planner/clustering.py
+++ b/pam/planner/clustering.py
@@ -1,11 +1,11 @@
-from Levenshtein import ratio, hamming
+from Levenshtein import ratio
 import numpy as np
 from sklearn.cluster import AgglomerativeClustering
 from typing import List, Optional
-from pam.core import Population, Household, Person
+from pam.core import Population
 from pam.activity import Plan
 import pandas as pd
-from functools import lru_cache, cached_property
+from functools import cached_property
 from pam.planner.encoder import PlansCharacterEncoder
 from pam.plot.plans import plot_activity_breakdown_area, plot_activity_breakdown_area_tiles
 import itertools
@@ -21,7 +21,7 @@ def _levenshtein_distance(a: str, b: str) -> float:
 
 def calc_levenshtein_matrix(x: List[str], y: List[str]) -> np.array:
     """
-    Create a levenshtein distance matrix from two lists of strings
+    Create a levenshtein distance matrix from two lists of strings.
     """
     levenshtein_distance = np.vectorize(_levenshtein_distance)
     distances = levenshtein_distance(np.array(x).reshape(-1, 1), np.array(y))
@@ -51,7 +51,7 @@ class PlanClusters:
     @cached_property
     def distances(self) -> np.array:
         """
-        Levenshtein distances between activity plans
+        Levenshtein distances between activity plans.
         """
         dist = calc_levenshtein_matrix(
             self.plans_encoded, self.plans_encoded)
@@ -69,8 +69,10 @@ class PlanClusters:
             linkage: str = 'complete',
     ) -> None:
         """
+        Fit an agglomerative clustering model.
+
         :param n_clusters: The number of clusters to use.
-        :param linkage: Linkage criterion
+        :param linkage: Linkage criterion.
         """
         model = AgglomerativeClustering(
             n_clusters=n_clusters,

--- a/pam/planner/clustering.py
+++ b/pam/planner/clustering.py
@@ -80,7 +80,7 @@ class PlanClusters:
         model = AgglomerativeClustering(
             n_clusters=n_clusters,
             linkage=linkage,
-            affinity='precomputed' # change argument to "metric" for sklearn version>=1.4
+            affinity='precomputed'  # change argument to "metric" for sklearn version>=1.4
         )
         model.fit((self.distances))
 
@@ -109,7 +109,7 @@ class PlanClusters:
         Get the number of plans in each cluster.
         """
         return pd.Series(self.model.labels_).value_counts()
-    
+
     def get_cluster_membership(self) -> dict:
         """
         Get the cluster membership of each person in the population.
@@ -119,7 +119,13 @@ class PlanClusters:
         ids = [(hid, pid) for hid, pid, person in self.population.people()]
         return dict(zip(ids, self.model.labels_))
 
-    def plot_plan_breakdowns(self, ax=None, cluster=None, **kwargs):
+    def plot_plan_breakdowns(
+            self,
+            ax=None,
+            cluster=None,
+            activity_classes: Optional[List[str]] = None,
+            **kwargs
+    ):
         """
         Area plot of the breakdown of activities taking place every minute
             for a specific cluster.
@@ -128,6 +134,9 @@ class PlanClusters:
             plans = self.get_cluster_plans(cluster)
         else:
             plans = self.plans
+
+        if activity_classes is None:
+            activity_classes = self.activity_classes
 
         return plot_activity_breakdown_area(
             plans=plans,
@@ -151,6 +160,5 @@ class PlanClusters:
 
         return plot_activity_breakdown_area_tiles(
             plans=plans,
-            activity_classes=self.activity_classes,
             **kwargs
         )

--- a/pam/planner/clustering.py
+++ b/pam/planner/clustering.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 from pam.core import Population
 from pam.activity import Plan
 import pandas as pd
-from functools import cached_property
+from functools import lru_cache
 from pam.planner.encoder import PlansCharacterEncoder
 from pam.plot.plans import plot_activity_breakdown_area, plot_activity_breakdown_area_tiles
 import itertools
@@ -41,14 +41,16 @@ class PlanClusters:
         self.activity_classes = sorted(
             list(population.activity_classes) + ['travel']
         )
-        self.plan_encoder = PlansCharacterEncoder(
+        self.plans_encoder = PlansCharacterEncoder(
             activity_classes=self.activity_classes)
 
-    @cached_property
+    @property
+    @lru_cache()
     def plans_encoded(self) -> List[str]:
-        return self.plan_encoder.encode(self.plans)
+        return self.plans_encoder.encode(self.plans)
 
-    @cached_property
+    @property
+    @lru_cache()
     def distances(self) -> np.array:
         """
         Levenshtein distances between activity plans.
@@ -57,7 +59,8 @@ class PlanClusters:
             self.plans_encoded, self.plans_encoded)
         return dist
 
-    @cached_property
+    @property
+    @lru_cache()
     def distances_no_diagonal(self) -> np.array:
         dist = self.distances.copy()
         np.fill_diagonal(dist, 1)

--- a/pam/planner/clustering.py
+++ b/pam/planner/clustering.py
@@ -1,0 +1,150 @@
+from Levenshtein import ratio, hamming
+import numpy as np
+from sklearn.cluster import AgglomerativeClustering
+from typing import List, Optional
+from pam.core import Population, Household, Person
+from pam.activity import Plan
+import pandas as pd
+from functools import lru_cache, cached_property
+from pam.planner.encoder import PlansCharacterEncoder
+from pam.plot.plans import plot_activity_breakdown_area, plot_activity_breakdown_area_tiles
+import itertools
+from datetime import timedelta as td
+
+
+def _levenshtein_distance(a: str, b: str) -> float:
+    """
+    Levenstein distance between two strings.
+    """
+    return 1 - ratio(a, b)
+
+
+def calc_levenshtein_matrix(x: List[str], y: List[str]) -> np.array:
+    """
+    Create a levenshtein distance matrix from two lists of strings
+    """
+    levenshtein_distance = np.vectorize(_levenshtein_distance)
+    distances = levenshtein_distance(np.array(x).reshape(-1, 1), np.array(y))
+    return distances
+
+
+class PlanClusters:
+    def __init__(
+        self,
+        population: Population
+    ) -> None:
+        self.population = population
+        self.plans = list(population.plans())
+        self.model = None
+
+        # encodings
+        self.activity_classes = sorted(
+            list(population.activity_classes) + ['travel']
+        )
+        self.plan_encoder = PlansCharacterEncoder(
+            activity_classes=self.activity_classes)
+
+    @cached_property
+    def plans_encoded(self) -> List[str]:
+        return self.plan_encoder.encode(self.plans)
+
+    @cached_property
+    def distances(self) -> np.array:
+        """
+        Levenshtein distances between activity plans
+        """
+        dist = calc_levenshtein_matrix(
+            self.plans_encoded, self.plans_encoded)
+        return dist
+
+    @cached_property
+    def distances_no_diagonal(self) -> np.array:
+        dist = self.distances.copy()
+        np.fill_diagonal(dist, 1)
+        return dist
+
+    def fit(
+            self,
+            n_clusters: int,
+            linkage: str = 'complete',
+    ) -> None:
+        """
+        :param n_clusters: The number of clusters to use.
+        :param linkage: Linkage criterion
+        """
+        model = AgglomerativeClustering(
+            n_clusters=n_clusters,
+            linkage=linkage,
+            metric='precomputed'
+        )
+        model.fit((self.distances))
+
+        self.model = model
+
+    def get_closest_matches(self, plan, n) -> List[Plan]:
+        """
+        Get the n closest matches of a PAM activity schedule.
+        """
+        idx = self.plans.index(plan)
+        idx_closest = np.argsort(self.distances_no_diagonal[idx])[:n]
+        return [self.plans[x] for x in idx_closest]
+
+    def get_cluster_plans(self, cluster: int):
+        """
+        Get the plans that belong in a specific cluster.
+
+        :param cluster: The cluster index.
+        """
+        return list(
+            itertools.compress(self.plans, self.model.labels_ == cluster)
+        )
+
+    def get_cluster_sizes(self) -> pd.Series:
+        """
+        Get the number of plans in each cluster.
+        """
+        return pd.Series(self.model.labels_).value_counts()
+    
+    def get_cluster_membership(self) -> dict:
+        """
+        Get the cluster membership of each person in the population.
+        Returns a dictionary where the index values are (hid, pid) tuples,
+            and the values are the correponding agents' clusters.
+        """
+        ids = [(hid, pid) for hid, pid, person in self.population.people()]
+        return dict(zip(ids, self.model.labels_))
+
+    def plot_plan_breakdowns(self, ax=None, cluster=None, **kwargs):
+        """
+        Area plot of the breakdown of activities taking place every minute
+            for a specific cluster.
+        """
+        if cluster is not None:
+            plans = self.get_cluster_plans(cluster)
+        else:
+            plans = self.plans
+
+        return plot_activity_breakdown_area(
+            plans=plans,
+            activity_classes=self.activity_classes,
+            ax=ax,
+            **kwargs
+        )
+
+    def plot_plan_breakdowns_tiles(self, n: Optional[int] = None):
+        """
+        Tiled area plot of the breakdown of activities taking place every minute,
+            for the clusters with the top n number of plans.
+        """
+        if n is None:
+            n = len(set(self.model.labels_))
+
+        clusters = self.get_cluster_sizes().head(n).index
+        plans = {
+            cluster: self.get_cluster_plans(cluster) for cluster in clusters
+        }
+
+        return plot_activity_breakdown_area_tiles(
+            plans=plans,
+            activity_classes=self.activity_classes
+        )

--- a/pam/planner/clustering.py
+++ b/pam/planner/clustering.py
@@ -80,7 +80,8 @@ class PlanClusters:
         model = AgglomerativeClustering(
             n_clusters=n_clusters,
             linkage=linkage,
-            metric='precomputed'
+            # metric='precomputed', 
+            affinity='precomputed' # change to metric for sklearn version>=1.4
         )
         model.fit((self.distances))
 

--- a/pam/planner/clustering.py
+++ b/pam/planner/clustering.py
@@ -80,8 +80,7 @@ class PlanClusters:
         model = AgglomerativeClustering(
             n_clusters=n_clusters,
             linkage=linkage,
-            # metric='precomputed', 
-            affinity='precomputed' # change to metric for sklearn version>=1.4
+            affinity='precomputed' # change argument to "metric" for sklearn version>=1.4
         )
         model.fit((self.distances))
 
@@ -137,7 +136,7 @@ class PlanClusters:
             **kwargs
         )
 
-    def plot_plan_breakdowns_tiles(self, n: Optional[int] = None):
+    def plot_plan_breakdowns_tiles(self, n: Optional[int] = None, **kwargs):
         """
         Tiled area plot of the breakdown of activities taking place every minute,
             for the clusters with the top n number of plans.
@@ -152,5 +151,6 @@ class PlanClusters:
 
         return plot_activity_breakdown_area_tiles(
             plans=plans,
-            activity_classes=self.activity_classes
+            activity_classes=self.activity_classes,
+            **kwargs
         )

--- a/pam/planner/encoder.py
+++ b/pam/planner/encoder.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from pam.activity import Plan
+
+from typing import List, Optional, Union
+import numpy as np
+from pam import activity
+from pam.utils import minutes_to_datetime
+from pam.variables import START_OF_DAY, END_OF_DAY
+from datetime import timedelta as td
+from itertools import groupby
+
+
+class Encoder:
+    labels = None
+    label_code = None
+    code_label = None
+
+    def encode(self, label: str) -> Union[int, str]:
+        return self.label_code[label]
+
+    def decode(self, code: Union[int, str]) -> str:
+        return self.code_label[code]
+
+
+class StringCharacterEncoder(Encoder):
+    """
+    Encodes strings as single characters.
+    """
+
+    def __init__(self, labels: List[str]) -> None:
+        self.labels = set(labels)
+        self.label_code = self.get_mapping(self.labels)
+        self.code_label = {v: k for k, v in self.label_code.items()}
+
+    @staticmethod
+    def get_mapping(labels: List[str]) -> dict:
+        encoded = {}
+        for i, act in enumerate(labels):
+            encoded[act] = chr(i+65)
+        return encoded
+
+
+class StringIntEncoder(Encoder):
+    """
+    Encodes strings as integers.
+    """
+
+    def __init__(self, labels: List[str]) -> None:
+        self.labels = set(labels)
+        self.label_code = {label: i for i, label in enumerate(labels)}
+        self.code_label = {i: label for i, label in enumerate(labels)}
+
+
+class PlanEncoder:
+    activity_encoder_class = None
+
+    def __init__(
+            self,
+            activity_encoder: Optional[StringCharacterEncoder] = None,
+            labels: Optional[List[str]] = None
+    ) -> None:
+        if activity_encoder is not None:
+            self.activity_encoder = activity_encoder
+        elif labels is not None:
+            self.activity_encoder = self.activity_encoder_class(labels)
+        else:
+            raise ValueError(
+                'Please provide appropriate activity labels or encodings')
+
+    @staticmethod
+    def add_plan_component(plan: Plan, seq, act, start_time, duration) -> None:
+        if act == 'travel':
+            plan.add(
+                activity.Leg(
+                    seq=seq,
+                    start_time=start_time,
+                    end_time=start_time+duration
+                )
+            )
+        else:
+            plan.add(
+                activity.Activity(
+                    seq=seq,
+                    act=act,
+                    start_time=start_time,
+                    end_time=start_time+duration
+                )
+            )
+
+    def encode(self):
+        raise NotImplementedError
+
+    def decode(self, encoded_plan: np.array) -> Plan:
+        """
+        Decode a sequence to a new PAM plan.
+        """
+        start_time = START_OF_DAY
+        plan = Plan()
+        # for every activity/leg:
+        for seq, (k, g) in enumerate(groupby(self.get_seq(encoded_plan))):
+            duration = td(minutes=len(list(g)))
+            act = self.activity_encoder.decode(k)
+            # add to the plan and advance start time
+            self.add_plan_component(
+                plan=plan, seq=seq, act=act, start_time=start_time, duration=duration)
+            start_time += duration
+
+        return plan
+
+    @staticmethod
+    def get_seq(x):
+        raise NotImplementedError
+
+
+class PlanCharacterEncoder(PlanEncoder):
+    activity_encoder_class = StringCharacterEncoder
+
+    def encode(self, plan: Plan) -> np.array:
+        """
+        Convert a pam plan to a character sequence
+        """
+        seq = ''
+        for act in plan.day:
+            duration = int(act.duration / td(minutes=1))
+            seq = seq + (self.activity_encoder.encode(act.act)*duration)
+
+        return seq
+
+    @staticmethod
+    def get_seq(x):
+        return x
+
+
+class PlanOneHotEncoder(PlanEncoder):
+    activity_encoder_class = StringIntEncoder
+
+    def encode(self, plan: Plan) -> np.array:
+        """
+        Encode a PAM plan into a 2D numpy boolean array, 
+            where the row indicates the activity
+            and the column indicates the minute of the day.
+        """
+        encoded = np.zeros(
+            shape=(len(self.activity_encoder.labels), 24*60),
+            dtype=bool
+        )
+        for act in plan.day:
+            start_minute = int((act.start_time - START_OF_DAY) / td(minutes=1))
+            end_minute = int((act.end_time - START_OF_DAY) / td(minutes=1))
+            idx = self.activity_encoder.encode(act.act)
+            encoded[idx, start_minute: end_minute] = True
+
+        return encoded
+
+    @staticmethod
+    def get_seq(x):
+        return x.argmax(axis=0)
+
+
+class PlansEncoder(Encoder):
+    plans_encoder_class = None
+    dtype = None
+
+    def __init__(self, activity_classes: set) -> None:
+        self.plan_encoder = self.plans_encoder_class(labels=activity_classes)
+        super().__init__()
+
+    def encode(self, plans: List[Plan]) -> np.ndarray:
+        """
+        Encode all plans to a stacked numpy array.
+        """
+        plans_encoded = np.stack([
+            self.plan_encoder.encode(x) for x in plans
+        ], dtype=self.dtype)
+        return plans_encoded
+
+
+class PlansCharacterEncoder(PlansEncoder):
+    plans_encoder_class = PlanCharacterEncoder
+    dtype = str
+
+
+class PlansOneHotEncoder(PlansEncoder):
+    """
+    Encode plans to a 3D numpy array,
+        where the first axis indicates the person,
+        the second indicates the activity,
+        and the third indicates the minute of the day.
+    """
+    plans_encoder_class = PlanOneHotEncoder
+    dtype = bool

--- a/pam/planner/encoder.py
+++ b/pam/planner/encoder.py
@@ -6,7 +6,6 @@ if TYPE_CHECKING:
 from typing import List, Optional, Union
 import numpy as np
 from pam import activity
-from pam.utils import minutes_to_datetime
 from pam.variables import START_OF_DAY, END_OF_DAY
 from datetime import timedelta as td
 from itertools import groupby

--- a/pam/planner/encoder.py
+++ b/pam/planner/encoder.py
@@ -121,12 +121,12 @@ class PlanCharacterEncoder(PlanEncoder):
         """
         Convert a pam plan to a character sequence
         """
-        seq = ''
+        encoded = ''
         for act in plan.day:
             duration = int(act.duration / td(minutes=1))
-            seq = seq + (self.activity_encoder.encode(act.act)*duration)
+            encoded = encoded + (self.activity_encoder.encode(act.act)*duration)
 
-        return seq
+        return encoded
 
     @staticmethod
     def get_seq(x):

--- a/pam/planner/encoder.py
+++ b/pam/planner/encoder.py
@@ -6,10 +6,9 @@ if TYPE_CHECKING:
 from typing import List, Optional, Union
 import numpy as np
 from pam import activity
-from pam.variables import START_OF_DAY, END_OF_DAY
+from pam.variables import START_OF_DAY
 from datetime import timedelta as td
 from itertools import groupby
-
 
 class Encoder:
 
@@ -144,9 +143,10 @@ class PlanOneHotEncoder(PlanEncoder):
         Encode a PAM plan into a 2D numpy boolean array, 
             where the row indicates the activity
             and the column indicates the minute of the day.
-        """
+        """    
+        duration = int((plan.day[-1].end_time - START_OF_DAY) / td(minutes=1))
         encoded = np.zeros(
-            shape=(len(self.activity_encoder.labels), 24*60),
+            shape=(len(self.activity_encoder.labels), duration),
             dtype=bool
         )
         for act in plan.day:

--- a/pam/planner/encoder.py
+++ b/pam/planner/encoder.py
@@ -172,13 +172,12 @@ class PlansEncoder(Encoder):
         """
         plans_encoded = np.stack([
             self.plan_encoder.encode(x) for x in plans
-        ], dtype=self.dtype)
+        ])
         return plans_encoded
 
 
 class PlansCharacterEncoder(PlansEncoder):
     plans_encoder_class = PlanCharacterEncoder
-    dtype = str
 
 
 class PlansOneHotEncoder(PlansEncoder):
@@ -189,4 +188,3 @@ class PlansOneHotEncoder(PlansEncoder):
         and the third indicates the minute of the day.
     """
     plans_encoder_class = PlanOneHotEncoder
-    dtype = bool

--- a/pam/plot/plans.py
+++ b/pam/plot/plans.py
@@ -409,7 +409,10 @@ def plot_activity_breakdown_area_tiles(
     fig.tight_layout(pad=2)
     for k, v in plans.items():
         n = len(v)
-        ax = axs[irow, icol]
+        if nrows>1:
+            ax = axs[irow, icol]
+        else:
+            ax = axs[icol]
         print(ax)
         plot_activity_breakdown_area(
             plans=v, ax=ax, legend=False, normalize=True, 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     python_requires='>=3.7',
     entry_points={"console_scripts": ["pam = pam.cli:cli"]},
     extras_require = {
-        'full': ['scikit-learn>=1.2.2', 'python-Levenshtein']
+        'full': ['scikit-learn', 'python-Levenshtein']
     },
     install_requires=install_requires,
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     python_requires='>=3.7',
     entry_points={"console_scripts": ["pam = pam.cli:cli"]},
     extras_require = {
-        'full': ['scikit-learn', 'python-Levenshtein']
+        'full': ['scikit-learn>=1.2.2', 'python-Levenshtein']
     },
     install_requires=install_requires,
 )

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,8 @@ setup(
     ],
     python_requires='>=3.7',
     entry_points={"console_scripts": ["pam = pam.cli:cli"]},
+    extras_require = {
+        'full': ['scikit-learn', 'python-Levenshtein']
+    },
     install_requires=install_requires,
 )

--- a/tests/test_10_plotting.py
+++ b/tests/test_10_plotting.py
@@ -12,6 +12,7 @@ from pam.plot.plans import build_person_df, build_cmap, build_person_travel_geod
 from pam.plot.stats import extract_activity_log, extract_leg_log, time_binner, plot_activity_times, \
       plot_leg_times, plot_population_comparisons, calculate_leg_duration_by_mode
 from .fixtures import person_heh, Steve, Hilda, instantiate_household_with, population_heh
+from tests.test_00_utils import cyclist, pt_person
 from pam.core import Household, Population
 from copy import deepcopy
 from pam.policy import policies

--- a/tests/test_10_plotting.py
+++ b/tests/test_10_plotting.py
@@ -1,18 +1,20 @@
 import pytest
 import pandas as pd
+import numpy as np
+import matplotlib
 from matplotlib.figure import Figure
-from shapely.geometry import Point, LineString
+from shapely.geometry import Point
 from plotly.graph_objs import Scattermapbox
 
-from pam.plot.plans import build_person_df, build_cmap, build_person_travel_geodataframe, build_rgb_travel_cmap, \
-    plot_travel_plans, plot_activities
-from pam.plot.stats import extract_activity_log, extract_leg_log, time_binner, plot_activity_times, plot_leg_times, \
-    plot_population_comparisons, calculate_leg_duration_by_mode
-from .fixtures import person_heh, Steve, Hilda, instantiate_household_with
+from pam.plot.plans import build_person_df, build_cmap, build_person_travel_geodataframe, \
+    build_rgb_travel_cmap, plot_travel_plans, plot_activities, plot_activity_breakdown_area, \
+    plot_activity_breakdown_area_tiles
+from pam.plot.stats import extract_activity_log, extract_leg_log, time_binner, plot_activity_times, \
+      plot_leg_times, plot_population_comparisons, calculate_leg_duration_by_mode
+from .fixtures import person_heh, Steve, Hilda, instantiate_household_with, population_heh
 from pam.core import Household, Population
 from copy import deepcopy
 from pam.policy import policies
-from tests.test_00_utils import cyclist, pt_person
 
 
 def test_build_person_dataframe(person_heh):
@@ -162,3 +164,13 @@ def test_plot_activities(person_heh):
         fig = plot_activities(df)
     except (RuntimeError, TypeError, NameError, OSError, ValueError):
         pytest.fail("Error")
+
+def test_plot_activity_breakdown_returns_axis(population_heh):
+    ax = plot_activity_breakdown_area(list(population_heh.plans()), population_heh.activity_classes)
+    assert isinstance(ax, matplotlib.axes._axes.Axes)
+
+def test_plot_activity_breakdown_tiles_shape(population_heh):
+    plans = {i: list(population_heh.plans()) for i in range(4)}
+    axs = plot_activity_breakdown_area_tiles(plans, population_heh.activity_classes)
+    assert isinstance(axs, np.ndarray)
+    assert axs.shape == (2, 2)

--- a/tests/test_20_planner_clustering.py
+++ b/tests/test_20_planner_clustering.py
@@ -1,0 +1,83 @@
+import pytest
+import numpy as np
+from pam.planner import clustering
+from pam.read import read_matsim
+from tests.fixtures import population_heh
+import os
+
+test_plans = os.path.abspath(
+    os.path.join(os.path.dirname(__file__),
+                 "test_data/test_matsim_plansv12.xml")
+)
+
+
+@pytest.fixture
+def population():
+    population = read_matsim(test_plans, version=12)
+    return population
+
+
+def test_identical_stings_have_zero_distance():
+    assert clustering._levenshtein_distance('aa', 'aa') == 0
+
+
+def test_completely_different_stings_have_distance_one():
+    assert clustering._levenshtein_distance('aa', 'bb') == 1
+
+
+def test_substitution_costs_one():
+    assert clustering._levenshtein_distance('aa', 'ab') == 0.5
+    assert clustering._levenshtein_distance('ba', 'aa') == 0.5
+
+
+def test_distance_matrix_is_summetrical():
+    sequences = ['aa', 'bb']
+    dist_matrix = clustering.calc_levenshtein_matrix(
+        x=sequences,
+        y=sequences
+    )
+
+    assert dist_matrix[0, 0] == 0
+    assert dist_matrix[0, 1] == clustering._levenshtein_distance(*sequences)
+    np.testing.assert_array_almost_equal(dist_matrix.T, dist_matrix)
+
+
+def test_clustering_create_model(population):
+    clusters = clustering.PlanClusters(population)
+    n_clusters = 2
+    assert clusters.model is None
+    clusters.fit(n_clusters=n_clusters)
+    assert set(clusters.model.labels_) == set([0, 1])
+
+
+def test_closest_matches_return_different_plan(population):
+    clusters = clustering.PlanClusters(population)
+    plan = population['chris']['chris'].plan
+    closest_plans = clusters.get_closest_matches(plan, 3)
+    for closest_plan in closest_plans:
+        assert plan != closest_plan
+
+
+def test_closest_matches_are_ordered_by_distance(population):
+    clusters = clustering.PlanClusters(population)
+    plan = population['chris']['chris'].plan
+    plan_encoded = clusters.plan_encoder.encode(plan)
+    closest_plans = clusters.get_closest_matches(plan, 3)
+    dist = 1
+    for closest_plan in closest_plans[::-1]:
+        dist_match = clustering._levenshtein_distance(
+            plan_encoded,
+            clusters.plan_encoder.encode(closest_plan)
+        )
+        assert dist_match <= dist
+        dist = dist_match 
+
+
+def test_cluster_plans_match_cluster_sizes(population):
+    clusters = clustering.PlanClusters(population)
+    n_clusters = 2
+    clusters.fit(n_clusters=n_clusters)
+    cluster_sizes = clusters.get_cluster_sizes()
+    for cluster, size in cluster_sizes.items():
+        assert len(clusters.get_cluster_plans(cluster)) == size
+    assert cluster_sizes.sum() == len(clusters.plans)

--- a/tests/test_20_planner_clustering.py
+++ b/tests/test_20_planner_clustering.py
@@ -61,16 +61,17 @@ def test_closest_matches_return_different_plan(population):
 def test_closest_matches_are_ordered_by_distance(population):
     clusters = clustering.PlanClusters(population)
     plan = population['chris']['chris'].plan
-    plan_encoded = clusters.plan_encoder.encode(plan)
+    encode = clusters.plans_encoder.plan_encoder.encode
+    plan_encoded = encode(plan)
     closest_plans = clusters.get_closest_matches(plan, 3)
     dist = 1
     for closest_plan in closest_plans[::-1]:
         dist_match = clustering._levenshtein_distance(
             plan_encoded,
-            clusters.plan_encoder.encode(closest_plan)
+            encode(closest_plan)
         )
         assert dist_match <= dist
-        dist = dist_match 
+        dist = dist_match
 
 
 def test_cluster_plans_match_cluster_sizes(population):
@@ -81,6 +82,7 @@ def test_cluster_plans_match_cluster_sizes(population):
     for cluster, size in cluster_sizes.items():
         assert len(clusters.get_cluster_plans(cluster)) == size
     assert cluster_sizes.sum() == len(clusters.plans)
+
 
 def test_cluster_membership_includes_everyone(population):
     clusters = clustering.PlanClusters(population)

--- a/tests/test_20_planner_clustering.py
+++ b/tests/test_20_planner_clustering.py
@@ -81,3 +81,10 @@ def test_cluster_plans_match_cluster_sizes(population):
     for cluster, size in cluster_sizes.items():
         assert len(clusters.get_cluster_plans(cluster)) == size
     assert cluster_sizes.sum() == len(clusters.plans)
+
+def test_cluster_membership_includes_everyone(population):
+    clusters = clustering.PlanClusters(population)
+    n_clusters = 2
+    clusters.fit(n_clusters=n_clusters)
+    membership = clusters.get_cluster_membership()
+    assert len(membership) == len(population)

--- a/tests/test_21_planner_encoder.py
+++ b/tests/test_21_planner_encoder.py
@@ -1,0 +1,21 @@
+import pytest
+from pam.planner.encoder import StringCharacterEncoder
+
+@pytest.fixture
+def acts():
+    return ['work', 'home', 'shop']
+
+def test_strings_encoded_to_single_characters(acts):
+    encoder = StringCharacterEncoder(acts)
+    for act in acts:
+        encoded = encoder.encode(act)
+        assert type(encoded) == str
+        assert len(encoded)==1
+
+def test_encoding_works_two_way(acts):
+    """ Encoded labels can be converted back to the same value  """
+    encoder = StringCharacterEncoder(acts)
+    for act in acts:
+        encoded = encoder.encode(act)
+        decoded = encoder.decode(encoded)
+        assert decoded == act

--- a/tests/test_21_planner_encoder.py
+++ b/tests/test_21_planner_encoder.py
@@ -78,3 +78,22 @@ def test_all_plans_are_encoded(population, encoder_class):
     plans_encoded = encoder.encode(population.plans())
     assert plans_encoded.shape[0] == len(population)
 
+def test_one_hot_encoder_shape(Steve):
+    plan = Steve.plan
+    labels = plan.activity_classes
+    encoder = PlanOneHotEncoder(labels=labels)
+    plan_encoded = encoder.encode(plan)
+    
+    assert plan_encoded.shape == (len(labels)+1, 24*60)
+    assert plan_encoded.dtype == bool
+    assert (plan_encoded.sum(axis=0) == 1).all()
+
+
+def test_character_encoder_shape(Steve):
+    plan = Steve.plan
+    labels = plan.activity_classes
+    encoder = PlanCharacterEncoder(labels=labels)
+    plan_encoded = encoder.encode(plan)
+
+    assert len(plan_encoded) == 24*60
+    assert type(plan_encoded) == str

--- a/tests/test_21_planner_encoder.py
+++ b/tests/test_21_planner_encoder.py
@@ -1,21 +1,80 @@
 import pytest
-from pam.planner.encoder import StringCharacterEncoder
+import os
+from tests.fixtures import Steve
+from pam.read import read_matsim
+from pam.planner.encoder import StringCharacterEncoder, \
+    StringIntEncoder, PlanCharacterEncoder, PlanOneHotEncoder, \
+    PlansCharacterEncoder, PlansOneHotEncoder
+
 
 @pytest.fixture
 def acts():
     return ['work', 'home', 'shop']
+
+
+test_plans = os.path.abspath(
+    os.path.join(os.path.dirname(__file__),
+                 "test_data/test_matsim_plansv12.xml")
+)
+
+
+@pytest.fixture
+def population():
+    population = read_matsim(test_plans, version=12)
+    return population
+
 
 def test_strings_encoded_to_single_characters(acts):
     encoder = StringCharacterEncoder(acts)
     for act in acts:
         encoded = encoder.encode(act)
         assert type(encoded) == str
-        assert len(encoded)==1
+        assert len(encoded) == 1
 
-def test_encoding_works_two_way(acts):
+
+def test_strings_encoded_to_integers(acts):
+    encoder = StringIntEncoder(acts)
+    for act in acts:
+        encoded = encoder.encode(act)
+        assert type(encoded) == int
+
+
+@pytest.mark.parametrize('encoder_class', [StringCharacterEncoder, StringIntEncoder])
+def test_activity_encoding_works_two_way(acts, encoder_class):
     """ Encoded labels can be converted back to the same value  """
-    encoder = StringCharacterEncoder(acts)
+    encoder = encoder_class(acts)
     for act in acts:
         encoded = encoder.encode(act)
         decoded = encoder.decode(encoded)
         assert decoded == act
+
+
+@pytest.mark.parametrize('encoder_class', [PlanCharacterEncoder, PlanOneHotEncoder])
+def test_plan_encoding_works_two_way(Steve, encoder_class):
+    """ Encoded plans can be converted back to the original  """
+    plan = Steve.plan
+    labels = plan.activity_classes
+    encoder = encoder_class(labels=labels)
+    plan_encoded_decoded = encoder.decode(
+        encoder.encode(plan)
+    )
+
+    acts = [x.act for x in plan.day]
+    acts_ed = [x.act for x in plan_encoded_decoded.day]
+    assert acts == acts_ed
+
+    start_times = [x.start_time for x in plan.day]
+    start_times_ed = [x.start_time for x in plan_encoded_decoded.day]
+    assert start_times == start_times_ed
+
+    end_times = [x.end_time for x in plan.day]
+    end_times_ed = [x.end_time for x in plan_encoded_decoded.day]
+    assert end_times == end_times_ed
+
+
+@pytest.mark.parametrize('encoder_class', [PlansCharacterEncoder, PlansOneHotEncoder])
+def test_all_plans_are_encoded(population, encoder_class):
+    encoder = encoder_class(population.activity_classes)
+    plans_encoded = encoder.encode(population.plans())
+    assert plans_encoded.shape[0] == len(population)
+


### PR DESCRIPTION
Adds a plan clustering module for grouping similar activity sequences. An "encoder" module converts PAM plans to character sequences, and an agglomeration clustering model is fitted using the edit distance between those sequences.

Introduces some new library dependencies, which -however- will only be used by few users doing more advanced synthesis. I have therefore kept them as "extras" (ie a "full" version of PAM can be installed with `pip install -e .[full]` if a user wishes to work with the planner module).