### PR TITLE
Fix coverage reporting

### DIFF
--- a/pam/__init__.py
+++ b/pam/__init__.py
@@ -1,52 +1,34 @@
 class PAMValidationError(Exception):
     """Custom exception raised for an Activity Plan validation Error."""
 
-    pass
-
 
 class PAMSequenceValidationError(PAMValidationError):
     """Custom exception raised for an Activity Plan sequence validation Error."""
-
-    pass
 
 
 class PAMTimesValidationError(PAMValidationError):
     """Custom exception raised for an Activity Plan Time validation Error."""
 
-    pass
-
 
 class PAMInvalidStartTimeError(PAMTimesValidationError):
     """Custom exception raised for an Activity Plan Time validation Error."""
-
-    pass
 
 
 class PAMInvalidTimeSequenceError(PAMTimesValidationError):
     """Custom exception raised for an Activity Plan Time validation Error."""
 
-    pass
-
 
 class PAMInvalidEndTimeError(PAMTimesValidationError):
     """Custom exception raised for an Activity Plan Time validation Error."""
-
-    pass
 
 
 class PAMValidationLocationsError(PAMValidationError):
     """Custom exception raised for an Activity Plan Locations validation Error."""
 
-    pass
-
 
 class PAMVehicleIdError(PAMValidationError):
     """Custom exception raised for Vehicle not matching Person ID."""
 
-    pass
-
 
 class InvalidMATSimError(PAMValidationError):
     """Custom exception raised for invalid MATSim."""
-
-    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ testpaths = ["tests", "examples", "mkdocs_plugins"]
 markers = ["high_mem", "limit_memory"]
 
 [tool.coverage.run]
-branch = true
 source = ["pam/", "mkdocs_plugins/"]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ minversion = "6.0"
 # `--strict-markers` - Raise error on unexpected pytest markers being used (add new markers to `markers` config)
 # `-n2` - parallelise over two threads (uses pytest-xdist)
 # `--nbmake --nbmake-kernel=pam` - test example notebooks using the "pam" notebook kernel (uses nbmake)
-# `--cov=. --cov-report=xml --cov-config=pyproject.toml` - generate coverage report for tests (uses pytest-cov; call `--no-cov` in CLI to switch off)
+# `--cov --cov-report=xml --cov-config=pyproject.toml` - generate coverage report for tests (uses pytest-cov; call `--no-cov` in CLI to switch off; `--cov-config` include to avoid bug)
 # `-m 'not high_mem'` - Do not run tests marked as consuming large amounts of memory (call `-m "high_mem"` in CLI to invert this; only `high_mem` marked tests will be run)
 # `-p no:memray` - Do not use the memray memory profiling plugin (call `-p memray` in CLI to switch on memory profiling)
-addopts = "-rav --strict-markers -n2 --nbmake --nbmake-kernel=pam --cov=. --cov-report=xml --cov-config=pyproject.toml -m 'not high_mem' -p no:memray"
+addopts = "-rav --strict-markers -n2 --nbmake --nbmake-kernel=pam --cov --cov-report=xml --cov-config=pyproject.toml -m 'not high_mem' -p no:memray"
 testpaths = ["tests", "examples", "mkdocs_plugins"]
 # to mark a test, decorate it with `@pytest.mark.[marker-name]`
 markers = ["high_mem", "limit_memory"]
@@ -15,7 +15,6 @@ markers = ["high_mem", "limit_memory"]
 [tool.coverage.run]
 branch = true
 source = ["pam/", "mkdocs_plugins/"]
-omit = ["__init__.py"]
 
 [tool.coverage.report]
 fail_under = 89

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ testpaths = ["tests", "examples", "mkdocs_plugins"]
 markers = ["high_mem", "limit_memory"]
 
 [tool.coverage.run]
+branch = true
 source = ["pam/", "mkdocs_plugins/"]
 
 [tool.coverage.report]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,7 +132,7 @@ def SmithHousehold(instantiate_household_with, Steve, Hilda, Timmy, Bobby):
 
 
 @pytest.fixture
