### PR TITLE
Update test fixtures & de-package test directory

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -18,7 +18,7 @@ jobs:
         post-cleanup: all
         cache-environment: true
     - name: install PAM
-      run: pip install --no-dependencies .
+      run: pip install --no-dependencies -e .
     - name: run tests
       run: pytest -v
       
@@ -35,7 +35,7 @@ jobs:
         cache-environment: true
       
     - name: install PAM
-      run: pip install --no-dependencies .
+      run: pip install --no-dependencies -e .
 
     - name: Lint with flake8
       run: |

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -25,7 +25,7 @@ jobs:
         cache-environment: true
 
     - name: install PAM
-      run: pip install --no-deps .
+      run: pip install --no-deps -e .
   
     - name: Run tests
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1-bullseye-slim
+FROM mambaorg/micromamba:1.4.3-bullseye-slim
 COPY --chown=$MAMBA_USER:$MAMBA_USER . . 
 RUN micromamba install -y -n base -f environment.yml && \
     micromamba clean --all --yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1.4.3-bullseye-slim
+FROM mambaorg/micromamba:1-bullseye-slim
 COPY --chown=$MAMBA_USER:$MAMBA_USER . . 
 RUN micromamba install -y -n base -f environment.yml && \
     micromamba clean --all --yes

--- a/scripts/code-qa/.coveragerc
+++ b/scripts/code-qa/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-omit = venv/*, tests/*, notebooks/*, scripts/*, setup.py, pam/__init__.py, pam/*/__init__.py, requirements/*, environment.yml
+source = pam/
 
 [report]
 fail_under = 89

--- a/scripts/code-qa/.coveragerc
+++ b/scripts/code-qa/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-omit = venv/*, tests/*, notebooks/*, scripts/*, setup.py, pam/__init__.py, pam/*/__init__.py
+omit = venv/*, tests/*, notebooks/*, scripts/*, setup.py, pam/__init__.py, pam/*/__init__.py, requirements/*, environment.yml
 
 [report]
 fail_under = 89

--- a/tests/test_01_core.py
+++ b/tests/test_01_core.py
@@ -2,12 +2,11 @@ import pytest
 from datetime import datetime, timedelta
 
 from pam.core import Population, Household, Person
-from pam.activity import Plan, Activity, Leg
+from pam.activity import Activity, Leg
 from pam.utils import minutes_to_datetime as mtdt
 from pam.utils import timedelta_to_matsim_time as tdtm
 from pam import PAMSequenceValidationError, PAMTimesValidationError, PAMValidationLocationsError
 from pam.variables import END_OF_DAY
-from .fixtures import person_heh
 
 
 testdata = [

--- a/tests/test_01_core_operations.py
+++ b/tests/test_01_core_operations.py
@@ -1,12 +1,7 @@
 import pytest
-from datetime import datetime, timedelta
 
 from pam.core import Population, Household, Person
-from pam.activity import Plan, Activity, Leg
-from pam.utils import minutes_to_datetime as mtdt
-from pam.utils import timedelta_to_matsim_time as tdtm
-from pam import PAMSequenceValidationError
-from .fixtures import person_heh
+from pam.activity import Activity, Leg
 
 
 def test_get_last_component_activity():

--- a/tests/test_01_core_sample_locs.py
+++ b/tests/test_01_core_sample_locs.py
@@ -1,11 +1,8 @@
-import pytest
 from random import random
 from shapely.geometry import Point
 
-from pam.core import Population, Household, Person
-from pam.activity import Plan, Activity, Leg
+from pam.core import Population
 from pam.location import Location
-from .fixtures import *
 
 
 def test_assign_same_locs_to_household(SmithHousehold):

--- a/tests/test_02_activity.py
+++ b/tests/test_02_activity.py
@@ -1,6 +1,5 @@
-from pam.activity import Plan, Activity, Leg, Location
+from pam.activity import Plan, Activity, Leg
 from pam.utils import minutes_to_datetime as mtdt
-from pam.variables import END_OF_DAY
 import pytest
 
 

--- a/tests/test_02_activity_fix.py
+++ b/tests/test_02_activity_fix.py
@@ -1,7 +1,6 @@
-from pam.activity import Plan, Activity, Leg, Location
+from pam.activity import Plan, Activity, Leg
 from pam.utils import minutes_to_datetime as mtdt
 from pam.variables import END_OF_DAY
-import pytest
 
 
 def test_crop_act_past_end_of_day():

--- a/tests/test_02_activity_plan.py
+++ b/tests/test_02_activity_plan.py
@@ -1,10 +1,8 @@
 import pytest
-from datetime import datetime
 from datetime import timedelta
 
 from pam.activity import Plan, Activity, Leg, Location
 from pam.utils import minutes_to_datetime as mtdt
-from .fixtures import person_heh, person_heh_open1, person_hew_open2, person_whw, person_whshw
 from pam.variables import END_OF_DAY
 from pam import PAMSequenceValidationError
 

--- a/tests/test_02_activity_validate.py
+++ b/tests/test_02_activity_validate.py
@@ -1,10 +1,8 @@
 import pytest
-from datetime import datetime
 
 from pam.core import Person
 from pam.activity import Plan, Activity, Leg
 from pam.utils import minutes_to_datetime as mtdt
-from .fixtures import person_heh, person_heh_open1, person_hew_open2, person_whw, person_whshw
 from pam.variables import END_OF_DAY
 from pam import PAMSequenceValidationError, PAMTimesValidationError, PAMValidationLocationsError
 

--- a/tests/test_03_read.py
+++ b/tests/test_03_read.py
@@ -3,10 +3,9 @@ import pytest
 import pandas as pd
 from datetime import datetime
 
-from pam.core import Population, Household, Person
+from pam.core import Population, Household
 from pam.read import load_travel_diary, load_pickle
 from pam.utils import parse_time
-from .fixtures import person_crop_last_act, person_crop_last_leg
 
 test_trips_path = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "test_data/simple_travel_diaries.csv")

--- a/tests/test_03_read_travel_diary.py
+++ b/tests/test_03_read_travel_diary.py
@@ -1,4 +1,3 @@
-from logging import error
 import os
 from io import StringIO
 from pam.core import Person

--- a/tests/test_05_filters.py
+++ b/tests/test_05_filters.py
@@ -1,9 +1,11 @@
+import pytest
 from random import choice
-from tests.fixtures import *
 from pam.policy.filters import PersonAttributeFilter, Filter
+from pam.activity import Activity
+from pam.core import Household, Person
 
 
-def test_Filter_throws_exception_when_used():
+def test_Filter_throws_exception_when_used(Bobby):
     attrib_filter = Filter()
     with pytest.raises(NotImplementedError) as e:
         attrib_filter.satisfies_conditions(Bobby)

--- a/tests/test_05_modifiers.py
+++ b/tests/test_05_modifiers.py
@@ -1,9 +1,8 @@
-from tests.fixtures import Bobby
 import pytest
 from pam.policy.modifiers import Modifier, RemoveActivity
 
 
-def test_Modifier_throws_exception_when_used():
+def test_Modifier_throws_exception_when_used(Bobby):
     modifier = Modifier()
     with pytest.raises(NotImplementedError) as e:
         modifier.apply_to(Bobby)

--- a/tests/test_05_modifiers_AddActivity.py
+++ b/tests/test_05_modifiers_AddActivity.py
@@ -2,7 +2,6 @@ from pam.activity import Activity
 from pam.utils import minutes_to_datetime as mtdt
 from pam.variables import END_OF_DAY
 from pam.policy import modifiers
-from tests.fixtures import Bobby
 import pytest
 
 
@@ -15,7 +14,7 @@ def assert_correct_activities(person, ordered_activities_list):
     assert person.plan[len(person.plan)-1].end_time == END_OF_DAY
 
 
-def test_AddActivity_throws_exception_if_apply_to_given_wrong_input():
+def test_AddActivity_throws_exception_if_apply_to_given_wrong_input(Bobby):
     policy = modifiers.AddActivity([''])
     with pytest.raises(NotImplementedError) as e:
         policy.apply_to(Bobby)

--- a/tests/test_05_modifiers_MoveActivity.py
+++ b/tests/test_05_modifiers_MoveActivity.py
@@ -1,7 +1,9 @@
 from pam.activity import Plan
 from pam.policy.modifiers import MoveActivityTourToHomeLocation
-from tests.fixtures import *
 import pytest
+from pam.activity import Activity
+from pam.utils import minutes_to_datetime as mtdt
+from pam.variables import END_OF_DAY
 
 
 def assert_correct_activities(person, ordered_activities_list):

--- a/tests/test_05_modifiers_RemoveActivity.py
+++ b/tests/test_05_modifiers_RemoveActivity.py
@@ -1,6 +1,7 @@
-from pam.policy import modifiers
-from tests.fixtures import *
+import pytest
 
+from pam.policy import modifiers
+from pam.activity import Activity
 
 def test_RemoveActivity_apply_to_delegates_to_remove_individual_activities_when_given_person_and_activities(mocker, SmithHousehold):
     mocker.patch.object(modifiers.RemoveActivity, 'remove_individual_activities')
@@ -37,7 +38,7 @@ def test_RemoveActivity_throws_exception_if_apply_to_given_wrong_input(Bobby):
            in str(e.value)
 
 
-def test_remove_activities_removes_Bobbys_education(Bobby):
+def test_remove_activities_removes_Bobbys_education(assert_correct_activities, Bobby):
     policy = modifiers.RemoveActivity(['education'])
     def fnc(act): return True
     policy.remove_activities(Bobby, fnc)

--- a/tests/test_05_policy_levels.py
+++ b/tests/test_05_policy_levels.py
@@ -1,9 +1,13 @@
+import pytest
+import random
+
 from pam.policy import modifiers
 from pam.policy import probability_samplers
 from pam.policy import policies
 from pam.policy import filters
-from tests.fixtures import *
-import random
+from pam.activity import Activity
+from pam.utils import minutes_to_datetime as mtdt
+from pam.variables import END_OF_DAY
 
 
 def assert_correct_activities(person, ordered_activities_list):
@@ -15,7 +19,7 @@ def assert_correct_activities(person, ordered_activities_list):
     assert person.plan[len(person.plan)-1].end_time == END_OF_DAY
 
 
-def test_Policy_throws_exception_when_used():
+def test_Policy_throws_exception_when_used(Bobby):
     policy = policies.PolicyLevel(modifiers.Modifier())
     with pytest.raises(NotImplementedError) as e:
         policy.apply_to(Bobby)

--- a/tests/test_05_probability_samplers.py
+++ b/tests/test_05_probability_samplers.py
@@ -1,17 +1,12 @@
 import random
+import pytest
 from pam.policy import probability_samplers
-from tests.fixtures import *
-
-
-def instantiate_household_with(persons: list):
-    household = Household(1)
-    for person in persons:
-        household.add(person)
-    return household
+from pam.activity import Activity
+from pam.core import Person, Household
 
 
 @pytest.fixture()
-def SmithHousehold_alt(Steve, Hilda):
+def SmithHousehold_alt(instantiate_household_with, Steve, Hilda):
     return instantiate_household_with([Steve, Hilda])
 
 

--- a/tests/test_06_activity_remove_plan.py
+++ b/tests/test_06_activity_remove_plan.py
@@ -1,7 +1,3 @@
-import pytest
-
-from .fixtures import *
-
 
 def test_home_education_home_remove_activity_education(person_home_education_home):
 

--- a/tests/test_07_activity_fill_plan.py
+++ b/tests/test_07_activity_fill_plan.py
@@ -1,7 +1,5 @@
-import pytest
-from datetime import datetime
 
-from .fixtures import *
+from pam.utils import minutes_to_datetime as mtdt
 from pam.variables import END_OF_DAY
 
 

--- a/tests/test_08_write.py
+++ b/tests/test_08_write.py
@@ -1,14 +1,11 @@
-import csv
 import os
-import pytest
 from datetime import datetime
-from shapely.geometry import Point, LineString
+from shapely.geometry import Point
 from copy import deepcopy
 import pandas as pd
 import geopandas as gp
 import lxml
 
-from .fixtures import population_heh
 from pam.activity import Activity, Leg
 from pam.core import Household, Person, Population
 from pam import write

--- a/tests/test_10_plotting.py
+++ b/tests/test_10_plotting.py
@@ -11,8 +11,7 @@ from pam.plot.plans import build_person_df, build_cmap, build_person_travel_geod
     plot_activity_breakdown_area_tiles
 from pam.plot.stats import extract_activity_log, extract_leg_log, time_binner, plot_activity_times, \
       plot_leg_times, plot_population_comparisons, calculate_leg_duration_by_mode
-from .fixtures import person_heh, Steve, Hilda, instantiate_household_with, population_heh
-from tests.test_00_utils import cyclist, pt_person
+
 from pam.core import Household, Population
 from copy import deepcopy
 from pam.policy import policies
@@ -152,7 +151,7 @@ def test_plot_travel_plans_grouped_by_legs(pt_person):
                                               "('transit_walk', 8)"]
 
 
-def test_plot_travel_plans_for_household(cyclist, pt_person):
+def test_plot_travel_plans_for_household(instantiate_household_with, cyclist, pt_person):
     hhld = instantiate_household_with([cyclist, pt_person])
     fig = hhld.plot_travel_plotly(mapbox_access_token='token')
     assert len(fig.data) == 3

--- a/tests/test_11_population_sample.py
+++ b/tests/test_11_population_sample.py
@@ -1,4 +1,3 @@
-from .fixtures import population_heh
 from pam.samplers.population import sample
 
 

--- a/tests/test_12_scoring.py
+++ b/tests/test_12_scoring.py
@@ -1,15 +1,10 @@
 import pytest
-from pam.activity import Activity, Leg
-from pam.core import Person
-from pam.utils import minutes_to_datetime as mtdt
-from pam.variables import END_OF_DAY
+
 from pam.scoring import CharyparNagelPlanScorer
-from .fixtures import default_config, config, default_leg, pt_wait_leg, car_leg, short_activity, late_activity, Anna, \
-    AnnaPT, early_activity, small_plan, config_complex
 import os
 from pam.read import read_matsim
 
-test_experienced_plans_path = os.path.abspath(
+TEST_EXPERIENCED_PLANS_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "test_data", "test_matsim_experienced_plans_v12.xml")
 )
 
@@ -139,7 +134,7 @@ def test_score_pt_interchanges(AnnaPT, default_config):
 
 def test_scores_experienced(config_complex):
     """ Test calculated scores against MATSim experienced plan scores. """
-    population = read_matsim(test_experienced_plans_path, version = 12, crop = False)
+    population = read_matsim(TEST_EXPERIENCED_PLANS_PATH, version = 12, crop = False)
     scorer = CharyparNagelPlanScorer(config_complex)
     for hid, pid, person in population.people():
         if 'subpopulation' not in person.attributes:

--- a/tests/test_13_sample_time.py
+++ b/tests/test_13_sample_time.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from tests.fixtures import Steve
 from pam.samplers.time import jitter_activity, apply_jitter_to_plan
 
 

--- a/tests/test_18_reporting.py
+++ b/tests/test_18_reporting.py
@@ -1,23 +1,6 @@
-import os
-import pytest
 import numpy as np
 
-from pam.read import read_matsim
 from pam.report import summary, stringify
-
-
-@pytest.fixture
-def population():
-    path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "test_data/test_matsim_plansv12.xml")
-    )
-    return read_matsim(
-        path,
-        household_key="hid",
-        weight=1,
-        version=12
-    )
-
 
 # summary
 

--- a/tests/test_18_reporting_bms.py
+++ b/tests/test_18_reporting_bms.py
@@ -1,22 +1,6 @@
-import pytest
-import os
 import pandas as pd
 
-from pam.read import read_matsim
 from pam.report import benchmarks
-
-
-@pytest.fixture
-def population():
-    path = os.path.abspath(
-        os.path.join(os.path.dirname(__file__), "test_data/test_matsim_plansv12.xml")
-    )
-    return read_matsim(
-        path,
-        household_key="hid",
-        weight=1,
-        version=12
-    )
 
 
 def test_get_trips_data(population):

--- a/tests/test_19_combining.py
+++ b/tests/test_19_combining.py
@@ -1,15 +1,7 @@
 import pytest
 import os
-import geopandas as gp
-from shapely.geometry import Point, Polygon
-from copy import deepcopy
 
-from pam.core import Population, Household, Person
-from pam.activity import Activity, Leg, Plan
-from pam.utils import minutes_to_datetime as mtdt
-from pam.variables import END_OF_DAY
 from pam.operations import combine
-from pam import read
 
 
 @pytest.fixture

--- a/tests/test_20_planner_clustering.py
+++ b/tests/test_20_planner_clustering.py
@@ -1,23 +1,11 @@
 import pytest
 import numpy as np
 from pam.planner import clustering
-from pam.read import read_matsim
-import os
-
-test_plans = os.path.abspath(
-    os.path.join(os.path.dirname(__file__),
-                 "test_data/test_matsim_plansv12.xml")
-)
 
 
 @pytest.fixture
-def population():
-    population = read_matsim(test_plans, version=12)
-    return population
-
-@pytest.fixture
-def clusters(population):
-    clusters = clustering.PlanClusters(population)
+def clusters(population_no_args):
+    clusters = clustering.PlanClusters(population_no_args)
     n_clusters = 2
     clusters.fit(n_clusters=n_clusters)
     return clusters
@@ -47,25 +35,25 @@ def test_distance_matrix_is_summetrical():
     np.testing.assert_array_almost_equal(dist_matrix.T, dist_matrix)
 
 
-def test_clustering_create_model(population):
-    clusters = clustering.PlanClusters(population)
+def test_clustering_create_model(population_no_args):
+    clusters = clustering.PlanClusters(population_no_args)
     n_clusters = 2
     assert clusters.model is None
     clusters.fit(n_clusters=n_clusters)
     assert set(clusters.model.labels_) == set([0, 1])
 
 
-def test_closest_matches_return_different_plan(population):
-    clusters = clustering.PlanClusters(population)
-    plan = population['chris']['chris'].plan
+def test_closest_matches_return_different_plan(population_no_args):
+    clusters = clustering.PlanClusters(population_no_args)
+    plan = population_no_args["chris"]["chris"].plan
     closest_plans = clusters.get_closest_matches(plan, 3)
     for closest_plan in closest_plans:
         assert plan != closest_plan
 
 
-def test_closest_matches_are_ordered_by_distance(population):
-    clusters = clustering.PlanClusters(population)
-    plan = population['chris']['chris'].plan
+def test_closest_matches_are_ordered_by_distance(population_no_args):
+    clusters = clustering.PlanClusters(population_no_args)
+    plan = population_no_args["chris"]["chris"].plan
     encode = clusters.plans_encoder.plan_encoder.encode
     plan_encoded = encode(plan)
     closest_plans = clusters.get_closest_matches(plan, 3)
@@ -86,9 +74,9 @@ def test_cluster_plans_match_cluster_sizes(clusters):
     assert cluster_sizes.sum() == len(clusters.plans)
 
 
-def test_cluster_membership_includes_everyone(clusters, population):
+def test_cluster_membership_includes_everyone(clusters, population_no_args):
     membership = clusters.get_cluster_membership()
-    assert len(membership) == len(population)
+    assert len(membership) == len(population_no_args)
 
 
 def test_clustering_plot_calls_function(clusters, mocker):

--- a/tests/test_21_planner_encoder.py
+++ b/tests/test_21_planner_encoder.py
@@ -1,7 +1,5 @@
 import pytest
-import os
-from tests.fixtures import Steve
-from pam.read import read_matsim
+
 from pam.planner.encoder import StringCharacterEncoder, \
     StringIntEncoder, PlanCharacterEncoder, PlanOneHotEncoder, \
     PlansCharacterEncoder, PlansOneHotEncoder
@@ -10,18 +8,6 @@ from pam.planner.encoder import StringCharacterEncoder, \
 @pytest.fixture
 def acts():
     return ['work', 'home', 'shop']
-
-
-test_plans = os.path.abspath(
-    os.path.join(os.path.dirname(__file__),
-                 "test_data/test_matsim_plansv12.xml")
-)
-
-
-@pytest.fixture
-def population():
-    population = read_matsim(test_plans, version=12)
-    return population
 
 
 def test_strings_encoded_to_single_characters(acts):
@@ -73,10 +59,10 @@ def test_plan_encoding_works_two_way(Steve, encoder_class):
 
 
 @pytest.mark.parametrize('encoder_class', [PlansCharacterEncoder, PlansOneHotEncoder])
-def test_all_plans_are_encoded(population, encoder_class):
-    encoder = encoder_class(population.activity_classes)
-    plans_encoded = encoder.encode(population.plans())
-    assert plans_encoded.shape[0] == len(population)
+def test_all_plans_are_encoded(population_no_args, encoder_class):
+    encoder = encoder_class(population_no_args.activity_classes)
+    plans_encoded = encoder.encode(population_no_args.plans())
+    assert plans_encoded.shape[0] == len(population_no_args)
 
 def test_one_hot_encoder_shape(Steve):
     plan = Steve.plan

--- a/tests/test_22_planner_od.py
+++ b/tests/test_22_planner_od.py
@@ -6,34 +6,6 @@ from copy import deepcopy
 
 
 @pytest.fixture
-def data_od():
-    matrices = np.array(
-        [[[[20, 30], [40, 45]], [[40, 45], [20, 30]]],
-         [[[5,  5], [8,  9]], [[8,  9], [5,  5]]]]
-    )
-    return matrices
-
-
-@pytest.fixture
-def labels():
-    labels = {
-        'mode': ['car', 'bus'],
-        'vars': ['time', 'distance'],
-        'origin_zones': ['a', 'b'],
-        'destination_zones': ['a', 'b']
-    }
-    return labels
-
-
-@pytest.fixture
-def od(data_od, labels):
-    od = OD(
-        data=data_od,
-        labels=labels
-    )
-    return od
-
-@pytest.fixture
 def od_matrices():
     zone_labels = ['a', 'b']
     matrices = [

--- a/tests/test_23_planner_zones.py
+++ b/tests/test_23_planner_zones.py
@@ -1,19 +1,8 @@
 import pytest
 from pam.planner.zones import Zones
-import pandas as pd
+
 import numpy as np
 
-
-@pytest.fixture
-def data_zones():
-    df = pd.DataFrame(
-        {
-            'zone': ['a', 'b'],
-            'jobs': [100, 200],
-            'schools': [3, 1]
-        }
-    ).set_index('zone')
-    return df
 
 @pytest.fixture
 def zones(data_zones):


### PR DESCRIPTION
A quick clean-up of the test directory to place fixtures in the pytest-approved [conftest.py](https://docs.pytest.org/en/6.2.x/fixture.html#conftest-py-sharing-fixtures-across-multiple-files) file, and not have any imports between test files.

Where I've noticed unused imports, I've removed them. Running [ruff](https://beta.ruff.rs/docs/) on the whole codebase would clean it up even more. But that's for another PR. 