### PR TITLE
Replace base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM python:3.7-slim-stretch
+FROM python:3.7.16-bullseye
 
 RUN apt-get update \
 && apt-get upgrade -y \
-&& apt-get -y install libspatialindex-dev tk-dev --no-install-recommends \
+&& apt-get -y install libspatialindex-dev libgdal-dev tk-dev --no-install-recommends \
 && rm -rf /var/lib/apt/lists/* \
 && /usr/local/bin/python -m pip install --upgrade pip
 
 COPY . .
 
-RUN pip3 install -e .
+RUN pip install -e .[planner]
 ENV PYTHONPATH=./scripts:${PYTHONPATH}
 
 ENTRYPOINT ["python3"]

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/bin/bash
 
 # exit script if any step returns a non-0 code
 set -e

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,11 @@
+# !/bin/bash
+
+# exit script if any step returns a non-0 code
+set -e
+
+echo "Executing environment tests..."
+
+pytest -vv tests/
+./scripts/code-qa/notebooks-smoke-test.sh
+
+echo "Tests complete"


### PR DESCRIPTION
## The Problem

As it stands, PAM's Dockerfile is broken, which causes our CodeBuild CD pipeline to fail. 

<img width="921" alt="Screenshot 2023-05-16 at 18 57 57" src="https://github.com/arup-group/pam/assets/250899/6f5ce79e-1d26-4e2e-9ac1-152b69dea01c">

 The same error we see in the CD pipeline can be replicated when trying to build the image on my local machine.

```bash
(pam-venv-3.10.10) √ pam % docker build -t pam .
[+] Building 1.8s (7/9)
 => [internal] load build definition from Dockerfile                                                                                                                  0.0s
 => => transferring dockerfile: 413B                                                                                                                                  0.0s
 => [internal] load .dockerignore                                                                                                                                     0.0s
 => => transferring context: 71B                                                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/python:3.7-slim-stretch                                                                                            1.0s
 => [auth] library/python:pull token for registry-1.docker.io                                                                                                         0.0s
 => CACHED [1/4] FROM docker.io/library/python:3.7-slim-stretch@sha256:649b13bc3e6a70f7722d5eba4d78afbf4e9cec63193a29148271124840013286                               0.0s
 => [internal] load build context                                                                                                                                     0.0s
 => => transferring context: 40.27kB                                                                                                                                  0.0s
 => ERROR [2/4] RUN apt-get update && apt-get upgrade -y && apt-get -y install libspatialindex-dev tk-dev --no-install-recommends && rm -rf /var/lib/apt/lists/* &&   0.7s
------
 > [2/4] RUN apt-get update && apt-get upgrade -y && apt-get -y install libspatialindex-dev tk-dev --no-install-recommends && rm -rf /var/lib/apt/lists/* && /usr/local/bin/python -m pip install --upgrade pip:
#6 0.348 Ign:1 http://deb.debian.org/debian stretch InRelease
#6 0.350 Ign:2 http://security.debian.org/debian-security stretch/updates InRelease
#6 0.357 Ign:3 http://deb.debian.org/debian stretch-updates InRelease
#6 0.361 Ign:4 http://security.debian.org/debian-security stretch/updates Release
#6 0.369 Ign:5 http://deb.debian.org/debian stretch Release
#6 0.379 Ign:6 http://deb.debian.org/debian stretch-updates Release
#6 0.390 Ign:7 http://deb.debian.org/debian stretch/main arm64 Packages
#6 0.397 Ign:8 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#6 0.400 Ign:9 http://deb.debian.org/debian stretch/main all Packages
#6 0.409 Ign:10 http://security.debian.org/debian-security stretch/updates/main all Packages
#6 0.411 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#6 0.425 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#6 0.436 Ign:7 http://deb.debian.org/debian stretch/main arm64 Packages
#6 0.441 Ign:8 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#6 0.447 Ign:9 http://deb.debian.org/debian stretch/main all Packages
#6 0.452 Ign:10 http://security.debian.org/debian-security stretch/updates/main all Packages
#6 0.458 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#6 0.464 Ign:8 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#6 0.469 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#6 0.478 Ign:10 http://security.debian.org/debian-security stretch/updates/main all Packages
#6 0.480 Ign:7 http://deb.debian.org/debian stretch/main arm64 Packages
#6 0.490 Ign:9 http://deb.debian.org/debian stretch/main all Packages
#6 0.490 Ign:8 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#6 0.502 Ign:10 http://security.debian.org/debian-security stretch/updates/main all Packages
#6 0.502 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#6 0.513 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#6 0.513 Ign:8 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#6 0.524 Ign:7 http://deb.debian.org/debian stretch/main arm64 Packages
#6 0.526 Ign:10 http://security.debian.org/debian-security stretch/updates/main all Packages
#6 0.535 Ign:9 http://deb.debian.org/debian stretch/main all Packages
#6 0.537 Err:8 http://security.debian.org/debian-security stretch/updates/main arm64 Packages
#6 0.537   404  Not Found
#6 0.546 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#6 0.548 Ign:10 http://security.debian.org/debian-security stretch/updates/main all Packages
#6 0.566 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#6 0.584 Ign:7 http://deb.debian.org/debian stretch/main arm64 Packages
#6 0.595 Ign:9 http://deb.debian.org/debian stretch/main all Packages
#6 0.606 Ign:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#6 0.617 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#6 0.628 Err:7 http://deb.debian.org/debian stretch/main arm64 Packages
#6 0.628   404  Not Found
#6 0.639 Ign:9 http://deb.debian.org/debian stretch/main all Packages
#6 0.650 Err:11 http://deb.debian.org/debian stretch-updates/main arm64 Packages
#6 0.650   404  Not Found
#6 0.663 Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
#6 0.679 Reading package lists...
#6 0.695 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#6 0.695 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#6 0.695 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
#6 0.695 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-arm64/Packages  404  Not Found
#6 0.695 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-arm64/Packages  404  Not Found
#6 0.695 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-arm64/Packages  404  Not Found
#6 0.695 E: Some index files failed to download. They have been ignored, or old ones used instead.
------
executor failed running [/bin/sh -c apt-get update && apt-get upgrade -y && apt-get -y install libspatialindex-dev tk-dev --no-install-recommends && rm -rf /var/lib/apt/lists/* && /usr/local/bin/python -m pip install --upgrade pip]: exit code: 100
```

The base image we're using also has [security vulnerabilities](https://hub.docker.com/layers/library/python/3.7.7-slim-stretch/images/sha256-6ab3f1b840fb9757c8fb240c2eb63458b4ff503894a96cc4f10a36286f8acf75).


## The Solution

I've switched to [a different Python 3.7 base image](https://hub.docker.com/layers/library/python/3.7.16-bullseye/images/sha256-719de36dcc6278954de7be2cf345ae98b734812688c416bd734041adf9728407?context=explore) that has no security warnings and required only minimal changes to keep everything running. It has increased the image size considerably. For now I think it's best to fix the Docker file; later we can work on slimming the image down.


## Verifying the Image

### Building

```
(pam-venv-3.10.10) √ pam % docker build -t local-pam-new-image .

(pam-venv-3.10.10) √ pam % docker images
REPOSITORY                                              TAG       IMAGE ID       CREATED          SIZE
local-pam-new-image                                     latest    f580130c9db5   28 minutes ago   2.3GB
```

### Testing the container

```
(pam-venv-3.10.10) √ pam % docker run -it --entrypoint /bin/bash local-pam-new-image

root@84de7f8e9fb9:/# ./run-tests.sh
Executing environment tests...
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.7.16, pytest-7.3.1, pluggy-1.0.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /
plugins: mock-3.10.0, anyio-3.6.2, cov-4.0.0
collected 759 items

tests/test_00_utils.py::test_build_geodataframe_for_pt_person PASSED                                                                                                [  0%]
...
tests/test_99_cli.py::test_cli_link_wipe_selected_only PASSED                                                                                                       [100%]

============================================================================ warnings summary =============================================================================
pam/samplers/tour.py:50
  /pam/samplers/tour.py:50: UserWarning:

  Your density gdf has infinite values

tests/test_10_plotting.py::test_plot_population_comparisons
  /pam/plot/stats.py:185: UserWarning:

  FixedFormatter should only be used together with FixedLocator

tests/test_10_plotting.py::test_plot_population_comparisons
  /pam/plot/stats.py:162: UserWarning:

  FixedFormatter should only be used together with FixedLocator

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 752 passed, 6 skipped, 1 xfailed, 3 warnings in 6.71s ==========================================================


 a,  8a
 `8, `8)                            ,adPPRg,
  8)  ]8                        ,ad888888888b
 ,8' ,8'                    ,gPPR888888888888
,8' ,8'                 ,ad8""   `Y888888888P
8)  8)              ,ad8""        (8888888""
8,  8,          ,ad8""            d888""
`8, `8,     ,ad8""            ,ad8""
 `8, `" ,ad8""            ,ad8""
    ,gPPR8b           ,ad8""
   dP:::::Yb      ,ad8""
   8):::::(8  ,ad8""
   Yb:;;;:d888""
    "8ggg8P"
 _   _ ____    ____  __  __  ___  _  _______   _____ _____ ____ _____
| \ | | __ )  / ___||  \/  |/ _ \| |/ / ____| |_   _| ____/ ___|_   _|
|  \| |  _ \  \___ \| |\/| | | | | ' /|  _|     | | |  _| \___ \ | |
| |\  | |_) |  ___) | |  | | |_| | . \| |___    | | | |___ ___) || |
|_| \_|____/  |____/|_|  |_|\___/|_|\_\_____|   |_| |_____|____/ |_|

Smoke testing Jupyter notebooks in 'examples' directory
Found 14 notebook files in examples
['examples/01_PAM_Getting_Started.ipynb',
 'examples/02_Population_Basics.ipynb',
 'examples/03_Example_Generate_Random_Population.ipynb',
 'examples/04_Example_Ingest_NTS_Diaries.ipynb',
 'examples/05_PAM_Policies_Walk_Through.ipynb',
 'examples/06_PAM_Complex_Policies.ipynb',
 'examples/07_PAM_Point_Sampling.ipynb',
 'examples/08_PAM_Population_Activity_Plots.ipynb',
 'examples/09_Travel_Plots.ipynb',
 'examples/10_Advanced_Spatial-Sampling_Demo.ipynb',
 'examples/11_Advanced_Plan_Rescheduling.ipynb',
 'examples/12_Advanced_Adding_Vehicles.ipynb',
 'examples/13_Advanced_Freight_Synthesis.ipynb',
 'examples/14_Advanced_Plan_Cropping.ipynb']
...
                        Smoke Test Summary
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━┓
┃ Notebook                                    ┃ Result ┃ Time    ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━┩
│ 02_Population_Basics.ipynb                  │ PASSED │ 0:00:03 │
│ 01_PAM_Getting_Started.ipynb                │ PASSED │ 0:00:04 │
│ 04_Example_Ingest_NTS_Diaries.ipynb         │ PASSED │ 0:00:05 │
│ 07_PAM_Point_Sampling.ipynb                 │ PASSED │ 0:00:03 │
│ 08_PAM_Population_Activity_Plots.ipynb      │ PASSED │ 0:00:03 │
│ 06_PAM_Complex_Policies.ipynb               │ PASSED │ 0:00:08 │
│ 03_Example_Generate_Random_Population.ipynb │ PASSED │ 0:00:09 │
│ 09_Travel_Plots.ipynb                       │ PASSED │ 0:00:04 │
│ 12_Advanced_Adding_Vehicles.ipynb           │ PASSED │ 0:00:02 │
│ 10_Advanced_Spatial-Sampling_Demo.ipynb     │ PASSED │ 0:00:04 │
│ 11_Advanced_Plan_Rescheduling.ipynb         │ PASSED │ 0:00:04 │
│ 05_PAM_Policies_Walk_Through.ipynb          │ PASSED │ 0:00:13 │
│ 14_Advanced_Plan_Cropping.ipynb             │ PASSED │ 0:00:04 │
│ 13_Advanced_Freight_Synthesis.ipynb         │ PASSED │ 0:00:06 │
└─────────────────────────────────────────────┴────────┴─────────┘
                  0 failed, 14 passed in 0:00:16

/
Tests complete
root@84de7f8e9fb9:/#
```

## Continuous Deployment Build is Fixed

<img width="897" alt="Screenshot 2023-05-16 at 18 47 16" src="https://github.com/arup-group/pam/assets/250899/bf8c2605-1fc8-4df3-8e5d-91b325124303">


## Additional

Our CD CodeBuild template looks for a file called `run-tests.sh` after building the Docker image. If this script is present, the build launches a container from the new image and invokes the `run-tests.sh` inside the container. If the script fails, the CodeBuild job fails and the new Docker image will never be published to ECR.

You can put whatever you want inside the verification script - whatever is appropriate for the particular Docker image. I've added a `run-tests.sh` that runs the unit test suite and the notebooks smoke test, by way of verifying the image.