-def person_heh():
+def person_heh() -> Person:
     person = Person("1")
     person.add(Activity(seq=1, act="home", area="a", start_time=mtdt(0), end_time=mtdt(60)))
     person.add(

--- a/tests/test_26_optimise_grid.py
+++ b/tests/test_26_optimise_grid.py
@@ -11,16 +11,23 @@ def recorder():
 
 
 class TestRecorder:
-    def test_recorder_init(self, recorder):
+    def test_init(self, recorder):
         assert isinstance(recorder.best_plan, Plan)
         assert recorder.best_score == 0
 
-    def test_recorder_do_update(self, recorder):
+    def test_higher_scoring_plan_updates_best_plan(self, recorder):
         recorder.update(1, Plan(home_area="bar"))
         assert recorder.best_score == 1
         assert recorder.best_plan.home_location.area == "bar"
 
-    def test_recorder_do_not_update(self, recorder):
+    def test_lower_scoring_plan_does_not_update_best_plan(self, recorder):
         recorder.update(-1, Plan(home_area="bar"))
         assert recorder.best_score == 0
         assert recorder.best_plan.home_location.area == "foo"
+
+    def test_higher_scoring_plan_deepcopies_best_plan(self, recorder):
+        "id() of Plan object and objects within Plan (e.g., `home_location`) change on deepcopy"
+        best_plan = Plan(home_area="bar")
+        recorder.update(1, best_plan)
+        assert id(recorder.best_plan) != id(best_plan)
+        assert id(recorder.best_plan.home_location) != id(best_plan.home_location)

--- a/tests/test_26_optimise_grid.py
+++ b/tests/test_26_optimise_grid.py
@@ -1,0 +1,26 @@
+"""Tests for pam/optimise/grid.py"""
+import pytest
+
+from pam.activity import Plan
+from pam.optimise import grid
+
+
+@pytest.fixture
+def recorder():
+    return grid.Recorder(0, Plan(home_area="foo"))
+
+
+class TestRecorder:
+    def test_recorder_init(self, recorder):
+        assert isinstance(recorder.best_plan, Plan)
+        assert recorder.best_score == 0
+
+    def test_recorder_do_update(self, recorder):
+        recorder.update(1, Plan(home_area="bar"))
+        assert recorder.best_score == 1
+        assert recorder.best_plan.home_location.area == "bar"
+
+    def test_recorder_do_not_update(self, recorder):
+        recorder.update(-1, Plan(home_area="bar"))
+        assert recorder.best_score == 0
+        assert recorder.best_plan.home_location.area == "foo"

--- a/tests/test_27_optimise_random.py
+++ b/tests/test_27_optimise_random.py
@@ -10,27 +10,40 @@ def stopper():
 
 
 class TestStopper:
-    def test_stopper_init(self, stopper):
+    def test_init(self, stopper):
         assert stopper.record == []
         assert stopper.horizon == 3
         assert stopper.sensitivity == 0.03
 
-    def test_stopper_ok_1(self, stopper):
+    def test_adds_to_record(self, stopper):
         assert stopper.ok(1) is True
         assert stopper.record == [1]
 
-    def test_stopper_ok_2(self, stopper):
-        assert stopper.ok(1) is True
-        assert stopper.ok(1.02) is True
-        assert stopper.record == [1, 1.02]
+    def test_adds_to_already_populated_record(self, stopper):
+        stopper.ok(1)
+        stopper.ok(1.02)
+        stopper.ok(2)
+        assert stopper.record == [1, 1.02, 2]
 
-    def test_stopper_ok_3_no_stop(self, stopper):
+    def test_pops_oldest_value_when_record_exceeds_horizon_length(self, stopper):
         for i in [1, 2, 3, 4]:
-            assert stopper.ok(i) is True
+            stopper.ok(i)
         assert stopper.record == [2, 3, 4]
 
-    def test_stopper_ok_3_stop(self, stopper):
+    def test_ok_is_true_when_sensitivity_value_not_breached(self, stopper):
+        for i in [1, 2, 3, 4]:
+            assert stopper.ok(i) is True
+
+    def test_ok_is_false_when_sensitivity_value_breached_and_record_exceeds_horizon_length(
+        self, stopper
+    ):
         for i in [1, 2, 2.01]:
             assert stopper.ok(i) is True
         assert stopper.ok(2.02) is False
+
+    def test_pops_oldest_when_sensitivity_value_breached_and_record_exceeds_horizon_length(
+        self, stopper
+    ):
+        for i in [1, 2, 2.01, 2.02]:
+            stopper.ok(i)
         assert stopper.record == [2, 2.01, 2.02]

--- a/tests/test_27_optimise_random.py
+++ b/tests/test_27_optimise_random.py
@@ -1,0 +1,36 @@
+"""Tests for pam/optimise/random.py"""
+import pytest
+
+from pam.optimise import random
+
+
+@pytest.fixture
+def stopper():
+    return random.Stopper(horizon=3, sensitivity=0.03)
+
+
+class TestStopper:
+    def test_stopper_init(self, stopper):
+        assert stopper.record == []
+        assert stopper.horizon == 3
+        assert stopper.sensitivity == 0.03
+
+    def test_stopper_ok_1(self, stopper):
+        assert stopper.ok(1) is True
+        assert stopper.record == [1]
+
+    def test_stopper_ok_2(self, stopper):
+        assert stopper.ok(1) is True
+        assert stopper.ok(1.02) is True
+        assert stopper.record == [1, 1.02]
+
+    def test_stopper_ok_3_no_stop(self, stopper):
+        for i in [1, 2, 3, 4]:
+            assert stopper.ok(i) is True
+        assert stopper.record == [2, 3, 4]
+
+    def test_stopper_ok_3_stop(self, stopper):
+        for i in [1, 2, 2.01]:
+            assert stopper.ok(i) is True
+        assert stopper.ok(2.02) is False
+        assert stopper.record == [2, 2.01, 2.02]


### PR DESCRIPTION
I realised the config wasn't capturing coverage correctly (and, quite possibly, the old config didn't either). 

In updating the config to *only* focus on the source code + a plugin I wrote for the docs, coverage dropped to 88.something%, under the 89% threshold. I've now added some basic tests for some parts of the `pam/optimise` scripts, since these had _no_ tests so far. This brings it back over the threshold, but we should probably have a target of no single file below 89% coverage, which the repo wouldn't pass right now.