### PR TITLE
Sync the pip installed python GDAL version with the apt installed und…

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -27,7 +27,7 @@ jobs:
         export C_INCLUDE_PATH=/usr/include/gdal
         sudo apt-get install ca-certificates
         export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-        pip install GDAL==3.0.2
+        pip install GDAL==3.4.1
         pip install -e .
     - name: Lint with flake8
       run: |

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -34,7 +34,7 @@ jobs:
         export C_INCLUDE_PATH=/usr/include/gdal
         sudo apt-get install ca-certificates
         export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-        pip install GDAL==3.0.2
+        pip install GDAL==3.4.1
         pip install -e .
 
     - name: Run tests


### PR DESCRIPTION
…erlying native library version

I've added a bunch of people to this PR as an FYI (but someone still needs to approve, of course)

Fixes the broken CI and Daily builds.

Ideally, we would find a way to pin both the `apt-get` installed native `libgdal-dev` version and the corresponding `pip` installed python `GDAL` library version. For now, I have noted the version `apt-get` currently installs and amended the `pip` version to match. Although this fixes the build, it is not very future-proof, so I will try to come up with something less brittle and create a further PR when I have that.