### PR TITLE
Update dependencies to work from py3.9 to py3.11

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -20,14 +20,35 @@ jobs:
         environment-file: environment.yml
         post-cleanup: all
         cache-environment: true
+        create-args: python=3.11
     - name: install PAM
       run: |
         pip install --no-dependencies -e .
         python -m ipykernel install --user --name pam
     - name: run tests
       run: pytest
+
+  py39-build:
+      runs-on: ubuntu-latest
+      steps:
+      - uses: actions/checkout@v2
+      - uses: mamba-org/setup-micromamba@v1
+        with:
+          micromamba-version: latest
+          environment-file: environment.yml
+          post-cleanup: all
+          cache-environment: true
+          create-args: python=3.9
+  
+      - name: install PAM
+        run: |
+          pip install --no-dependencies -e .
+          python -m ipykernel install --user --name pam
+  
+      - name: Run unit tests
+        run: pytest tests/ --no-cov
       
-  build:
+  py311-build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -39,6 +60,7 @@ jobs:
         environment-file: environment.yml
         post-cleanup: all
         cache-environment: true
+        create-args: python=3.11
 
     - name: install PAM
       run: |

--- a/environment.yml
+++ b/environment.yml
@@ -3,40 +3,38 @@ channels:
   - conda-forge
   - default
 dependencies:
-    - click >= 8.1, < 9
+    - click < 9
     - gdal < 3.6
     - geopandas >= 0.13, < 0.14
-    - ipykernel >= 5.2, < 6
-    - lxml >= 4.6, < 5
-    - matplotlib >= 3.2, < 4
-    - pandas >= 1.3, < 2
-    - pip ~= 23.1
+    - ipykernel < 7
+    - lxml < 5
+    - matplotlib >= 3, < 4
+    - numpy >= 1, < 2
+    - pandas >= 1.5, < 3
+    - pip >= 23, < 24
     - pip:
       - s2sphere < 0.3
-    - plotly >= 4.10, < 5
-    - prettytable >= 3.3, < 4
-    - python >=3.7, <3.12
+    - plotly >= 4, < 6
+    - prettytable >= 3, < 4
+    - python >= 3.9, < 3.12
     - python-Levenshtein >= 0.21, < 0.22
-    - rich >= 12.5, < 13
-    - Rtree >= 0.9, < 1
+    - rich >= 12, < 14
+    - Rtree >= 1, < 2
     - scikit-learn >= 1.2, < 2
-    - shapely > 2.0, < 3
-    - xlrd >= 2.0, < 3
+    - shapely >= 1, < 3
+    - xlrd >= 2, < 3
     # dev
-    - nbmake ~= 1.3
-    - pre-commit ~= 3.3
-    - pytest ~= 7.3
-    - pytest-cov ~= 4.1
-    - pytest-mock ~= 3.10
-    - pytest-timeout ~= 2.1
-    - pytest-xdist ~= 3.3
+    - nbmake < 2
+    - pre-commit < 4
+    - pytest < 8
+    - pytest-cov < 5
+    - pytest-mock < 4
+    - pytest-timeout < 3
+    - pytest-xdist  < 4
     # docs
-    - colorama
     - jupyter < 2
-    - jupyter_contrib_nbextensions < 0.6
-    - mike ~= 1.1
-    - mkdocs ~= 1.4
-    - mkdocs-click ~= 0.6.0
-    - mkdocs-jupyter ~= 0.24.1
-    - mkdocstrings-python ~= 1.1
-    - tabulate < 1
+    - mike < 2
+    - mkdocs < 2
+    - mkdocs-click < 0.7
+    - mkdocs-jupyter < 0.25
+    - mkdocstrings-python < 2

--- a/examples/04_Example_Ingest_NTS_Diaries.ipynb
+++ b/examples/04_Example_Ingest_NTS_Diaries.ipynb
@@ -2485,7 +2485,7 @@
     "        for idx in ids:\n",
     "            split = target.loc[target[target_on] == i]\n",
     "            split[new_id] = idx\n",
-    "            expanded = expanded.append(split)\n",
+    "            expanded = pd.concat([expanded, split])\n",
     "    expanded = expanded.set_index(new_id)\n",
     "    print(\"Done\")\n",
     "    return expanded"

--- a/examples/04_Example_Ingest_NTS_Diaries.ipynb
+++ b/examples/04_Example_Ingest_NTS_Diaries.ipynb
@@ -36,10 +36,10 @@
      "start_time": "2020-11-23T09:58:59.245038Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:17.573602Z",
-     "iopub.status.busy": "2023-06-22T10:53:17.573243Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.003684Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.003292Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.096745Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.096653Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.516000Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.515684Z"
     }
    },
    "outputs": [],
@@ -59,10 +59,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.005425Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.005299Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.006808Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.006527Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.517804Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.517673Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.519640Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.519297Z"
     }
    },
    "outputs": [],
@@ -79,10 +79,10 @@
      "start_time": "2020-11-23T09:59:00.357541Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.008125Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.008038Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.009846Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.009598Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.521198Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.521093Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.523172Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.522858Z"
     }
    },
    "outputs": [],
@@ -134,10 +134,10 @@
      "start_time": "2020-11-23T09:59:01.049612Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.011147Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.011062Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.022187Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.021913Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.524581Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.524477Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.536325Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.536056Z"
     }
    },
    "outputs": [
@@ -359,10 +359,10 @@
      "start_time": "2020-11-23T09:59:02.362042Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.023611Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.023527Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.025231Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.024966Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.537794Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.537709Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.539609Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.539326Z"
     }
    },
    "outputs": [],
@@ -395,10 +395,10 @@
      "start_time": "2020-11-23T09:59:02.474033Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.026501Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.026417Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.033597Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.033333Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.540932Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.540833Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.548520Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.548231Z"
     }
    },
    "outputs": [
@@ -676,10 +676,10 @@
      "start_time": "2020-11-23T09:59:06.038395Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.034887Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.034806Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.041427Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.041173Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.549833Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.549746Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.556966Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.556696Z"
     }
    },
    "outputs": [
@@ -917,10 +917,10 @@
      "start_time": "2020-11-23T09:59:19.500969Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.042758Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.042669Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.045072Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.044831Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.558230Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.558149Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.560738Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.560449Z"
     }
    },
    "outputs": [],
@@ -938,10 +938,10 @@
      "start_time": "2020-11-23T09:59:19.924030Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.046355Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.046267Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.048333Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.048096Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.561988Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.561899Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.564105Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.563827Z"
     }
    },
    "outputs": [],
@@ -958,10 +958,10 @@
      "start_time": "2020-11-23T09:59:21.538108Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.049637Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.049553Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.054699Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.054445Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.565311Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.565227Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.570727Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.570405Z"
     }
    },
    "outputs": [
@@ -1192,10 +1192,10 @@
      "start_time": "2020-11-23T09:59:21.579327Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.055951Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.055869Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.061520Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.061270Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.571931Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.571841Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.577793Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.577493Z"
     }
    },
    "outputs": [
@@ -1425,10 +1425,10 @@
      "start_time": "2020-11-23T09:59:21.680364Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.062819Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.062738Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.065274Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.065009Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.579044Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.578957Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.581734Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.581462Z"
     }
    },
    "outputs": [
@@ -1477,10 +1477,10 @@
      "start_time": "2020-11-23T09:59:21.729518Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.066595Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.066511Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.068236Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.068003Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.583033Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.582947Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.584799Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.584527Z"
     }
    },
    "outputs": [],
@@ -1502,10 +1502,10 @@
      "start_time": "2020-11-23T09:59:21.772210Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.069509Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.069425Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.074359Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.074091Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.586021Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.585931Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.590181Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.589872Z"
     }
    },
    "outputs": [
@@ -1603,10 +1603,10 @@
      "start_time": "2020-11-23T09:59:21.925277Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.075876Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.075797Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.077278Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.077032Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.591604Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.591522Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.593136Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.592822Z"
     }
    },
    "outputs": [],
@@ -1623,10 +1623,10 @@
      "start_time": "2020-11-23T09:59:21.955206Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.078625Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.078538Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.136571Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.136308Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.594482Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.594392Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.655511Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.655184Z"
     }
    },
    "outputs": [
@@ -1698,10 +1698,10 @@
      "start_time": "2020-11-23T09:59:32.383388Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.137995Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.137904Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.201323Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.201054Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.657092Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.656982Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.727004Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.726635Z"
     }
    },
    "outputs": [
@@ -1749,10 +1749,10 @@
      "start_time": "2020-11-23T09:59:33.888534Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.202858Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.202758Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.204747Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.204469Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.728671Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.728545Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.730727Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.730435Z"
     }
    },
    "outputs": [],
@@ -1775,34 +1775,16 @@
      "start_time": "2020-11-23T09:59:33.923065Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.206238Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.206113Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.211740Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.211477Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.732150Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.732049Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.774775Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.774465Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-19-a7c619c3c7bc>:2: FutureWarning:\n",
-      "\n",
-      "Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
-      "To preserve the previous behavior, use\n",
-      "\n",
-      "\t>>> .groupby(..., group_keys=False)\n",
-      "\n",
-      "To adopt the future behavior and silence this warning, use \n",
-      "\n",
-      "\t>>> .groupby(..., group_keys=True)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "clean_travel_diaries = (\n",
-    "    travel_diaries.groupby([\"IndividualID\", \"TravDay\"]).apply(remove_broken_plans).reset_index(drop=True)\n",
+    "    travel_diaries.groupby([\"IndividualID\", \"TravDay\"], group_keys=False).apply(remove_broken_plans).reset_index(drop=True)\n",
     ")"
    ]
   },
@@ -1815,10 +1797,10 @@
      "start_time": "2020-11-23T10:04:57.833810Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.213083Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.212982Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.218106Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.217843Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.776292Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.776200Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.781820Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.781523Z"
     }
    },
    "outputs": [
@@ -2035,10 +2017,10 @@
      "start_time": "2020-11-23T10:04:57.992403Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.219489Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.219399Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.221190Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.220910Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.783142Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.783036Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.785023Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.784755Z"
     }
    },
    "outputs": [
@@ -2075,10 +2057,10 @@
      "start_time": "2020-11-23T10:04:58.103360Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.222479Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.222393Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.224532Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.224277Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.786317Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.786218Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.788445Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.788155Z"
     }
    },
    "outputs": [],
@@ -2103,10 +2085,10 @@
      "start_time": "2020-11-23T10:04:58.185590Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.225830Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.225745Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.229951Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.229714Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.789723Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.789627Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.793980Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.793686Z"
     }
    },
    "outputs": [],
@@ -2181,31 +2163,13 @@
      "start_time": "2020-11-23T10:04:58.468222Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.231225Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.231138Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.236904Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.236662Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.795196Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.795114Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.800767Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.800517Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-24-ff56e72459e1>:13: FutureWarning:\n",
-      "\n",
-      "Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
-      "To preserve the previous behavior, use\n",
-      "\n",
-      "\t>>> .groupby(..., group_keys=False)\n",
-      "\n",
-      "To adopt the future behavior and silence this warning, use \n",
-      "\n",
-      "\t>>> .groupby(..., group_keys=True)\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# reweight and split ids for unique days\n",
     "\n",
@@ -2219,7 +2183,7 @@
     "    return group\n",
     "\n",
     "\n",
-    "trips = clean_travel_diaries.groupby(\"IndividualID\").apply(reweight)\n",
+    "trips = clean_travel_diaries.groupby(\"IndividualID\", group_keys=False).apply(reweight)\n",
     "trips[\"pid\"] = [f\"{p}_{d}\" for p, d in zip(trips.IndividualID, trips.TravDay)]\n",
     "trips[\"hid\"] = [f\"{h}_{d}\" for h, d in zip(trips.HouseholdID, trips.TravDay)]"
    ]
@@ -2233,10 +2197,10 @@
      "start_time": "2020-11-23T10:07:34.516529Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.238205Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.238110Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.243831Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.243564Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.801957Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.801874Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.807763Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.807451Z"
     }
    },
    "outputs": [
@@ -2453,10 +2417,10 @@
      "start_time": "2020-11-23T10:07:34.712210Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.245202Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.245114Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.248083Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.247830Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.809097Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.809011Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.812305Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.811951Z"
     }
    },
    "outputs": [],
@@ -2484,8 +2448,7 @@
     "            print(f\"Building expanded data {p}/{n}\", end=\"\\r\", flush=True)\n",
     "        for idx in ids:\n",
     "            split = target.loc[target[target_on] == i]\n",
-    "            split[new_id] = idx\n",
-    "            expanded = pd.concat([expanded, split])\n",
+    "            expanded = pd.concat([expanded, split.assign(**{new_id: idx})])\n",
     "    expanded = expanded.set_index(new_id)\n",
     "    print(\"Done\")\n",
     "    return expanded"
@@ -2500,10 +2463,10 @@
      "start_time": "2020-11-23T10:07:34.767754Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.249390Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.249292Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.258567Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.258320Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.813565Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.813478Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.822526Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.822267Z"
     }
    },
    "outputs": [
@@ -2522,228 +2485,6 @@
      "text": [
       "Done\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n"
-     ]
     }
    ],
    "source": [
@@ -2759,10 +2500,10 @@
      "start_time": "2020-11-23T10:58:31.915713Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.259978Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.259872Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.264925Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.264696Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.823891Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.823796Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.829288Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.828987Z"
     }
    },
    "outputs": [
@@ -2836,31 +2577,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1_6</th>\n",
-       "      <td>1</td>\n",
-       "      <td>2002</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>3</td>\n",
-       "      <td>1</td>\n",
-       "      <td>-10</td>\n",
-       "      <td>3</td>\n",
-       "      <td>...</td>\n",
-       "      <td>2</td>\n",
-       "      <td>1</td>\n",
-       "      <td>5</td>\n",
-       "      <td>1</td>\n",
-       "      <td>-9</td>\n",
-       "      <td>1</td>\n",
-       "      <td>3</td>\n",
-       "      <td>-10</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1_4</th>\n",
+       "      <th>1_3</th>\n",
        "      <td>1</td>\n",
        "      <td>2002</td>\n",
        "      <td>1</td>\n",
@@ -2932,7 +2649,31 @@
        "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1_3</th>\n",
+       "      <th>1_6</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2002</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>3</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-10</td>\n",
+       "      <td>3</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-9</td>\n",
+       "      <td>1</td>\n",
+       "      <td>3</td>\n",
+       "      <td>-10</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1_5</th>\n",
        "      <td>1</td>\n",
        "      <td>2002</td>\n",
        "      <td>1</td>\n",
@@ -2963,43 +2704,43 @@
       "text/plain": [
        "     HouseholdID  SurveyYear  PSUID  W2  OutCom_B02ID  HHIncome2002_B02ID  \\\n",
        "hid                                                                         \n",
-       "1_6            1        2002      1   1             1                   2   \n",
-       "1_4            1        2002      1   1             1                   2   \n",
+       "1_3            1        2002      1   1             1                   2   \n",
        "1_2            1        2002      1   1             1                   2   \n",
        "1_1            1        2002      1   1             1                   2   \n",
-       "1_3            1        2002      1   1             1                   2   \n",
+       "1_6            1        2002      1   1             1                   2   \n",
+       "1_5            1        2002      1   1             1                   2   \n",
        "\n",
        "     AddressType_B01ID  Ten1_B02ID  Landlord_B01ID  ResLength_B01ID  ...  \\\n",
        "hid                                                                  ...   \n",
-       "1_6                  3           1             -10                3  ...   \n",
-       "1_4                  3           1             -10                3  ...   \n",
+       "1_3                  3           1             -10                3  ...   \n",
        "1_2                  3           1             -10                3  ...   \n",
        "1_1                  3           1             -10                3  ...   \n",
-       "1_3                  3           1             -10                3  ...   \n",
+       "1_6                  3           1             -10                3  ...   \n",
+       "1_5                  3           1             -10                3  ...   \n",
        "\n",
        "     NumCarVan  WalkBus_B01ID  Getbus_B01ID  WalkRail_B01ID  \\\n",
        "hid                                                           \n",
-       "1_6          2              1             5               1   \n",
-       "1_4          2              1             5               1   \n",
+       "1_3          2              1             5               1   \n",
        "1_2          2              1             5               1   \n",
        "1_1          2              1             5               1   \n",
-       "1_3          2              1             5               1   \n",
+       "1_6          2              1             5               1   \n",
+       "1_5          2              1             5               1   \n",
        "\n",
        "     WalkRailAlt_B01ID  HRPWorkStat_B02ID  HRPSEGWorkStat_B01ID  \\\n",
        "hid                                                               \n",
-       "1_6                 -9                  1                     3   \n",
-       "1_4                 -9                  1                     3   \n",
+       "1_3                 -9                  1                     3   \n",
        "1_2                 -9                  1                     3   \n",
        "1_1                 -9                  1                     3   \n",
-       "1_3                 -9                  1                     3   \n",
+       "1_6                 -9                  1                     3   \n",
+       "1_5                 -9                  1                     3   \n",
        "\n",
        "     HHoldOAClass2011_B03ID  Settlement2011EW_B03ID  Settlement2011EW_B04ID  \n",
        "hid                                                                          \n",
-       "1_6                     -10                       1                       1  \n",
-       "1_4                     -10                       1                       1  \n",
+       "1_3                     -10                       1                       1  \n",
        "1_2                     -10                       1                       1  \n",
        "1_1                     -10                       1                       1  \n",
-       "1_3                     -10                       1                       1  \n",
+       "1_6                     -10                       1                       1  \n",
+       "1_5                     -10                       1                       1  \n",
        "\n",
        "[5 rows x 33 columns]"
       ]
@@ -3022,10 +2763,10 @@
      "start_time": "2020-11-23T10:58:31.993216Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.266276Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.266197Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.284976Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.284728Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.830605Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.830503Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.850445Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.850190Z"
     }
    },
    "outputs": [
@@ -3044,480 +2785,6 @@
      "text": [
       "Done\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:31: SettingWithCopyWarning:\n",
-      "\n",
-      "\n",
-      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
-      "Try using .loc[row_indexer,col_indexer] = value instead\n",
-      "\n",
-      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "\n",
-      "<ipython-input-26-94d32797559f>:32: FutureWarning:\n",
-      "\n",
-      "The frame.append method is deprecated and will be removed from pandas in a future version. Use pandas.concat instead.\n",
-      "\n"
-     ]
     }
    ],
    "source": [
@@ -3533,10 +2800,10 @@
      "start_time": "2020-11-23T12:10:07.762160Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.286473Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.286357Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.291678Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.291416Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.851920Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.851815Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.857574Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.857304Z"
     }
    },
    "outputs": [
@@ -3610,7 +2877,7 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1_6</th>\n",
+       "      <th>1_3</th>\n",
        "      <td>2002</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
@@ -3658,7 +2925,7 @@
        "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1_3</th>\n",
+       "      <th>1_6</th>\n",
        "      <td>2002</td>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
@@ -3737,41 +3004,41 @@
       "text/plain": [
        "     SurveyYear  IndividualID  HouseholdID  PSUID VehicleID  PersNo  \\\n",
        "pid                                                                   \n",
-       "1_6        2002             1            1      1         1       1   \n",
-       "1_2        2002             1            1      1         1       1   \n",
        "1_3        2002             1            1      1         1       1   \n",
+       "1_2        2002             1            1      1         1       1   \n",
+       "1_6        2002             1            1      1         1       1   \n",
        "1_5        2002             1            1      1         1       1   \n",
        "1_7        2002             1            1      1         1       1   \n",
        "\n",
        "     Age_B01ID  OfPenAge_B01ID  Sex_B01ID  EdAttn1_B01ID  ...  \\\n",
        "pid                                                       ...   \n",
-       "1_6         13               2          2            -10  ...   \n",
-       "1_2         13               2          2            -10  ...   \n",
        "1_3         13               2          2            -10  ...   \n",
+       "1_2         13               2          2            -10  ...   \n",
+       "1_6         13               2          2            -10  ...   \n",
        "1_5         13               2          2            -10  ...   \n",
        "1_7         13               2          2            -10  ...   \n",
        "\n",
        "     CarAccess_B01ID  DrivDisable_B01ID  WkPlace_B01ID  ES2000_B01ID  \\\n",
        "pid                                                                    \n",
-       "1_6                2                 -9              1             7   \n",
-       "1_2                2                 -9              1             7   \n",
        "1_3                2                 -9              1             7   \n",
+       "1_2                2                 -9              1             7   \n",
+       "1_6                2                 -9              1             7   \n",
        "1_5                2                 -9              1             7   \n",
        "1_7                2                 -9              1             7   \n",
        "\n",
        "     NSSec_B03ID  SC_B01ID  Stat_B01ID  SVise_B01ID  EcoStat_B02ID  \\\n",
        "pid                                                                  \n",
-       "1_6            2         3           1            2              2   \n",
-       "1_2            2         3           1            2              2   \n",
        "1_3            2         3           1            2              2   \n",
+       "1_2            2         3           1            2              2   \n",
+       "1_6            2         3           1            2              2   \n",
        "1_5            2         3           1            2              2   \n",
        "1_7            2         3           1            2              2   \n",
        "\n",
        "     PossHom_B01ID  \n",
        "pid                 \n",
-       "1_6              2  \n",
-       "1_2              2  \n",
        "1_3              2  \n",
+       "1_2              2  \n",
+       "1_6              2  \n",
        "1_5              2  \n",
        "1_7              2  \n",
        "\n",
@@ -3806,10 +3073,10 @@
      "start_time": "2020-11-23T12:10:07.963560Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.293218Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.293100Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.295111Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.294881Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.858795Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.858713Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.860870Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.860563Z"
     }
    },
    "outputs": [],
@@ -3827,10 +3094,10 @@
      "start_time": "2020-11-23T12:10:08.014383Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.296507Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.296397Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.322223Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.321989Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.862172Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.862071Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.890147Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.889889Z"
     },
     "scrolled": true
    },
@@ -3900,6 +3167,13 @@
      "text": [
       " Person pid:2_7 hid:1_7 plan does not start with 'home' activity: work\n"
      ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hello there\n"
+     ]
     }
    ],
    "source": [
@@ -3917,10 +3191,10 @@
      "start_time": "2020-11-23T12:10:17.804047Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.323738Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.323655Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.325861Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.325621Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.891639Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.891553Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.893817Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.893553Z"
     }
    },
    "outputs": [],
@@ -3937,10 +3211,10 @@
      "start_time": "2020-11-23T12:10:18.001901Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.327218Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.327143Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.329009Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.328773Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.895060Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.894978Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.896995Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.896722Z"
     }
    },
    "outputs": [],
@@ -3960,10 +3234,10 @@
      "start_time": "2020-11-23T12:10:18.067138Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.330325Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.330241Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.332264Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.332034Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.898183Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.898103Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.900267Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.900011Z"
     }
    },
    "outputs": [
@@ -3991,10 +3265,10 @@
      "start_time": "2020-11-23T12:10:18.119285Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.333571Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.333488Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.335701Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.335446Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.901487Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.901401Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.903518Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.903288Z"
     }
    },
    "outputs": [
@@ -4025,10 +3299,10 @@
      "start_time": "2020-11-23T12:10:18.176008Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.336988Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.336905Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.339092Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.338828Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.904706Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.904618Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.906894Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.906605Z"
     }
    },
    "outputs": [
@@ -4056,10 +3330,10 @@
      "start_time": "2020-11-23T12:10:18.222929Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.340371Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.340283Z",
-     "iopub.status.idle": "2023-06-22T10:53:18.342353Z",
-     "shell.execute_reply": "2023-06-22T10:53:18.342093Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.908159Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.908067Z",
+     "iopub.status.idle": "2023-07-04T15:30:19.910466Z",
+     "shell.execute_reply": "2023-07-04T15:30:19.910190Z"
     }
    },
    "outputs": [
@@ -4087,17 +3361,17 @@
      "start_time": "2020-11-23T12:10:18.277070Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:18.343637Z",
-     "iopub.status.busy": "2023-06-22T10:53:18.343557Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.007659Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.007370Z"
+     "iopub.execute_input": "2023-07-04T15:30:19.911750Z",
+     "iopub.status.busy": "2023-07-04T15:30:19.911660Z",
+     "iopub.status.idle": "2023-07-04T15:30:20.622640Z",
+     "shell.execute_reply": "2023-07-04T15:30:20.622318Z"
     },
     "scrolled": false
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAKrCAYAAADs7iyrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAB7P0lEQVR4nOz9f5RldX3v+T9fNihIo6IIgQRvqxeSIQm20I3BKHQz6qjDdTQxGFZPLkzUNq4lilmsK4pLwEkyoBn9Rl2KFcxwR1uvCESNwUB0aLxoQBqEbtCIiq2YJsHONQaSFqF5f/84u+RQnh9VXbu6qs5+PtY66+z9eX8+e+/3p6s+1IfPPvukqpAkSZIkzd9jFvsCJEmSJGlSOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiQte0l2J7m173XOAp7rbQt1bEnS8he/B0uStNwlub+qVi7wOQIE+NeFPpckaflyBUuSNLGSXJjk60m2JvnTpuzQJH+Z5Lbm9dym/A+T3N68zmrKViX5RpIPArcAHwH2b1bJNi1WXpKkpcsVLEnSspdkN7Ctr+j/Av4W+DvgV6qqkjypqv4lySeBv6uq/1+SFcBK4D8ClwK/QW+V6kbgfwd+BNwFPLeqbmjOteCrZZKk5Wufxb4ASZJasKuqVvcXJNkH+AlwSZK/Bj7XhE4G/jNAVe0GfpzkecBfVtW/NW2vBJ4PfBb43vTkSpKkcbxFUJI0karqIeB44Arg5cDfjKieEbF/a/GyJEkTzgmWJGkiJVkJPLGqrgLOAlY3oS8Cr2/qrEjyBOBLwMuTPD7JAcArgP8+5NAPJtl3Ia9dkrR8eYugJGkS7J/k1r79vwH+DPhMkv3orVC9uYm9CZhK8mpgN/D6qvq7JJcCX23qXFJVX0uyasC5poCtSW6pqg3tpyJJWs58yIUkSZIktcRbBCVJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJT5FEHzKhyRJktRNo74HcY84wWJ0r5bxRY0vhWswbny+8fWbh8evXTc+vtjX7+/4+PgF5w+Pn3f+4l/fYsfH9c+4A0x6/y72GDCf808fY9L/jZZ7fLF/xpZ6vG3eIihJkiRJLXGCJUmSJEktGTvBSnJukjuSbE1ya5LnNOVnJXn8XE+Y5Iwkh88mluSSJEfP9RySJEmStBhGTrCSnACcAhxbVccALwDubsJnAXOaYCVZAZwBDJxgzYxV1Wuq6utzOYckSZIkLZZxK1iHATur6gGAqtpZVTuSvJHeROjaJNcCJPlQki3NatcF0wdIsj3JO5JcD5wGrAE2Nath+/fVe+XMWJLNSdY08fuTXJTk5iRfSHJ8E78rycuaOiuSvDvJTc2K2+ta6ylJkiRJGmPcBOsa4Igkdyb5YJKTAKrqfcAOYH1VrW/qnltVa4BjgJOSHNN3nJ9U1fOq6mPAFmBDVa2uql3TFarq8mGxxgHA5qo6DrgP+CPghcArgHc2dV4N/Liq1gJrgdcmefrMpJJsbCaDW6ampsZ0gSRJkiTNzsjHtFfV/UmOA54PrAc+meScqrp0QPVTk2xsjnkYcDSwtYl9soVr/SnwN832NuCBqnowyTZgVVP+IuCYZjUM4InAkcB3Z+Q1BUzPrMplLkmSJEltGPs9WFW1G9gMbG4mM6cDl/bXaVaJzgbWVtWPklwK7NdX5d9auNYHq2r6UfUPA9O3LT6cZDqPAGdW1dUtnE+SJEmS5mTcQy5+OcmRfUWrge812/cBBzbbT6A3ifpxkkOBl4w4bH+7ucRm42rg9Un2BUhyVJID5nE8SZIkSZq1cStYK4H3J3kS8BDwbWBjE5sCPp/knqpan+RrwB3AXcCXRxzzUuDiJLuAE2Z81upRsTnmAnAJvdsFb0kS4IfAy/fgOJIkSZI0Z+M+g3Uz8NwhsfcD7+/bP2NIvVUz9q8ArhhSd2ZsXV9sZd/2+TParWzeHwbe1rwkSZIkaa8a+0XDkiRJkqTZcYIlSZIkSS3JIw/m66zOd4AkSZLUUWn7gGMf094Fo3q1jC9qfClcg3HjCx3/1a8Pj99x9OJfn7/j4+Onfmp4/LLfWfzrW+z4uJ/xcfFxJ1js/Jb7GDCf808fw9+B+cUX+mdgsX/Glnq8bd4iKEmSJEktcYIlSZIkSS3ZowlWkt1Jbu17nTPH9tuTHDyg/G0z9r+yJ9cnSZIkSYthTz+DtauqVrd5IY23AX8yvVNVA7+DS5IkSZKWolZvEWxWpi5IckuSbUl+pSl/SpJrknwtyYcZ8FmzJBcC+zcrYpuasvub93VJrktyWZI7k1yYZEOSrzbneWZT76lJrkhyU/P6zTbzkyRJkqRR9nSCNT0Rmn69qi+2s6qOBT4EnN2UnQdcX1XPBj4LPG3mAavqHJqVsaraMOCczwLeBPw68HvAUVV1PHAJcGZT58+A91bVWuC3m9jPSbIxyZYkW6ampuaYuiRJkiQNthC3CF7ZvN8M/FazfeL0dlX9dZIf7cE5b6qqewCSfAe4pinfBqxvtl8AHJ38bIHsCUkOrKr7+g9UVVPA9MyqXrcHFyNJkiRJMy3E92A90LzvnnH8+T5m/oG+7Yf79h/uO89jgBOqatc8zyVJkiRJc7a3HtP+JWADQJKXAAcNqfdgkn3ncZ5rgDdM7yRZPY9jSZIkSdKctPUZrAvH1L8AODHJLcCLgO8PqTcFbJ1+yMUeeCOwJsnWJF8H/mAPjyNJkiRJc7ZHtwhW1Yoh5av6trcA65rtf6Y3sZr25iHt3wK8pW9/ZfO+GdjcV76ub/tnsaraCfQ/cEOSJEmS9pq9dYugJEmSJE28VM332RPLXuc7QJIkSeqon/t+3vlaiKcILj+jurXGho0vYHwpXINx48YXLr4UrqGAg/5lePxHT1r86zNufKnGl8I1GDc+33jbvEVQkiRJklriBEuSJEmSWjKvCVaS3c1j2u9IcluSP0zS2qQtyRlJDu/bvyTJ0W0dX5IkSZLaNN/PYO2qqtUASQ4BPg48EThvtgdIsqKqdg8JnwHcDuwAqKrXzOdiJUmSJGkhtbbaVFX3AhuBN6TnjCQfmI4n+VySdc32/UnemeRG4IQk70hyU5Lbk0w17V8JrAE2Natk+yfZnGRNc4zTkmxr2lzUd577k/xxs6J2Q5JD28pRkiRJkkZp9TNYVXVXc8xDxlQ9ALi9qp5TVdcDH6iqtVX1a8D+wClVdTmwBdhQVauratd04+a2wYuAk4HVwNokL+879g1V9SzgS8BrZ548ycYkW5JsmZqamkfGkiRJkvSIhXhM+2yeJb8buKJvf32S/wI8HngycAfwVyParwU2V9UPAZJsAk4EPg38FPhcU+9m4IUzG1fVFDA9sypeN4srliRJkqQxWp1gJXkGvcnTvcBDPHqFbL++7Z9Mf+4qyX7AB4E1VXV3kvNn1B14qhGxB+uRb0/ejd/1JUmSJGkvafOJf08FLqZ3u18B24HVSR6T5Ajg+CFNpydTO5OsBF7ZF7sPOHBAmxuBk5IcnGQFcBpwXQtpSJIkSdIem+/qzv5JbgX2pbdi9VHgPU3sy8B3gW30ngR4y6ADVNW/JPnzpt524Ka+8KXAxUl2ASf0tbknyVuBa+mtZl1VVZ+ZZy6SJEmSNC955G66zqqRNxzW6PsRC+MLGV8K12DcuPGFiy+FayjgoH8ZHv/Rkxb/+owbX6rxpXANxo3PMz6b50fMSatPEZQkSZKkLuv8ClaSjc1TBTup6/mDfWD+5t/l/ME+MH/z73L+YB+Yf/v5u4LV+3LkLut6/mAfmH+3dT1/sA/Mv9u6nj/YB+bfMidYkiRJktQSJ1iSJEmS1BInWNDZe04bXc8f7APz77au5w/2gfl3W9fzB/vA/FvW+YdcSJIkSVJbXMGSJEmSpJY4wZIkSZKklkzUBCvJi5N8M8m3k5zTlD05yd8m+VbzftBs286l/VIxpA/eneTvk2xN8pdJnjTbtk35sumDYTk0sbOTVJKD59J2EvJPcmZTfkeSd82x7bLOP8nqJDckuTXJliTHz7ZtU76c8v+LJPcmub2vrDNj4JD8OzP+weA+6It1YQwcmH+HxsBBvwNdGgOPSHJtkm80/9Zvaso7MQ6OyL8z4+CwPuiL751xsKom4gWsAL4DPAN4LHAbcDTwLuCcps45wEWzbdvExrZfKq8RffAiYJ+mzkWT2gdjcjgCuBr4HnBwl/IH1gNfAB7X1DukY/lfA7ykqfNSYPMk5t9c34nAscDtfWVdGgMH5d+J8W9UHzTlEz8GjvgZ6MQYOCL/Lo2BhwHHNtsHAnfSob8FR+TfmXFwWB80+3ttHFz0jmixQ08Aru7bf2vz+iZwWF+nf3O2bZvtse2XymtUHn1lrwA2TWIfjMnhcuBZwPYhv1QTmz9wGfCCefTdcs//auBVTdlpwMcnMf++a1/Fo/+46swYOCj/GbGJHf/G9UEXxsBh+XdlDByRf6fGwBl5fQZ4YdfGwZn5zyjrxDg4qA/25jg4SbcI/iJwd9/+D5qyQ6vqHoDm/RCAJIcnuWpMW4a1X6JG5THt94HPw0T2wcAckrwM+Iequq2/clfyB44Cnp/kxiTXJVkLncr/LODdSe4G/pTegDmJ+Q/TpTFwnEke/4bq0Bg4TFfGwGHOooNjYJJVwLOBG+ngODgj/36dGQf7+2Bvj4P7zP/yl4wMKKthlatqB72l8jm3XcJG5pHkXOAhYBNMZB8MyuFxwLn0lscfpSP5F73f84OA3wDWApcleUaH8n898OaquiLJqcBH6P3f7EnLf066ln8Hxr+Bkjye7oyBw3RlDBymc2NgkpXAFcBZVfWvyaD0Jvd3YGb+feWdGQf7+4Beznt1HJykFawf0Lu3ctovATuAf0pyGEDzfu8c2jLL9kvF0DySnA6cAmyoZn1ztm1ZPn0wKIfvA08HbkuyvSm7JckvzKLtJOS/oym/snq+CjwMzPxw5yTnfzpwZVP2KWDQB7wnIf9hujQGDtSR8W+YZ9KdMXCYroyBw3RqDEyyL70/rDdV1XTenRkHh+TfqXFwQB/s9XFwkiZYNwFHJnl6kscCvwt8tnmd3tQ5nd69mLNtyyzbLxUD80jyYuAtwMuq6t/n0raJLZc+GJTDlVV1SFWtqqpV9H55jq2qf5xF20nI/7PAp4GTAZIcRe+Dmztn2RaWf/47gJOaOicD35pDW1g++Q/TpTHw53Ro/BuoqrZ1aAwc5tN0YwwcpjNjYHpLVR8BvlFV7+kLdWIcHJZ/l8bBQX2wKOPgQnygbLFe9Jb47qT3BJBzm7KnAF+kN6B8EXhyU344cNWotqPaL9XXkD74Nr17Sm9tXhdPah8My6Evvp3mg41dyZ/eHxMfA24HbgFO7lj+zwNupvc0oBuB4yY4/08A9wAP0vsPyKu7NAYOyb8z49+wPpgRn/QxcNDPQJfGwEH5d2kMfB69W7q29v3Ov3RYDpPWByPy78w4OKwPZtTZzgKPg2kaSZIkSZLmaZJuEZQkSZKkReUES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSNHGSnJvkjiRbk9ya5DlJtic5eLGvTZI02fZZ7AuQJKlNSU4ATgGOraoHmknVYxf5siRJHeEKliRp0hwG7KyqBwCqamdV7WhiZya5Jcm2JL8CkOTJST7drHbdkOSYpvz8JB9N8v8l+VaS1y5OOpKk5cQJliRp0lwDHJHkziQfTHJSX2xnVR0LfAg4uym7APhaVR0DvA34f/vqHwP8r8AJwDuSHL7wly9JWs6cYEmSJkpV3Q8cB2wEfgh8MskZTfjK5v1mYFWz/Tzgo03b/w94SpInNrHPVNWuqtoJXAscv+AJSJKWNT+DJUmaOFW1G9gMbE6yDTi9CT3QvO/mkf8GZtAhZrzPLJckaSBXsCRJEyXJLyc5sq9oNfC9EU2+BGxo2q6jdxvhvzax/y3JfkmeAqwDbmr7eiVJk8UVLEnSpFkJvD/Jk4CHgG/Tu13wlCH1zwf+nyRbgX/nkdUugK8Cfw08Dfg/+x6WIUnSQKnybgdJkmZKcj5wf1X96WJfiyRp+fAWQUmSJElqiStYkiRJktQSV7AkSZIkqSVOsCRJkiSpJT5F0O80kSRJkrpq0HchzosTLEb3ahlf1PhSuAbjxo0vXHwpXEMb8fWbh8evXbf413fB+cPj552/8O0XOz6uwlL/91vK8aVwDcaNz3uMaJm3CEqSJElSS5xgSZIkSVJLxk6wkpyb5I4kW5PcmuQ5TflZSR4/1xMmOSPJ4bOJJbkkydFzPYckSZIkLYaRE6wkJwCnAMdW1THAC4C7m/BZwJwmWElWAGcAAydYM2NV9Zqq+vpcziFJkiRJi2XcCtZhwM6qegCgqnZW1Y4kb6Q3Ebo2ybUAST6UZEuz2nXB9AGSbE/yjiTXA6cBa4BNzWrY/n31XjkzlmRzkjVN/P4kFyW5OckXkhzfxO9K8rKmzook705yU7Pi9rrWekqSJEmSxhg3wboGOCLJnUk+mOQkgKp6H7ADWF9V65u651bVGuAY4KQkx/Qd5ydV9byq+hiwBdhQVauratd0haq6fFiscQCwuaqOA+4D/gh4IfAK4J1NnVcDP66qtcBa4LVJnj4zqSQbm8nglqmpqTFdIEmSJEmzM/Ix7VV1f5LjgOcD64FPJjmnqi4dUP3UJBubYx4GHA1sbWKfbOFafwr8TbO9DXigqh5Msg1Y1ZS/CDimWQ0DeCJwJPDdGXlNAdMzq3KZS5IkSVIbxn4PVlXtBjYDm5vJzOnApf11mlWis4G1VfWjJJcC+/VV+bcWrvXBqpp+VP3DwPRtiw8nmc4jwJlVdXUL55MkSZKkORn3kItfTnJkX9Fq4HvN9n3Agc32E+hNon6c5FDgJSMO299uLrHZuBp4fZJ9AZIcleSAeRxPkiRJkmZt3ArWSuD9SZ4EPAR8G9jYxKaAzye5p6rWJ/kacAdwF/DlEce8FLg4yS7ghBmftXpUbI65AFxC73bBW5IE+CHw8j04jiRJkiTN2bjPYN0MPHdI7P3A+/v2zxhSb9WM/SuAK4bUnRlb1xdb2bd9/ox2K5v3h4G3NS9JkiRJ2qvGftGwJEmSJGl2nGBJkiRJUkvyyIP5OqvzHSBJkiR1VNo+4NjHtHfBqF4t44saXwrXYNy48YWLL4VrMD6+wkKf/1OnDo//zmULf/5TPzU8ftnvjI8v9f71d9i48dHxtnmLoCRJkiS1xAmWJEmSJLVkjyZYSXYnubXvdc4c229PcvCA8rfN2P/KnlyfJEmSJC2GPf0M1q6qWt3mhTTeBvzJ9E5VDfwOLkmSJElailq9RbBZmbogyS1JtiX5lab8KUmuSfK1JB9mwGfNklwI7N+siG1qyu5v3tcluS7JZUnuTHJhkg1Jvtqc55lNvacmuSLJTc3rN9vMT5IkSZJG2dMJ1vREaPr1qr7Yzqo6FvgQcHZTdh5wfVU9G/gs8LSZB6yqc2hWxqpqw4BzPgt4E/DrwO8BR1XV8cAlwJlNnT8D3ltVa4HfbmI/J8nGJFuSbJmamppj6pIkSZI02ELcInhl834z8FvN9onT21X110l+tAfnvKmq7gFI8h3gmqZ8G7C+2X4BcHTyswWyJyQ5sKru6z9QVU0B0zOret0eXIwkSZIkzbQQ34P1QPO+e8bx5/uY+Qf6th/u23+47zyPAU6oql3zPJckSZIkzdneekz7l4ANAEleAhw0pN6DSfadx3muAd4wvZNk9TyOJUmSJElz0tZnsC4cU/8C4MQktwAvAr4/pN4UsHX6IRd74I3AmiRbk3wd+IM9PI4kSZIkzdke3SJYVSuGlK/q294CrGu2/5nexGram4e0fwvwlr79lc37ZmBzX/m6vu2fxapqJ9D/wA1JkiRJ2mv21i2CkiRJkjTxUjXfZ08se53vAEmSJKmjfu77eedrIZ4iuOyc+qnhsct+Bz516vD471zG6H+WGhued/tx1z+u/VKOL4VrMG7c+MLFl8I1GDdufM/jS+EajBufb7xt3iIoSZIkSS1xgiVJkiRJLZnXBCvJ7uYx7XckuS3JHyZpbdKW5Iwkh/ftX5Lk6LaOL0mSJEltmu9nsHZV1WqAJIcAHweeCJw32wMkWVFVu4eEzwBuB3YAVNVr5nOxkiRJkrSQWlttqqp7gY3AG9JzRpIPTMeTfC7Jumb7/iTvTHIjcEKSdyS5KcntSaaa9q8E1gCbmlWy/ZNsTrKmOcZpSbY1bS7qO8/9Sf64WVG7IcmhbeUoSZIkSaO0+hmsqrqrOeYhY6oeANxeVc+pquuBD1TV2qr6NWB/4JSquhzYAmyoqtVVtWu6cXPb4EXAycBqYG2Sl/cd+4aqehbwJeC1M0+eZGOSLUm2TE1NzSNjSZIkSXrEQjzkYjbPkt8NXNG3vz7JjUm20Zs0/eqY9muBzVX1w6p6CNgEnNjEfgp8rtm+GVg1s3FVTVXVmqpas3HjxllcriRJkiSN1+r3YCV5Br3J073AQzx6Ardf3/ZPpj93lWQ/4IPAmqq6O8n5M+oOPNWI2IP1yLcn78bv+pIkSZK0l7T5xL+nAhfTu92vgO3A6iSPSXIEcPyQptOTqZ1JVgKv7IvdBxw4oM2NwElJDk6yAjgNuK6FNCRJkiRpj813dWf/JLcC+9Jbsfoo8J4m9mXgu8A2ek8CvGXQAarqX5L8eVNvO3BTX/hS4OIku4AT+trck+StwLX0VrOuqqrPzDMXSZIkSZqXeU2wqmrFiFgBG4bEVs7Yfzvw9gH1ruDRn9Va1xf7OL3Hwg89dvOgjMuHJiBJkiRJLVqIh1xIkiRJUic5wZIkSZKkluSRB+51U5KNVdXZL8Pqev5gH5i/+Xc5f7APzN/8u5w/2Afm337+rmBB178Iq+v5g31g/t3W9fzBPjD/but6/mAfmH/LnGBJkiRJUkucYEmSJElSS5xgQWfvOW10PX+wD8y/27qeP9gH5t9tXc8f7APzb1nnH3IhSZIkSW1xBUuSJEmSWjJRE6wkL07yzSTfTnJOU/bkJH+b5FvN+0GzbTuX9kvFkD54d5K/T7I1yV8medJs2zbly6YPhuXQxM5OUkkOnkvbScg/yZlN+R1J3jXHtss6/ySrk9yQ5NYkW5IcP9u2Tflyyv8vktyb5Pa+ss6MgUPy78z4B4P7oC/WhTFwYP4dGgMH/Q50aQw8Ism1Sb7R/Fu/qSnvxDg4Iv/OjIPD+qAvvnfGwaqaiBewAvgO8AzgscBtwNHAu4BzmjrnABfNtm0TG9t+qbxG9MGLgH2aOhdNah+MyeEI4Grge8DBXcofWA98AXhcU++QjuV/DfCSps5Lgc2TmH9zfScCxwK395V1aQwclH8nxr9RfdCUT/wYOOJnoBNj4Ij8uzQGHgYc22wfCNxJh/4WHJF/Z8bBYX3Q7O+1cXDRO6LFDj0BuLpv/63N65vAYX2d/s3Ztm22x7ZfKq9RefSVvQLYNIl9MCaHy4FnAduH/FJNbP7AZcAL5tF3yz3/q4FXNWWnAR+fxPz7rn0Vj/7jqjNj4KD8Z8Qmdvwb1wddGAOH5d+VMXBE/p0aA2fk9RnghV0bB2fmP6OsE+PgoD7Ym+PgJN0i+IvA3X37P2jKDq2qewCa90MAkhye5KoxbRnWfokalce03wc+DxPZBwNzSPIy4B+q6rb+yl3JHzgKeH6SG5Ncl2QtdCr/s4B3J7kb+FN6A+Yk5j9Ml8bAcSZ5/BuqQ2PgMF0ZA4c5iw6OgUlWAc8GbqSD4+CM/Pt1Zhzs74O9PQ7uM//LXzIyoKyGVa6qHfSWyufcdgkbmUeSc4GHgE0wkX0wKIfHAefSWx5/lI7kX/R+zw8CfgNYC1yW5Bkdyv/1wJur6ookpwIfofd/syct/znpWv4dGP8GSvJ4ujMGDtOVMXCYzo2BSVYCVwBnVdW/JoPSm9zfgZn595V3Zhzs7wN6Oe/VcXCSVrB+QO/eymm/BOwA/inJYQDN+71zaMss2y8VQ/NIcjpwCrChmvXN2bZl+fTBoBy+DzwduC3J9qbsliS/MIu2k5D/jqb8yur5KvAwMPPDnZOc/+nAlU3Zp4BBH/CehPyH6dIYOFBHxr9hnkl3xsBhujIGDtOpMTDJvvT+sN5UVdN5d2YcHJJ/p8bBAX2w18fBSZpg3QQcmeTpSR4L/C7w2eZ1elPndHr3Ys62LbNsv1QMzCPJi4G3AC+rqn+fS9smtlz6YFAOV1bVIVW1qqpW0fvlObaq/nEWbSch/88CnwZOBkhyFL0Pbu6cZVtY/vnvAE5q6pwMfGsObWH55D9Ml8bAn9Oh8W+gqtrWoTFwmE/TjTFwmM6MgektVX0E+EZVvacv1IlxcFj+XRoHB/XBooyDC/GBssV60Vviu5PeE0DObcqeAnyR3oDyReDJTfnhwFWj2o5qv1RfQ/rg2/TuKb21eV08qX0wLIe++HaaDzZ2JX96f0x8DLgduAU4uWP5Pw+4md7TgG4Ejpvg/D8B3AM8SO8/IK/u0hg4JP/OjH/D+mBGfNLHwEE/A10aAwfl36Ux8Hn0buna2vc7/9JhOUxaH4zIvzPj4LA+mFFnOws8DqZpJEmSJEmap0m6RVCSJEmSFpUTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJ0pKWZHeSW/te5wyosy7J51o+77okz+3b/4Mk/7nNc0iSJs8+i30BkiSNsauqVi/CedcB9wNfAaiqixfhGiRJy4wrWJKkZSnJi5P8fZLrgd/qKz8/ydl9+7cnWdVs/+ckW5PcluSjTdl/SnJjkq8l+UKSQ5v6fwC8uVk1e37/cZOsTnJDc6y/THJQU745yUVJvprkziTP32sdIklaEpxgSZKWuv1n3CL4qiT7AX8O/Cfg+cAvjDtIkl8FzgVOrqpnAW9qQtcDv1FVzwb+G/Bfqmo7cDHw3qpaXVX/fcbh/l/gLVV1DLANOK8vtk9VHQ+cNaNcktQB3iIoSVrqfu4WwSSrge9W1bea/Y8BG8cc52Tg8qraCVBV/6Mp/yXgk0kOAx4LfHfUQZI8EXhSVV3XFP1X4FN9Va5s3m8GVo25JknShHEFS5K0XNWQ8od49H/f9mveM6TN+4EPVNWvA6/rq7+nHmjed+P/yJSkznGCJUlajv4eeHqSZzb7p/XFtgPHAiQ5Fnh6U/5F4NQkT2liT27Knwj8Q7N9et9x7gMOnHniqvox8KO+z1f9HnDdzHqSpG5ygiVJWupmfgbrwqr6Cb1bAv+6ecjF9/rqXwE8OcmtwOuBOwGq6g7gj4HrktwGvKepfz7wqST/HdjZd5y/Al4x/ZCLGdd0OvDuJFuB1cA720tXkrScpWrYHRaSJEmSpLlwBUuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuL3cwz/HhVJkiRJky1tH9AJFozu1hobNr6A8aVwDcaNzzc+3wMs9vX7O27cuPFRFvsajBuf93+nW+YtgpIkSZLUEidYkiRJktQSJ1iSJEmS1JKxE6wk5ya5I8nWJLcmeU5TflaSx8/1hEnOSHL4bGJJLkly9FzPIUmSJEmLYeQEK8kJwCnAsVV1DPAC4O4mfBYwpwlWkhXAGcDACdbMWFW9pqq+PpdzSJIkSdJiGbeCdRiws6oeAKiqnVW1I8kb6U2Erk1yLUCSDyXZ0qx2XTB9gCTbk7wjyfXAacAaYFOzGrZ/X71Xzowl2ZxkTRO/P8lFSW5O8oUkxzfxu5K8rKmzIsm7k9zUrLi9rrWekiRJkqQxxk2wrgGOSHJnkg8mOQmgqt4H7ADWV9X6pu65VbUGOAY4Kckxfcf5SVU9r6o+BmwBNlTV6qraNV2hqi4fFmscAGyuquOA+4A/Al4IvAJ4Z1Pn1cCPq2otsBZ4bZKnz0wqycZmMrhlampqTBdIkiRJ0uyM/B6sqro/yXHA84H1wCeTnFNVlw6ofmqSjc0xDwOOBrY2sU+2cK0/Bf6m2d4GPFBVDybZBqxqyl8EHNOshgE8ETgS+O6MvKaA6ZlV4TqXJEmSpBaM/aLhqtoNbAY2N5OZ04FL++s0q0RnA2ur6kdJLgX266vyby1c64NVNf1dYA8D07ctPpxkOo8AZ1bV1S2cT5IkSZLmZNxDLn45yZF9RauB7zXb9wEHNttPoDeJ+nGSQ4GXjDhsf7u5xGbjauD1SfYFSHJUkgPmcTxJkiRJmrVxK1grgfcneRLwEPBtYGMTmwI+n+Seqlqf5GvAHcBdwJdHHPNS4OIku4ATZnzW6lGxOeYCcAm92wVvSRLgh8DL9+A4kiRJkjRneeSuu84qMjI6Lmx8AeNL4RqMG59vfL4HWOzr93fcuHHjoyz2NRg3voD/md0jY79oWJIkSZI0O65gNf+DWZIkSVLntL6CNfYpgl2wxJctOx1fCtdg3LjxhYsvhWswvvTjXb6NdqnHl8I1GDc+7zGmZd4iKEmSJEktcYIlSZIkSS3ZowlWkt1Jbu17nTPH9tuTHDyg/G0z9r+yJ9cnSZIkSYthTz+DtauqVrd5IY23AX8yvVNVz12Ac0iSJEnSgmj1FsFmZeqCJLck2ZbkV5rypyS5JsnXknyYAZ81S3IhsH+zIrapKbu/eV+X5LoklyW5M8mFSTYk+Wpznmc29Z6a5IokNzWv32wzP0mSJEkaZU8nWNMToenXq/piO6vqWOBDwNlN2XnA9VX1bOCzwNNmHrCqzqFZGauqDQPO+SzgTcCvA78HHFVVxwOXAGc2df4MeG9VrQV+u4n9nCQbk2xJsmVqamqOqUuSJEnSYAtxi+CVzfvNwG812ydOb1fVXyf50R6c86aqugcgyXeAa5rybcD6ZvsFwNHJzxbInpDkwKq6r/9AVTUFTM+s6nV7cDGSJEmSNNNCfA/WA8377hnHn+9j5h/o2364b//hvvM8BjihqnbN81ySJEmSNGd76zHtXwI2ACR5CXDQkHoPJtl3Hue5BnjD9E6S1fM4liRJkiTNSVufwbpwTP0LgBOT3AK8CPj+kHpTwNbph1zsgTcCa5JsTfJ14A/28DiSJEmSNGepmu+de8te/dwjDfuDDHjkofG9Fl8K12DcuPGFiy+FazC+9OPjKiz29XU5vhSuwbjxecbH/YjP2d66RVCSJEmSJp4rWPN/+IYkSZKk5an1FayFeIrgsrPEly07HV8K12B8fIXFvj7jyze+FK7B+NKPX3D+8Ph55y/+9XU5vhSuwbjxef+d0zJvEZQkSZKkljjBkiRJkqSWzGuClWR385j2O5LcluQPk7Q2aUtyRpLD+/YvSXJ0W8eXJEmSpDbN9zNYu6pqNUCSQ4CPA08EzpvtAZKsqKrdQ8JnALcDOwCq6jXzuVhJkiRJWkitrTZV1b3ARuAN6TkjyQem40k+l2Rds31/kncmuRE4Ick7ktyU5PYkU037VwJrgE3NKtn+STYnWdMc47Qk25o2F/Wd5/4kf9ysqN2Q5NC2cpQkSZKkUVr9DFZV3dUc85AxVQ8Abq+q51TV9cAHqmptVf0asD9wSlVdDmwBNlTV6qraNd24uW3wIuBkYDWwNsnL+459Q1U9C/gS8NqZJ0+yMcmWJFumpqbmkbEkSZIkPWIhHtM+m2fJ7wau6Ntfn+S/AI8HngzcAfzViPZrgc1V9UOAJJuAE4FPAz8FPtfUuxl44czGVTUFTM+s6nWzuGBJkiRJGqfVCVaSZ9CbPN0LPMSjV8j269v+yfTnrpLsB3wQWFNVdyc5f0bdgacaEXuwHvn25N34XV+SJEmS9pI2n/j3VOBierf7FbAdWJ3kMUmOAI4f0nR6MrUzyUrglX2x+4ADB7S5ETgpycFJVgCnAde1kIYkSZIk7bH5ru7sn+RWYF96K1YfBd7TxL4MfBfYRu9JgLcMOkBV/UuSP2/qbQdu6gtfClycZBdwQl+be5K8FbiW3mrWVVX1mXnmIkmSJEnzkkfupuusGnW/YTH6fkTjCxtfCtdgfHyFxb4+48s3vhSuwfjSj19w/vD4eecv/vV1Ob4UrsG48XnGZ/P8iDlp9SmCkiRJktRlTrAkSZIkqSWdv0Uwycbmse2d1PX8wT4wf/Pvcv5gH5i/+Xc5f7APzL/9/F3Bgo2LfQGLrOv5g31g/t3W9fzBPjD/but6/mAfmH/LnGBJkiRJUkucYEmSJElSS5xgQWfvOW10PX+wD8y/27qeP9gH5t9tXc8f7APzb1nnH3IhSZIkSW1xBUuSJEmSWuIES5IkSZJaMlETrCQvTvLNJN9Ock5T9uQkf5vkW837QbNtO5f2S8WQPnh3kr9PsjXJXyZ50mzbNuXLpg+G5dDEzk5SSQ6eS9tJyD/JmU35HUneNce2yzr/JKuT3JDk1iRbkhw/27ZN+XLK/y+S3Jvk9r6yzoyBQ/LvzPgHg/ugL9aFMXBg/h0aAwf9DnRpDDwiybVJvtH8W7+pKe/EODgi/86Mg8P6oC++d8bBqpqIF7AC+A7wDOCxwG3A0cC7gHOaOucAF822bRMb236pvEb0wYuAfZo6F01qH4zJ4QjgauB7wMFdyh9YD3wBeFxT75CO5X8N8JKmzkuBzZOYf3N9JwLHArf3lXVpDByUfyfGv1F90JRP/Bg44megE2PgiPy7NAYeBhzbbB8I3EmH/hYckX9nxsFhfdDs77VxcNE7osUOPQG4um//rc3rm8BhfZ3+zdm2bbbHtl8qr1F59JW9Atg0iX0wJofLgWcB24f8Uk1s/sBlwAvm0XfLPf+rgVc1ZacBH5/E/PuufRWP/uOqM2PgoPxnxCZ2/BvXB10YA4fl35UxcET+nRoDZ+T1GeCFXRsHZ+Y/o6wT4+CgPtib4+Ak3SL4i8Ddffs/aMoOrap7AJr3QwCSHJ7kqjFtGdZ+iRqVx7TfBz4PE9kHA3NI8jLgH6rqtv7KXckfOAp4fpIbk1yXZC10Kv+zgHcnuRv4U3oD5iTmP0yXxsBxJnn8G6pDY+AwXRkDhzmLDo6BSVYBzwZupIPj4Iz8+3VmHOzvg709Du4z/8tfMjKgrIZVrqod9JbK59x2CRuZR5JzgYeATTCRfTAoh8cB59JbHn+UjuRf9H7PDwJ+A1gLXJbkGR3K//XAm6vqiiSnAh+h93+zJy3/Oela/h0Y/wZK8ni6MwYO05UxcJjOjYFJVgJXAGdV1b8mg9Kb3N+Bmfn3lXdmHOzvA3o579VxcJJWsH5A797Kab8E7AD+KclhAM37vXNoyyzbLxVD80hyOnAKsKGa9c3ZtmX59MGgHL4PPB24Lcn2puyWJL8wi7aTkP+OpvzK6vkq8DAw88Odk5z/6cCVTdmngEEf8J6E/Ifp0hg4UEfGv2GeSXfGwGG6MgYO06kxMMm+9P6w3lRV03l3Zhwckn+nxsEBfbDXx8FJmmDdBByZ5OlJHgv8LvDZ5nV6U+d0evdizrYts2y/VAzMI8mLgbcAL6uqf59L2ya2XPpgUA5XVtUhVbWqqlbR++U5tqr+cRZtJyH/zwKfBk4GSHIUvQ9u7pxlW1j++e8ATmrqnAx8aw5tYfnkP0yXxsCf06Hxb6Cq2tahMXCYT9ONMXCYzoyB6S1VfQT4RlW9py/UiXFwWP5dGgcH9cGijIML8YGyxXrRW+K7k94TQM5typ4CfJHegPJF4MlN+eHAVaPajmq/VF9D+uDb9O4pvbV5XTypfTAsh774dpoPNnYlf3p/THwMuB24BTi5Y/k/D7iZ3tOAbgSOm+D8PwHcAzxI7z8gr+7SGDgk/86Mf8P6YEZ80sfAQT8DXRoDB+XfpTHwefRu6dra9zv/0mE5TFofjMi/M+PgsD6YUWc7CzwOpmkkSZIkSZqnSbpFUJIkSZIWlRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJ0sRJsjnJ/zKj7KwkdyU5Z0S7NUne12yvS/Lchb5WSdJk2WexL0CSpAXwCeB3gav7yn4XOL2q/vuwRlW1BdjS7K4D7ge+skDXKEmaQK5gSZIm0eXAKUkeB5BkFXA48B+TfKAp+50ktye5LcmXmrJ1ST7X1P8D4M1Jbk3y/EXJQpK07LiCJUmaOFX1z0m+CrwY+Ay91atPAtVX7R3A/1JV/5DkSTPab09yMXB/Vf3pXrpsSdIEcAVLkjSppm8TpHn/xIz4l4FLk7wWWLE3L0ySNLmcYEmSJtWngf85ybHA/lV1S3+wqv4AeDtwBHBrkqfs/UuUJE0abxGUJE2kqro/yWbgL/j51SuSPLOqbgRuTPKf6E20+t0HPGHBL1SSNFFcwZIkTbJPAM8C/tuA2LuTbEtyO/Al4LYZ8b8CXuFDLiRJc5GqGl9LkiRJkjSWK1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BIf0w4+5UOSJEnqprR9QCdYjO7VMr6o8aVwDcaNdz2+fvPw+LXr9s7v+LgKi91HF5w/PH7e+ePj404wrv1Sz3+xr2+pxxf653sp/A4bN76U423zFkFJkiRJaokTLEmSJElqiRMsSZIkSWrJ2AlWknOT3JFka5JbkzynKT8ryePnesIkZyQ5fDaxJJckOXqu55AkSZKkxTBygpXkBOAU4NiqOgZ4AXB3Ez4LmNMEK8kK4Axg4ARrZqyqXlNVX5/LOSRJkiRpsYxbwToM2FlVDwBU1c6q2pHkjfQmQtcmuRYgyYeSbGlWuy6YPkCS7UnekeR64DRgDbCpWQ3bv6/eK2fGkmxOsqaJ35/koiQ3J/lCkuOb+F1JXtbUWZHk3UlualbcXtdaT0mSJEnSGOMmWNcARyS5M8kHk5wEUFXvA3YA66tqfVP33KpaAxwDnJTkmL7j/KSqnldVHwO2ABuqanVV7ZquUFWXD4s1DgA2V9VxwH3AHwEvBF4BvLOp82rgx1W1FlgLvDbJ02cmlWRjMxncMjU1NaYLJEmSJGl2Rn4PVlXdn+Q44PnAeuCTSc6pqksHVD81ycbmmIcBRwNbm9gnW7jWnwJ/02xvAx6oqgeTbANWNeUvAo5pVsMAnggcCXx3Rl5TwPTMqlzmkiRJktSGsV80XFW7gc3A5mYyczpwaX+dZpXobGBtVf0oyaXAfn1V/q2Fa32wqqa/C+xhYPq2xYeTTOcR4MyqurqF80mSJEnSnIx7yMUvJzmyr2g18L1m+z7gwGb7CfQmUT9OcijwkhGH7W83l9hsXA28Psm+AEmOSnLAPI4nSZIkSbM2bgVrJfD+JE8CHgK+DWxsYlPA55PcU1Xrk3wNuAO4C/jyiGNeClycZBdwwozPWj0qNsdcAC6hd7vgLUkC/BB4+R4cR5IkSZLmbNxnsG4Gnjsk9n7g/X37Zwypt2rG/hXAFUPqzoyt64ut7Ns+f0a7lc37w8DbmpckSZIk7VVjv2hYkiRJkjQ7eeS5EZ3V+Q6QJEmSOiptH3DsUwS7YFSvlvFFjS+FazBu3PjCxds6x5qbh8e3HDe+/c1rhseP27LwffS6EV/J+OGNC99+oePj/n2mRnxfysYPL/71T3p8Pv0/fYxxJ1nsHLsen+8YOenxtnmLoCRJkiS1xAmWJEmSJLVkjyZYSXYnubXvdc4c229PcvCA8rfN2P/KnlyfJEmSJC2GPf0M1q6qWt3mhTTeBvzJ9E5VDXxEvCRJkiQtRa3eItisTF2Q5JYk25L8SlP+lCTXJPlakg8z4LNmSS4E9m9WxDY1Zfc37+uSXJfksiR3JrkwyYYkX23O88ym3lOTXJHkpub1m23mJ0mSJEmj7OkEa3oiNP16VV9sZ1UdC3wIOLspOw+4vqqeDXwWeNrMA1bVOTQrY1W1YcA5nwW8Cfh14PeAo6rqeOAS4Mymzp8B762qtcBvN7Gfk2Rjki1JtkxNjXj0kiRJkiTNwULcInhl834z8FvN9onT21X110l+tAfnvKmq7gFI8h3gmqZ8G7C+2X4BcHTyswWyJyQ5sKru6z9QVU0B0zOrGvF0UkmSJEmatYX4HqwHmvfdM44/38fMP9C3/XDf/sN953kMcEJV7ZrnuSRJkiRpzvbWY9q/BGwASPIS4KAh9R5Msu88znMN8IbpnSSr53EsSZIkSZqTtj6DdeGY+hcAJya5BXgR8P0h9aaArdMPudgDbwTWJNma5OvAH+zhcSRJkiRpzvboFsGqWjGkfFXf9hZgXbP9z/QmVtPePKT9W4C39O2vbN43A5v7ytf1bf8sVlU7gf4HbkiSJEnSXrO3bhGUJEmSpImXqvk+e2LZ63wHSJIkSR31c9/PO18L8RTBZeelnx8eu+ol4+Mj/1kK3vj+4eH3nTm2OUd+e3j8W/9xfPv5xsflv5Dnb+MYeyO+2P9G73/j8PiZ71v8/jFufJTFvgbjxo3veXwpXINx4/ONt81bBCVJkiSpJU6wJEmSJKkl85pgJdndPKb9jiS3JfnDJK1N2pKckeTwvv1Lkhzd1vElSZIkqU3z/QzWrqpaDZDkEODjwBOB82Z7gCQrqmr3kPAZwO3ADoCqes18LlaSJEmSFlJrq01VdS+wEXhDes5I8oHpeJLPJVnXbN+f5J1JbgROSPKOJDcluT3JVNP+lcAaYFOzSrZ/ks1J1jTHOC3JtqbNRX3nuT/JHzcrajckObStHCVJkiRplFY/g1VVdzXHPGRM1QOA26vqOVV1PfCBqlpbVb8G7A+cUlWXA1uADVW1uqp2TTdubhu8CDgZWA2sTfLyvmPfUFXPAr4EvHbmyZNsTLIlyZapqal5ZCxJkiRJj1iIh1zM5lnyu4Er+vbXJ7kxyTZ6k6ZfHdN+LbC5qn5YVQ8Bm4ATm9hPgc812zcDq2Y2rqqpqlpTVWs2btw4i8uVJEmSpPFa/R6sJM+gN3m6F3iIR0/g9uvb/sn0566S7Ad8EFhTVXcnOX9G3YGnGhF7sB759uTd+F1fkiRJkvaSNp/491TgYnq3+xWwHVid5DFJjgCOH9J0ejK1M8lK4JV9sfuAAwe0uRE4KcnBSVYApwHXtZCGJEmSJO2x+a7u7J/kVmBfeitWHwXe08S+DHwX2EbvSYC3DDpAVf1Lkj9v6m0HbuoLXwpcnGQXcEJfm3uSvBW4lt5q1lVV9Zl55iJJkiRJ8zKvCVZVrRgRK2DDkNjKGftvB94+oN4VPPqzWuv6Yh+n91j4ocduHpRx+dAEJEmSJKlFC/GQC0mSJEnqJCdYkiRJktSSPPLAvW5KsrGqOvtlWF3PH+wD8zf/LucP9oH5m3+X8wf7wPzbz98VLOj6F2F1PX+wD8y/27qeP9gH5t9tXc8f7APzb5kTLEmSJElqiRMsSZIkSWqJEyzo7D2nja7nD/aB+Xdb1/MH+8D8u63r+YN9YP4t6/xDLiRJkiSpLa5gSZIkSVJLnGBJkiRJUksmaoKV5MVJvpnk20nOacqenORvk3yreT9otm3n0n6pGNIH707y90m2JvnLJE+abdumfNn0wbAcmtjZSSrJwXNpOwn5JzmzKb8jybvm2HZZ559kdZIbktyaZEuS42fbtilfTvn/RZJ7k9zeV9aZMXBI/p0Z/2BwH/TFujAGDsy/Q2PgoN+BLo2BRyS5Nsk3mn/rNzXlnRgHR+TfmXFwWB/0xffOOFhVE/ECVgDfAZ4BPBa4DTgaeBdwTlPnHOCi2bZtYmPbL5XXiD54EbBPU+eiSe2DMTkcAVwNfA84uEv5A+uBLwCPa+od0rH8rwFe0tR5KbB5EvNvru9E4Fjg9r6yLo2Bg/LvxPg3qg+a8okfA0f8DHRiDByRf5fGwMOAY5vtA4E76dDfgiPy78w4OKwPmv29Ng4ueke02KEnAFf37b+1eX0TOKyv078527bN9tj2S+U1Ko++slcAmyaxD8bkcDnwLGD7kF+qic0fuAx4wTz6brnnfzXwqqbsNODjk5h/37Wv4tF/XHVmDByU/4zYxI5/4/qgC2PgsPy7MgaOyL9TY+CMvD4DvLBr4+DM/GeUdWIcHNQHe3McnKRbBH8RuLtv/wdN2aFVdQ9A834IQJLDk1w1pi3D2i9Ro/KY9vvA52Ei+2BgDkleBvxDVd3WX7kr+QNHAc9PcmOS65KshU7lfxbw7iR3A39Kb8CcxPyH6dIYOM4kj39DdWgMHKYrY+AwZ9HBMTDJKuDZwI10cByckX+/zoyD/X2wt8fBfeZ/+UtGBpTVsMpVtYPeUvmc2y5hI/NIci7wELAJJrIPBuXwOOBcesvjj9KR/Ive7/lBwG8Aa4HLkjyjQ/m/HnhzVV2R5FTgI/T+b/ak5T8nXcu/A+PfQEkeT3fGwGG6MgYO07kxMMlK4ArgrKr612RQepP7OzAz/77yzoyD/X1AL+e9Og5O0grWD+jdWzntl4AdwD8lOQygeb93Dm2ZZfulYmgeSU4HTgE2VLO+Odu2LJ8+GJTD94GnA7cl2d6U3ZLkF2bRdhLy39GUX1k9XwUeBmZ+uHOS8z8duLIp+xQw6APek5D/MF0aAwfqyPg3zDPpzhg4TFfGwGE6NQYm2ZfeH9abqmo6786Mg0Py79Q4OKAP9vo4OEkTrJuAI5M8Pcljgd8FPtu8Tm/qnE7vXszZtmWW7ZeKgXkkeTHwFuBlVfXvc2nbxJZLHwzK4cqqOqSqVlXVKnq/PMdW1T/Oou0k5P9Z4NPAyQBJjqL3wc2ds2wLyz//HcBJTZ2TgW/NoS0sn/yH6dIY+HM6NP4NVFXbOjQGDvNpujEGDtOZMTC9paqPAN+oqvf0hToxDg7Lv0vj4KA+WJRxcCE+ULZYL3pLfHfSewLIuU3ZU4Av0htQvgg8uSk/HLhqVNtR7Zfqa0gffJvePaW3Nq+LJ7UPhuXQF99O88HGruRP74+JjwG3A7cAJ3cs/+cBN9N7GtCNwHETnP8ngHuAB+n9B+TVXRoDh+TfmfFvWB/MiE/6GDjoZ6BLY+Cg/Ls0Bj6P3i1dW/t+5186LIdJ64MR+XdmHBzWBzPqbGeBx8E0jSRJkiRJ8zRJtwhKkiRJ0qJygiVJkiRJLXGCJUmSJEktcYIlSZIkSS1xgiVJkiRJLXGCJUmSJEktcYIlSZIkSS1xgiVJkiRJLXGCJUmSJEktcYIlSZIkSS1xgiVJkiRJLXGCJUmaCEnun7F/RpIPLNb1SJK6yQmWJEmSJLXECZYkaeIl+Q9Jvphka/P+tKb80iQfSnJtkruSnJTkL5J8I8mlfe1flOTvktyS5FNJVi5aMpKkJc0JliRpUuyf5NbpF/DOvtgHgP+3qo4BNgHv64sdBJwMvBn4K+C9wK8Cv55kdZKDgbcDL6iqY4EtwB8ueDaSpGVpn8W+AEmSWrKrqlZP7yQ5A1jT7J4A/Faz/VHgXX3t/qqqKsk24J+qalvT/g5gFfBLwNHAl5MAPBb4uwXLQpK0rDnBkiR1UfVtP9C8P9y3Pb2/D7Ab+NuqOm0vXZskaRnzFkFJUhd8BfjdZnsDcP0c2t4A/GaS/wiQ5PFJjmr5+iRJE8IJliSpC94I/B9JtgK/B7xptg2r6ofAGcAnmvY3AL+yEBcpSVr+UlXja0mSJEmSxnIFS5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4vdgPfq7UCRJkiR1R9o+oBMsGN2tNTZsfAHjS+EaJiH+xH8dHv/xE2C/B4bHf/K4xb/+rscn+d9nb13DuD5c6n281K9vvtc/boz6za8Mj3/5ubDm5uHxLcct/PUt9PHn++8/3/M/7e4RJwC+f8ToOt8/An7tjuHx23918X9Gl3p8vj8D/h0wOt42bxGUJEmSpJY4wZIkSZKkljjBkiRJkqSWjJ1gJTk3yR1Jtia5NclzmvKzkjx+ridMckaSw2cTS3JJkqPneg5JkiRJWgwjJ1hJTgBOAY6tqmOAFwDTH2M8C5jTBCvJCuAMYOAEa2asql5TVV+fyzkkSZIkabGMW8E6DNhZVQ8AVNXOqtqR5I30JkLXJrkWIMmHkmxpVrsumD5Aku1J3pHkeuA0YA2wqVkN27+v3itnxpJsTrKmid+f5KIkNyf5QpLjm/hdSV7W1FmR5N1JbmpW3F7XWk9JkiRJ0hjjJljXAEckuTPJB5OcBFBV7wN2AOuran1T99yqWgMcA5yU5Ji+4/ykqp5XVR8DtgAbqmp1Ve2arlBVlw+LNQ4ANlfVccB9wB8BLwReAbyzqfNq4MdVtRZYC7w2ydNnJpVkYzMZ3DI1NTWmCyRJkiRpdkZ+D1ZV3Z/kOOD5wHrgk0nOqapLB1Q/NcnG5piHAUcDW5vYJ1u41p8Cf9NsbwMeqKoHk2wDVjXlLwKOaVbDAJ4IHAl8d0ZeU8D0zKpwnUuSJElSC8Z+0XBV7QY2A5ubyczpwKX9dZpVorOBtVX1oySXAvv1Vfm3Fq71waqa/i6wh4Hp2xYfTjKdR4Azq+rqFs4nSZIkSXMy7iEXv5zkyL6i1cD3mu37gAOb7SfQm0T9OMmhwEtGHLa/3Vxis3E18Pok+wIkOSrJAfM4niRJkiTN2rgVrJXA+5M8CXgI+DawsYlNAZ9Pck9VrU/yNeAO4C7gyyOOeSlwcZJdwAkzPmv1qNgccwG4hN7tgrckCfBD4OV7cBxJkiRJmrNxn8G6GXjukNj7gff37Z8xpN6qGftXAFcMqTsztq4vtrJv+/wZ7VY27w8Db2tekiRJkrRXjf2iYUmSJEnS7OSR50Z0Vuc7QJIkSeqotH3AsU8R7IRR3Vpjw8YXML4UrsH44seP+tbw+J1HLv3z/4fvD49/72nj2+/3wPD4Tx639Nu38Ts+3z6cb47jzv+kHw+P/8sTF/76x51/XH7z/Tced/6F/h1d7N+xpd4/8/35GNV++hiL/d+JhY4v9M/IQl/fYv8MLvV427xFUJIkSZJa4gRLkiRJklqyRxOsJLuT3Nr3OmeO7bcnOXhA+dtm7H9lT65PkiRJkhbDnn4Ga1dVrW7zQhpvA/5keqeqBj4iXpIkSZKWolZvEWxWpi5IckuSbUl+pSl/SpJrknwtyYcZ8FmzJBcC+zcrYpuasvub93VJrktyWZI7k1yYZEOSrzbneWZT76lJrkhyU/P6zTbzkyRJkqRR9nSCNT0Rmn69qi+2s6qOBT4EnN2UnQdcX1XPBj4LPG3mAavqHJqVsaraMOCczwLeBPw68HvAUVV1PHAJcGZT58+A91bVWuC3m9jPSbIxyZYkW6ampuaYuiRJkiQNthC3CF7ZvN8M/FazfeL0dlX9dZIf7cE5b6qqewCSfAe4pinfBqxvtl8AHJ38bIHsCUkOrKr7+g9UVVPA9MyqeN0eXI0kSZIkzbAQ34M1/ST+3TOOP9/HzPc/4f/hvv2H+87zGOCEqto1z3NJkiRJ0pztrce0fwnYAJDkJcBBQ+o9mGTfeZznGuAN0ztJVs/jWJIkSZI0J219BuvCMfUvAE5McgvwImDYd65PAVunH3KxB94IrEmyNcnXgT/Yw+NIkiRJ0pzt0S2CVbViSPmqvu0twLpm+5/pTaymvXlI+7cAb+nbX9m8bwY295Wv69v+WayqdgL9D9yQJEmSpL1mb90iKEmSJEkTL1XzffbEstf5DpAkSZI66ue+n3e+FuIpgsvOH753eOw9bx7d68X840f8YHj87l8a3/7UTw2PX/Y74+Mn3DA8/ne/Mf76FjI+XWeh/w0W+t9oXPxTpw6P/85l439Gx8XH/RuPu775tp/vz8h7/3B4/M3vWfh/n3EV5vvvt9j9v5jtZ3uM+fbhuBzG9fF8x9Fx7ef7M7rQ4/hij8HLfYyf5PhSuAbjxuf93/mWeYugJEmSJLXECZYkSZIktWReE6wku5vHtN+R5LYkf5iktUlbkjOSHN63f0mSo9s6viRJkiS1ab6fwdpVVasBkhwCfBx4InDebA+QZEVV7R4SPgO4HdgBUFWvmc/FSpIkSdJCam21qaruBTYCb0jPGUk+MB1P8rkk65rt+5O8M8mNwAlJ3pHkpiS3J5lq2r8SWANsalbJ9k+yOcma5hinJdnWtLmo7zz3J/njZkXthiSHtpWjJEmSJI3S6mewququ5piHjKl6AHB7VT2nqq4HPlBVa6vq14D9gVOq6nJgC7ChqlZX1a7pxs1tgxcBJwOrgbVJXt537Buq6lnAl4DXzjx5ko1JtiTZMjU1NY+MJUmSJOkRC/GQi9k8S343cEXf/vokNybZRm/S9Ktj2q8FNlfVD6vqIWATcGIT+ynwuWb7ZmDVzMZVNVVVa6pqzcaNG2dxuZIkSZI0Xqvfg5XkGfQmT/cCD/HoCdx+fds/mf7cVZL9gA8Ca6rq7iTnz6g78FQjYg/WI9+evBu/60uSJEnSXtLmE/+eClxM73a/ArYDq5M8JskRwPFDmk5PpnYmWQm8si92H3DggDY3AiclOTjJCuA04LoW0pAkSZKkPTbf1Z39k9wK7EtvxeqjwHua2JeB7wLb6D0J8JZBB6iqf0ny50297cBNfeFLgYuT7AJO6GtzT5K3AtfSW826qqo+M89cJEmSJGle5jXBqqoVI2IFbBgSWzlj/+3A2wfUu4JHf1ZrXV/s4/QeCz/02M2DMi4fmoAkSZIktWghHnIhSZIkSZ3kBEuSJEmSWpJHHrjXTUk2VlVnvwyr6/mDfWD+5t/l/ME+MH/z73L+YB+Yf/v5u4IFXf8irK7nD/aB+Xdb1/MH+8D8u63r+YN9YP4tc4IlSZIkSS1xgiVJkiRJLXGCBZ2957TR9fzBPjD/but6/mAfmH+3dT1/sA/Mv2Wdf8iFJEmSJLXFFSxJkiRJaokTLEmSJElqyURNsJK8OMk3k3w7yTlN2ZOT/G2SbzXvB8227VzaLxVD+uDdSf4+ydYkf5nkSbNt25Qvmz4YlkMTOztJJTl4Lm0nIf8kZzbldyR51xzbLuv8k6xOckOSW5NsSXL8bNs25csp/79Icm+S2/vKOjMGDsm/M+MfDO6DvlgXxsCB+XdoDBz0O9ClMfCIJNcm+Ubzb/2mprwT4+CI/DszDg7rg7743hkHq2oiXsAK4DvAM4DHArcBRwPvAs5p6pwDXDTbtk1sbPul8hrRBy8C9mnqXDSpfTAmhyOAq4HvAQd3KX9gPfAF4HFNvUM6lv81wEuaOi8FNk9i/s31nQgcC9zeV9alMXBQ/p0Y/0b1QVM+8WPgiJ+BToyBI/Lv0hh4GHBss30gcCcd+ltwRP6dGQeH9UGzv9fGwUXviBY79ATg6r79tzavbwKH9XX6N2fbttke236pvEbl0Vf2CmDTJPbBmBwuB54FbB/ySzWx+QOXAS+YR98t9/yvBl7VlJ0GfHwS8++79lU8+o+rzoyBg/KfEZvY8W9cH3RhDByWf1fGwBH5d2oMnJHXZ4AXdm0cnJn/jLJOjIOD+mBvjoOTdIvgLwJ39+3/oCk7tKruAWjeDwFIcniSq8a0ZVj7JWpUHtN+H/g8TGQfDMwhycuAf6iq2/ordyV/4Cjg+UluTHJdkrXQqfzPAt6d5G7gT+kNmJOY/zBdGgPHmeTxb6gOjYHDdGUMHOYsOjgGJlkFPBu4kQ6OgzPy79eZcbC/D/b2OLjP/C9/yciAshpWuap20Fsqn3PbJWxkHknOBR4CNsFE9sGgHB4HnEtvefxROpJ/0fs9Pwj4DWAtcFmSZ3Qo/9cDb66qK5KcCnyE3v/NnrT856Rr+Xdg/BsoyePpzhg4TFfGwGE6NwYmWQlcAZxVVf+aDEpvcn8HZubfV96ZcbC/D+jlvFfHwUlawfoBvXsrp/0SsAP4pySHATTv986hLbNsv1QMzSPJ6cApwIZq1jdn25bl0weDcvg+8HTgtiTbm7JbkvzCLNpOQv47mvIrq+erwMPAzA93TnL+pwNXNmWfAgZ9wHsS8h+mS2PgQB0Z/4Z5Jt0ZA4fpyhg4TKfGwCT70vvDelNVTefdmXFwSP6dGgcH9MFeHwcnaYJ1E3BkkqcneSzwu8Bnm9fpTZ3T6d2LOdu2zLL9UjEwjyQvBt4CvKyq/n0ubZvYcumDQTlcWVWHVNWqqlpF75fn2Kr6x1m0nYT8Pwt8GjgZIMlR9D64uXOWbWH5578DOKmpczLwrTm0heWT/zBdGgN/TofGv4GqaluHxsBhPk03xsBhOjMGprdU9RHgG1X1nr5QJ8bBYfl3aRwc1AeLMg4uxAfKFutFb4nvTnpPADm3KXsK8EV6A8oXgSc35YcDV41qO6r9Un0N6YNv07un9NbmdfGk9sGwHPri22k+2NiV/On9MfEx4HbgFuDkjuX/POBmek8DuhE4boLz/wRwD/Agvf+AvLpLY+CQ/Dsz/g3rgxnxSR8DB/0MdGkMHJR/l8bA59G7pWtr3+/8S4flMGl9MCL/zoyDw/pgRp3tLPA4mKaRJEmSJGmeJukWQUmSJElaVE6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSRMjyS8l+UySbyX5TpI/S/LYJKuTvLSv3vlJzl7Ma5UkTSYnWJKkiZAkwJXAp6vqSOAoYCXwx8Bq4KXDW8/5XCvaOpYkabI4wZIkTYqTgZ9U1f8DUFW7gTcDrwHeBbwqya1JXtXUPzrJ5iR3JXnj9EGS/O9JvtrU/fD0ZCrJ/UnemeRG4IS9mpkkadlwgiVJmhS/CtzcX1BV/wpsB/4I+GRVra6qTzbhXwH+F+B44Lwk+yb5n4BXAb9ZVauB3cCGpv4BwO1V9Zyqun6hk5EkLU/7LPYFSJLUkgA1h/K/rqoHgAeS3AscCvzPwHHATb07DtkfuLepvxu4ou2LliRNFidYkqRJcQfw2/0FSZ4AHEFvcjTTA33bu+n9NzHAf62qtw6o/5PmtkNJkobyFkFJ0qT4IvD4JP8ZfvYgiv8buBT4J+DAWR7jlUkOaY7x5CT/YWEuV5I0iZxgSZImQlUV8Argd5J8C7gT+AnwNuBaeg+16H/IxaBjfB14O3BNkq3A3wKHLfjFS5ImRnr/PZIkSZIkzZcrWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEr8Ha/CXT0qSJEmafGn7gE6wGN2rZXxR40vhGowbN75w8aVwDbOJj6uw1I9/wfnD4+edPz6+2P1vfOnGl8I17I34+s3D49euW/rHNz463jZvEZQkSZKkljjBkiRJkqSWOMGSJEmSpJaMnWAlOTfJHUm2Jrk1yXOa8rOSPH6uJ0xyRpLDZxNLckmSo+d6DkmSJElaDCMnWElOAE4Bjq2qY4AXAHc34bOAOU2wkqwAzgAGTrBmxqrqNVX19bmcQ5IkSZIWy7gVrMOAnVX1AEBV7ayqHUneSG8idG2SawGSfCjJlma164LpAyTZnuQdSa4HTgPWAJua1bD9++q9cmYsyeYka5r4/UkuSnJzki8kOb6J35XkZU2dFUneneSmZsXtda31lCRJkiSNMW6CdQ1wRJI7k3wwyUkAVfU+YAewvqrWN3XPrao1wDHASUmO6TvOT6rqeVX1MWALsKGqVlfVrukKVXX5sFjjAGBzVR0H3Af8EfBC4BXAO5s6rwZ+XFVrgbXAa5M8fWZSSTY2k8EtU1NTY7pAkiRJkmZn5PdgVdX9SY4Dng+sBz6Z5JyqunRA9VOTbGyOeRhwNLC1iX2yhWv9KfA3zfY24IGqejDJNmBVU/4i4JhmNQzgicCRwHdn5DUFTM+symUuSZIkSW0Y+0XDVbUb2AxsbiYzpwOX9tdpVonOBtZW1Y+SXArs11fl31q41geravq7wB4Gpm9bfDjJdB4Bzqyqq1s4nyRJkiTNybiHXPxykiP7ilYD32u27wMObLafQG8S9eMkhwIvGXHY/nZzic3G1cDrk+wLkOSoJAfM43iSJEmSNGvjVrBWAu9P8iTgIeDbwMYmNgV8Psk9VbU+ydeAO4C7gC+POOalwMVJdgEnzPis1aNic8wF4BJ6twvekiTAD4GX78FxJEmSJGnOxn0G62bguUNi7wfe37d/xpB6q2bsXwFcMaTuzNi6vtjKvu3zZ7Rb2bw/DLyteUmSJEnSXjX2i4YlSZIkSbOTR54b0Vmd7wBJkiSpo9L2Acc+RbAL1m8eHrt23eheL4wvZHwpXINx48YXLr4UrmFvxMdVWOzru+D84fHzzh8fn/T+MT7aYl/DJMT9W3Rx423zFkFJkiRJaokTLEmSJElqyR5NsJLsTnJr3+ucObbfnuTgAeVvm7H/lT25PkmSJElaDHv6GaxdVbW6zQtpvA34k+mdqhr4iHhJkiRJWopavUWwWZm6IMktSbYl+ZWm/ClJrknytSQfZsBnzZJcCOzfrIhtasrub97XJbkuyWVJ7kxyYZINSb7anOeZTb2nJrkiyU3N6zfbzE+SJEmSRtnTCdb0RGj69aq+2M6qOhb4EHB2U3YecH1VPRv4LPC0mQesqnNoVsaqasOAcz4LeBPw68DvAUdV1fHAJcCZTZ0/A95bVWuB325iPyfJxiRbkmyZmpqaY+qSJEmSNNhC3CJ4ZfN+M/BbzfaJ09tV9ddJfrQH57ypqu4BSPId4JqmfBuwvtl+AXB08rMFsickObCq7us/UFVNAdMzq/rE5j24GkmSJEmaYSG+B+uB5n33jOPP9zHzD/RtP9y3/3DfeR4DnFBVu+Z5LkmSJEmas731mPYvARsAkrwEOGhIvQeT7DuP81wDvGF6J8nqeRxLkiRJkuakrc9gXTim/gXAiUluAV4EfH9IvSlg6/RDLvbAG4E1SbYm+TrwB3t4HEmSJEmasz26RbCqVgwpX9W3vQVY12z/M72J1bQ3D2n/FuAtffsrm/fNwOa+8nV92z+LVdVOoP+BG5IkSZK01+ytWwQlSZIkaeKlar7Pnlj2Ot8BkiRJUkf93PfzztdCPEVw2bng/OGx884fHx/5z1KwfvPw8LXrxjZf8Pi4CvM9/nzyn+05jBs3vjzjS+EajBs3vufxpXANxo3P+2/hlnmLoCRJkiS1xAmWJEmSJLVkXhOsJLubx7TfkeS2JH+YpLVJW5Izkhzet39JkqPbOr4kSZIktWm+n8HaVVWrAZIcAnwceCJw3mwPkGRFVe0eEj4DuB3YAVBVr5nPxUqSJEnSQmpttamq7gU2Am9IzxlJPjAdT/K5JOua7fuTvDPJjcAJSd6R5KYktyeZatq/ElgDbGpWyfZPsjnJmuYYpyXZ1rS5qO889yf542ZF7YYkh7aVoyRJkiSN0upnsKrqruaYh4ypegBwe1U9p6quBz5QVWur6teA/YFTqupyYAuwoapWV9Wu6cbNbYMXAScDq4G1SV7ed+wbqupZwJeA1848eZKNSbYk2TI1NTWPjCVJkiTpEQvxkIvZPEt+N3BF3/76JDcm2UZv0vSrY9qvBTZX1Q+r6iFgE3BiE/sp8Llm+2Zg1czGVTVVVWuqas3GjRtncbmSJEmSNF6r34OV5Bn0Jk/3Ag/x6Ancfn3bP5n+3FWS/YAPAmuq6u4k58+oO/BUI2IP1iPfnrwbv+tLkiRJ0l7S5hP/ngpcTO92vwK2A6uTPCbJEcDxQ5pOT6Z2JlkJvLIvdh9w4IA2NwInJTk4yQrgNOC6FtKQJEmSpD0239Wd/ZPcCuxLb8Xqo8B7mtiXge8C2+g9CfCWQQeoqn9J8udNve3ATX3hS4GLk+wCTuhrc0+StwLX0lvNuqqqPjPPXCRJkiRpXuY1waqqFSNiBWwYEls5Y//twNsH1LuCR39Wa11f7OP0Hgs/9NjNgzIuH5qAJEmSJLVoIR5yIUmSJEmd5ARLkiRJklqSRx64101JNlZVZ78Mq+v5g31g/ubf5fzBPjB/8+9y/mAfmH/7+buCBV3/Iqyu5w/2gfl3W9fzB/vA/Lut6/mDfWD+LXOCJUmSJEktcYIlSZIkSS1xggWdvee00fX8wT4w/27rev5gH5h/t3U9f7APzL9lnX/IhSRJkiS1xRUsSZIkSWqJEyxJkiRJaslETbCSvDjJN5N8O8k5TdmTk/xtkm817wfNtu1c2i8VQ/rg3Un+PsnWJH+Z5EmzbduUL5s+GJZDEzs7SSU5eC5tJyH/JGc25Xckedcc2y7r/JOsTnJDkluTbEly/GzbNuXLKf+/SHJvktv7yjozBg7JvzPjHwzug75YF8bAgfl3aAwc9DvQpTHwiCTXJvlG82/9pqa8E+PgiPw7Mw4O64O++N4ZB6tqIl7ACuA7wDOAxwK3AUcD7wLOaeqcA1w027ZNbGz7pfIa0QcvAvZp6lw0qX0wJocjgKuB7wEHdyl/YD3wBeBxTb1DOpb/NcBLmjovBTZPYv7N9Z0IHAvc3lfWpTFwUP6dGP9G9UFTPvFj4IifgU6MgSPy79IYeBhwbLN9IHAnHfpbcET+nRkHh/VBs7/XxsFF74gWO/QE4Oq+/bc2r28Ch/V1+jdn27bZHtt+qbxG5dFX9gpg0yT2wZgcLgeeBWwf8ks1sfkDlwEvmEffLff8rwZe1ZSdBnx8EvPvu/ZVPPqPq86MgYPynxGb2PFvXB90YQwcln9XxsAR+XdqDJyR12eAF3ZtHJyZ/4yyToyDg/pgb46Dk3SL4C8Cd/ft/6ApO7Sq7gFo3g8BSHJ4kqvGtGVY+yVqVB7Tfh/4PExkHwzMIcnLgH+oqtv6K3clf+Ao4PlJbkxyXZK10Kn8zwLeneRu4E/pDZiTmP8wXRoDx5nk8W+oDo2Bw3RlDBzmLDo4BiZZBTwbuJEOjoMz8u/XmXGwvw/29ji4z/wvf8nIgLIaVrmqdtBbKp9z2yVsZB5JzgUeAjbBRPbBoBweB5xLb3n8UTqSf9H7PT8I+A1gLXBZkmd0KP/XA2+uqiuSnAp8hN7/zZ60/Oeka/l3YPwbKMnj6c4YOExXxsBhOjcGJlkJXAGcVVX/mgxKb3J/B2bm31femXGwvw/o5bxXx8FJWsH6Ab17K6f9ErAD+KckhwE07/fOoS2zbL9UDM0jyenAKcCGatY3Z9uW5dMHg3L4PvB04LYk25uyW5L8wizaTkL+O5ryK6vnq8DDwMwPd05y/qcDVzZlnwIGfcB7EvIfpktj4EAdGf+GeSbdGQOH6coYOEynxsAk+9L7w3pTVU3n3ZlxcEj+nRoHB/TBXh8HJ2mCdRNwZJKnJ3ks8LvAZ5vX6U2d0+ndiznbtsyy/VIxMI8kLwbeArysqv59Lm2b2HLpg0E5XFlVh1TVqqpaRe+X59iq+sdZtJ2E/D8LfBo4GSDJUfQ+uLlzlm1h+ee/AzipqXMy8K05tIXlk/8wXRoDf06Hxr+Bqmpbh8bAYT5NN8bAYTozBqa3VPUR4BtV9Z6+UCfGwWH5d2kcHNQHizIOLsQHyhbrRW+J7056TwA5tyl7CvBFegPKF4EnN+WHA1eNajuq/VJ9DemDb9O7p/TW5nXxpPbBsBz64ttpPtjYlfzp/THxMeB24Bbg5I7l/zzgZnpPA7oROG6C8/8EcA/wIL3/gLy6S2PgkPw7M/4N64MZ8UkfAwf9DHRpDByUf5fGwOfRu6Vra9/v/EuH5TBpfTAi/86Mg8P6YEad7SzwOJimkSRJkiRpnibpFkFJkiRJWlROsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEkTI8l7k5zVt391kkv69v/vJH84y2NtTrJmAS5TkjTBnGBJkibJV4DnAiR5DHAw8Kt98ecCXx53kCQrFuTqJEkTzwmWJGmSfJlmgkVvYnU7cF+Sg5I8DvifgCcl+VqSbUn+oiknyfYk70hyPfA70wdM8pgk/zXJH+3lXCRJy5ATLEnSxKiqHcBDSZ5Gb6L1d8CNwAnAGuBO4BLgVVX168A+wOv7DvGTqnpeVf23Zn8fYBNwZ1W9fS+lIUlaxpxgSZImzfQq1vQE6+/69v8B+G5V3dnU/a/AiX1tPznjWB8Gbq+qP17QK5YkTQwnWJKkSTP9Oaxfp3eL4A30VrCeC9wypu2/DTjW+iT7tX2RkqTJ5ARLkjRpvgycAvyPqtpdVf8DeBK9Sdb/A6xK8h+bur8HXDfiWB8BrgI+lWSfhbtkSdKkcIIlSZo02+g9PfCGGWU/rqofAP8HvQnTNuBh4OJRB6uq99Bb+fpo82RCSZKGSlUt9jVIkiRJ0kTw/8RJkiRJUkucYEmSJElSS5xgSZIkSVJLnGBJkiRJUkucYEmSJElSS/xOD/AxipIkSVI3pe0DOsECpl43PLbxw6N7vTC+kPGlcA3Gl398XIXFvr6b1wyPH7cF1tw8PL7luMW/fn/Hx/8bLfa/4WKf3/jixhfy53O212B8ceOvmxoe//DGxb++xY63zVsEJUmSJKklTrAkSZIkqSVjJ1hJzk1yR5KtSW5N8pym/Kwkj5/rCZOckeTw2cSSXJLk6LmeQ5IkSZIWw8gJVpITgFOAY6vqGOAFwN1N+CxgThOsJCuAM4CBE6yZsap6TVV9fS7nkCRJkqTFMm4F6zBgZ1U9AFBVO6tqR5I30psIXZvkWoAkH0qypVntumD6AEm2J3lHkuuB04A1wKZmNWz/vnqvnBlLsjnJmiZ+f5KLktyc5AtJjm/idyV5WVNnRZJ3J7mpWXEb8fgKSZIkSWrXuAnWNcARSe5M8sEkJwFU1fuAHcD6qlrf1D23qtYAxwAnJTmm7zg/qarnVdXHgC3AhqpaXVW7pitU1eXDYo0DgM1VdRxwH/BHwAuBVwDvbOq8GvhxVa0F1gKvTfL0mUkl2dhMBrdMTY14rIokSZIkzcHIx7RX1f1JjgOeD6wHPpnknKq6dED1U5NsbI55GHA0sLWJfbKFa/0p8DfN9jbggap6MMk2YFVT/iLgmGY1DOCJwJHAd2fkNQVMz6xq1GPaJUmSJGm2xn4PVlXtBjYDm5vJzOnApf11mlWis4G1VfWjJJcC+/VV+bcWrvXBqpp+VP3DwPRtiw8nmc4jwJlVdXUL55MkSZKkORn3kItfTnJkX9Fq4HvN9n3Agc32E+hNon6c5FDgJSMO299uLrHZuBp4fZJ9AZIcleSAeRxPkiRJkmZt3ArWSuD9SZ4EPAR8G9jYxKaAzye5p6rWJ/kacAdwF/DlEce8FLg4yS7ghBmftXpUbI65AFxC73bBW5IE+CHw8j04jiRJkiTN2bjPYN0MPHdI7P3A+/v2zxhSb9WM/SuAK4bUnRlb1xdb2bd9/ox2K5v3h4G3NS9JkiRJ2qvGftGwJEmSJGl28shzIzqr8x0gSZIkdVTaPuDYpwh2wqhurbFh4wsYXwrXMAnxC84fHj/vfFi/eXj82nWLf/3GJze+FK7B+OLHx41BCz1GLfT5F/r6x1W4bt3w8Emb/R027t8BbfMWQUmSJElqiRMsSZIkSWrJHk2wkuxOcmvf65w5tt+e5OAB5W+bsf+VPbk+SZIkSVoMe/oZrF1VtbrNC2m8DfiT6Z2qGviIeEmSJElailq9RbBZmbogyS1JtiX5lab8KUmuSfK1JB9mwGfNklwI7N+siG1qyu5v3tcluS7JZUnuTHJhkg1Jvtqc55lNvacmuSLJTc3rN9vMT5IkSZJG2dMJ1vREaPr1qr7Yzqo6FvgQcHZTdh5wfVU9G/gs8LSZB6yqc2hWxqpqw4BzPgt4E/DrwO8BR1XV8cAlwJlNnT8D3ltVa4HfbmI/J8nGJFuSbJmamppj6pIkSZI02ELcInhl834z8FvN9onT21X110l+tAfnvKmq7gFI8h3gmqZ8G7C+2X4BcHTyswWyJyQ5sKru6z9QVU0B0zOr4nV7cDWSJEmSNMNCfA/WA8377hnHn+9j5h/o2364b//hvvM8BjihqnbN81ySJEmSNGd76zHtXwI2ACR5CXDQkHoPJtl3Hue5BnjD9E6S1fM4liRJkiTNSVufwbpwTP0LgBOT3AK8CPj+kHpTwNbph1zsgTcCa5JsTfJ14A/28DiSJEmSNGd7dItgVa0YUr6qb3sLsK7Z/md6E6tpbx7S/i3AW/r2Vzbvm4HNfeXr+rZ/FquqnUD/AzckSZIkaa/ZW7cISpIkSdLES9V8nz2x7HW+AyRJkqSO+rnv552vhXiK4LIzqlerA/FPnTo8/juXLe717Y1zdKGPx51/3AEWu/9O/dTw+GW/Mz6+0P0z7vzjjj/f61/O8aVwDcaNG9/z+FK4BuPG5xtvm7cISpIkSVJLnGBJkiRJUkucYEmSJElSS+Y1wUqyu/kerDuS3JbkD5O0NmlLckaSw/v2L0lydFvHlyRJkqQ2zfchF7uqajVAkkOAjwNPBM6b7QGSrKiq3UPCZwC3AzsAquo187lYSZIkSVpIra02VdW9wEbgDek5I8kHpuNJPpdkXbN9f5J3JrkROCHJO5LclOT2JFNN+1cCa4BNzSrZ/kk2J1nTHOO0JNuaNhf1nef+JH/crKjdkOTQtnKUJEmSpFFa/QxWVd3VHPOQMVUPAG6vqudU1fXAB6pqbVX9GrA/cEpVXQ5sATZU1eqq2jXduLlt8CLgZGA1sDbJy/uOfUNVPQv4EvDamSdPsjHJliRbpqam5pGxJEmSJD1iIb4HazZf1rUbuKJvf32S/wI8HngycAfwVyParwU2V9UPAZJsAk4EPg38FPhcU+9m4IUzG1fVFDA9s6rXzeKCJUmSJGmcVidYSZ5Bb/J0L/AQj14h269v+yfTn7tKsh/wQWBNVd2d5PwZdQeeakTswaqa/s6w3fhlypIkSZL2kjaf+PdU4GJ6t/sVsB1YneQxSY4Ajh/SdHoytTPJSuCVfbH7gAMHtLkROCnJwUlWAKcB17WQhiRJkiTtsfmu7uyf5FZgX3orVh8F3tPEvgx8F9hG70mAtww6QFX9S5I/b+ptB27qC18KXJxkF3BCX5t7krwVuJbeatZVVfWZeeYiSZIkSfMyrwlWVa0YEStgw5DYyhn7bwfePqDeFTz6s1rr+mIfp/dY+KHHbh6UcfnQBCRJkiSpRa0+RVCSJEmSuiyPPA+im5JsbJ4q2Eldzx/sA/M3/y7nD/aB+Zt/l/MH+8D828/fFazelyN3WdfzB/vA/Lut6/mDfWD+3db1/ME+MP+WOcGSJEmSpJY4wZIkSZKkljjBgs7ec9roev5gH5h/t3U9f7APzL/bup4/2Afm37LOP+RCkiRJktriCpYkSZIktcQJliRJkiS1ZKImWElenOSbSb6d5Jym7MlJ/jbJt5r3g2bbdi7tl4ohffDuJH+fZGuSv0zypNm2bcqXTR8My6GJnZ2kkhw8l7aTkH+SM5vyO5K8a45tl3X+SVYnuSHJrUm2JDl+tm2b8uWU/18kuTfJ7X1lnRkDh+TfmfEPBvdBX6wLY+DA/Ds0Bg76HejSGHhEkmuTfKP5t35TU96JcXBE/p0ZB4f1QV9874yDVTURL2AF8B3gGcBjgduAo4F3Aec0dc4BLppt2yY2tv1SeY3ogxcB+zR1LprUPhiTwxHA1cD3gIO7lD+wHvgC8Lim3iEdy/8a4CVNnZcCmycx/+b6TgSOBW7vK+vSGDgo/06Mf6P6oCmf+DFwxM9AJ8bAEfl3aQw8DDi22T4QuJMO/S04Iv/OjIPD+qDZ32vj4KJ3RIsdegJwdd/+W5vXN4HD+jr9m7Nt22yPbb9UXqPy6Ct7BbBpEvtgTA6XA88Ctg/5pZrY/IHLgBfMo++We/5XA69qyk4DPj6J+fdd+yoe/cdVZ8bAQfnPiE3s+DeuD7owBg7Lvytj4Ij8OzUGzsjrM8ALuzYOzsx/RlknxsFBfbA3x8FJukXwF4G7+/Z/0JQdWlX3ADTvhwAkOTzJVWPaMqz9EjUqj2m/D3weJrIPBuaQ5GXAP1TVbf2Vu5I/cBTw/CQ3JrkuyVroVP5nAe9Ocjfwp/QGzEnMf5gujYHjTPL4N1SHxsBhujIGDnMWHRwDk6wCng3cSAfHwRn59+vMONjfB3t7HNxn/pe/ZGRAWQ2rXFU76C2Vz7ntEjYyjyTnAg8Bm2Ai+2BQDo8DzqW3PP4oHcm/6P2eHwT8BrAWuCzJMzqU/+uBN1fVFUlOBT5C7/9mT1r+c9K1/Dsw/g2U5PF0Zwwcpitj4DCdGwOTrASuAM6qqn9NBqU3ub8DM/PvK+/MONjfB/Ry3qvj4CStYP2A3r2V034J2AH8U5LDAJr3e+fQllm2XyqG5pHkdOAUYEM165uzbcvy6YNBOXwfeDpwW5LtTdktSX5hFm0nIf8dTfmV1fNV4GFg5oc7Jzn/04Erm7JPAYM+4D0J+Q/TpTFwoI6Mf8M8k+6MgcN0ZQwcplNjYJJ96f1hvamqpvPuzDg4JP9OjYMD+mCvj4OTNMG6CTgyydOTPBb4XeCzzev0ps7p9O7FnG1bZtl+qRiYR5IXA28BXlZV/z6Xtk1sufTBoByurKpDqmpVVa2i98tzbFX94yzaTkL+nwU+DZwMkOQoeh/c3DnLtrD8898BnNTUORn41hzawvLJf5gujYE/p0Pj30BVta1DY+Awn6YbY+AwnRkD01uq+gjwjap6T1+oE+PgsPy7NA4O6oNFGQcX4gNli/Wit8R3J70ngJzblD0F+CK9AeWLwJOb8sOBq0a1HdV+qb6G9MG36d1TemvzunhS+2BYDn3x7TQfbOxK/vT+mPgYcDtwC3Byx/J/HnAzvacB3QgcN8H5fwK4B3iQ3n9AXt2lMXBI/p0Z/4b1wYz4pI+Bg34GujQGDsq/S2Pg8+jd0rW173f+pcNymLQ+GJF/Z8bBYX0wo852FngcTNNIkiRJkjRPk3SLoCRJkiQtKidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJKkZSdJJflo3/4+SX6Y5HNzPM7mJGua7auSPGkPruWMJB+YaztJ0mTaZ7EvQJKkPfBvwK8l2b+qdgEvBP5hPgesqpe2cmWSpE5zBUuStFx9Hvhfm+3TgE9MB5IckOQvktyU5GtJ/remfP8k/y3J1iSfBPbva7M9ycHN9n9u6tw2vVKW5D8lubE53heSHLq3EpUkLR9OsCRJy9V/A343yX7AMcCNfbFzgf+vqtYC64F3JzkAeD3w71V1DPDHwHEzD5rkV5v2J1fVs4A3NaHrgd+oqmc35/4vC5OWJGk58xZBSdKyVFVbk6yit3p11Yzwi4CXJTm72d8PeBpwIvC+vvZbBxz6ZODyqtrZ1PsfTfkvAZ9MchjwWOC7LaYjSZoQTrAkScvZZ4E/BdYBT+krD/DbVfXN/spJAGrMMTOkzvuB91TVZ5OsA87fkwuWJE02bxGUJC1nfwG8s6q2zSi/GjgzzYwqybOb8i8BG5qyX6N3a+FMXwROTfKUpt6Tm/In8siDNE5vLQNJ0kRxgiVJWraq6gdV9WcDQv8nsC+wNcntzT7Ah4CVza2B/wX46oBj3kHv81nXJbkNeE8TOh/4VJL/DuxsNRFJ0sRI1bg7JSRJkiRJs+EKliRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRJkiS1xO/BGv99KJIkSZImU9o+oBMsRvdqGV/U+FK4BuPGjS9cfClcg/Hx8XEVFvv6jC9efClcg3Hj8x7jWuYtgpIkSZLUEidYkiRJktSSsROsJOcmuSPJ1iS3JnlOU35WksfP9YRJzkhy+GxiSS5JcvRczyFJkiRJi2HkBCvJCcApwLFVdQzwAuDuJnwWMKcJVpIVwBnAwAnWzFhVvaaqvj6Xc0iSJEnSYhm3gnUYsLOqHgCoqp1VtSPJG+lNhK5Nci1Akg8l2dKsdl0wfYAk25O8I8n1wGnAGmBTsxq2f1+9V86MJdmcZE0Tvz/JRUluTvKFJMc38buSvKypsyLJu5Pc1Ky4va61npIkSZKkMcZNsK4BjkhyZ5IPJjkJoKreB+wA1lfV+qbuuVW1BjgGOCnJMX3H+UlVPa+qPgZsATZU1eqq2jVdoaouHxZrHABsrqrjgPuAPwJeCLwCeGdT59XAj6tqLbAWeG2Sp89MKsnGZjK4ZWpqakwXSJIkSdLsjHxMe1Xdn+Q44PnAeuCTSc6pqksHVD81ycbmmIcBRwNbm9gnW7jWnwJ/02xvAx6oqgeTbANWNeUvAo5pVsMAnggcCXx3Rl5TwPTMqlzmkiRJktSGsd+DVVW7gc3A5mYyczpwaX+dZpXobGBtVf0oyaXAfn1V/q2Fa32wqqYfVf8wMH3b4sNJpvMIcGZVXd3C+SRJkiRpTsY95OKXkxzZV7Qa+F6zfR9wYLP9BHqTqB8nORR4yYjD9rebS2w2rgZen2RfgCRHJTlgHseTJEmSpFkbt4K1Enh/kicBDwHfBjY2sSng80nuqar1Sb4G3AHcBXx5xDEvBS5Osgs4YcZnrR4Vm2MuAJfQu13wliQBfgi8fA+OI0mSJElzlkfuuuusyqggvfsOjS9OfClcg3HjxhcuvhSuwfj4+LgKi319xhcvvhSuwbjxecbH/YjP2dgvGpYkSZIkzY4rWM3/nJMkSZLUOa2vYI19imAXLPFly07Hl8I1GDdufOHiS+EajBv3Fso9jy+FazBufN6/wy3zFkFJkiRJaokTLEmSJElqyR5NsJLsTnJr3+ucObbfnuTgAeVvm7H/lT25PkmSJElaDHv6GaxdVbW6zQtpvA34k+mdqnruApxDkiRJkhZEq7cINitTFyS5Jcm2JL/SlD8lyTVJvpbkwwz4rFmSC4H9mxWxTU3Z/c37uiTXJbksyZ1JLkyyIclXm/M8s6n31CRXJLmpef1mm/lJkiRJ0ih7OsGanghNv17VF9tZVccCHwLObsrOA66vqmcDnwWeNvOAVXUOzcpYVW0YcM5nAW8Cfh34PeCoqjoeuAQ4s6nzZ8B7q2ot8NtN7Ock2ZhkS5ItU1NTc0xdkiRJkgZbiFsEr2zebwZ+q9k+cXq7qv46yY/24Jw3VdU9AEm+A1zTlG8D1jfbLwCOTn62QPaEJAdW1X39B6qqKWB6ZlWv24OLkSRJkqSZFuJ7sB5o3nfPOP58HzP/QN/2w337D/ed5zHACVW1a57nkiRJkqQ521uPaf8SsAEgyUuAg4bUezDJvvM4zzXAG6Z3kqyex7EkSZIkaU7a+gzWhWPqXwCcmOQW4EXA94fUmwK2Tj/kYg+8EViTZGuSrwN/sIfHkSRJkqQ5S9V879xb9urnHmnYH2TAIw+N77X4UrgG48aNL1x8KVyDcePzjY+rsNjX5++wceMj4+N+xOdsb90iKEmSJEkTzxWs+T98Q5IkSdLy1PoK1kI8RXDZWeLLloseX8xbH9o4hnHjxpdufClcg3Hjxvc8vhSuwbjxef+t2zJvEZQkSZKkljjBkiRJkqSWOMGSJEmSpJbMa4KVZHfzPVh3JLktyR8maW3SluSMJIf37V+S5Oi2ji9JkiRJbZrvQy52VdVqgCSHAB8HngicN9sDJFlRVbuHhM8Abgd2AFTVa+Zzsfr/t3d/IXKdZRzHvz/7N7UFG2NqqoE0Yi9EaIzZaqC2NlippRSFooZeRBQjgmIE0ZSAiOBFWulVkRCpCBqF2sS0lkjU0lQUEpOGpEmpaauupiYaeyFarNjWx4vzLj0Zz5md7Z7dzJ7n94FhZ9/3vDPze5J5MifnzIyZmZmZmc2lzo42RcQZYCPwOVU+IeneqXlJD0t6f7n+gqSvSzoArJX0VUkHJR2XtL2svx1YA+woR8kWSdonaU25jfWSjpU1W2v384Kkb5QjavslXdFVRjMzMzMzs2E6fQ9WRPy+3ObSaTZ9PXA8It4TEb8C7o2IiYh4J7AIuDUiHgAOAXdExKqIeHFqcTltcCuwDlgFTEj6cO2290fENcAvgU8P3rmkjZIOSTq0ffv2WSQ2MzMzMzN71Vx8D9YoX9b1CrCz9vuNkr4MXAIsBp4EfjJk/QSwLyL+BiBpB3A9sBv4D/Bw2e5x4KbBxRGxHZjas4rPjPCAzczMzMzMptPpDpaklVQ7T2eAlzn7CNnFtev/nnrflaSLgW8BayLipKSvDWzbeFdD5l6KiKnvDHsFf5mymZmZmZnNky4/8e9NwDaq0/0CmARWSXqdpOXAtS1Lp3amnpd0KXB7be6fwGUNaw4AN0haIuk8YD3wWAcxzMzMzMzMXrPZHt1ZJOkIcAHVEavvAfeUuV8DfwCOUX0S4OGmG4iIv0v6dtluEjhYm/4usE3Si8Da2prTku4EHqU6mrUnIh6cZRYzMzMzM7NZ0atn06UVw843DIafj5hhfroN5vL+u7gNz3ve8+M7Pw6PwfOe9/xrnx+Hx+B5z89yfpTPj5iRTj9F0MzMzMzMLLP0R7AkbSyfKphS9vzgGji/82fOD66B8zt/5vzgGjh/9/l9BKv6cuTMsucH18D5c8ueH1wD588te35wDZy/Y97BMjMzMzMz64h3sMzMzMzMzDriHSxIe85pkT0/uAbOn1v2/OAaOH9u2fODa+D8HUv/IRdmZmZmZmZd8REsMzMzMzOzjngHy8zMzMzMrCO92sGSdLOkE5KelbS5jC2W9HNJz5Sfl4+6dibrx0VLDe6W9FtJT0j6saQ3jLq2jC+YGrRlKHNfkhSSlsxkbR/yS/p8GX9S0l0zXLug80taJWm/pCOSDkm6dtS1ZXwh5f+OpDOSjtfG0vTAlvxp+h8016A2l6EHNuZP1AObngOZeuBySY9Keqr8WX+hjKfog0Pyp+mDbTWozc9PH4yIXlyA84DfASuBC4GjwDuAu4DNZZvNwNZR15a5adePy2VIDT4InF+22drXGkyTYTmwF/gjsCRTfuBG4BfARWW7pcny/wz4UNnmFmBfH/OXx3c9sBo4XhvL1AOb8qfof8NqUMZ73wOH/B1I0QOH5M/UA5cBq8v1y4CnSfRacEj+NH2wrQbl93nrg+e8EB0WdC2wt/b7neVyAlhWK/qJUdeW69OuH5fLsBy1sY8AO/pYg2kyPABcA0y2PKl6mx+4H/jALGq30PPvBT5WxtYDP+hj/tpjX8HZL67S9MCm/ANzve1/09UgQw9sy5+lBw7Jn6oHDuR6ELgpWx8czD8wlqIPNtVgPvtgn04RfAtwsvb7c2Xsiog4DVB+LgWQdKWkPdOspW39mBqWY8ongZ9CL2vQmEHSbcCfI+JofeMs+YGrgfdJOiDpMUkTkCr/JuBuSSeBb1I1zD7mb5OpB06nz/2vVaIe2CZLD2yziYQ9UNIK4F3AARL2wYH8dWn6YL0G890Hz5/9wx8bahiLto0j4hTVofIZrx1jQ3NI2gK8DOyAXtagKcNFwBaqw+NnSZI/qJ7nlwPvBSaA+yWtTJT/s8AXI2KnpI8C91H9b3bf8s9ItvwJ+l8jSZeQpwe2ydID26TrgZIuBXYCmyLiH1JTvP4+Bwbz18bT9MF6Dagyz2sf7NMRrOeozq2c8lbgFPBXScsAys8zM1jLiOvHRWsOSRuAW4E7ohzfHHUtC6cGTRn+BFwFHJU0WcYOS3rzCGv7kP9UGd8Vld8A/wUG39zZ5/wbgF1l7EdA0xu8+5C/TaYe2ChJ/2vzNvL0wDZZemCbVD1Q0gVUL6x3RMRU7jR9sCV/qj7YUIN574N92sE6CLxd0lWSLgQ+DjxULhvKNhuozsUcdS0jrh8XjTkk3Qx8BbgtIv41k7VlbqHUoCnDrohYGhErImIF1ZNndUT8ZYS1fcj/ELAbWAcg6WqqN24+P+JaWPj5TwE3lG3WAc/MYC0snPxtMvXA/5Oo/zWKiGOJemCb3eTogW3S9EBVh6ruA56KiHtqUyn6YFv+TH2wqQbnpA/OxRvKztWF6hDf01SfALKljL0ReISqoTwCLC7jVwJ7hq0dtn5cLy01eJbqnNIj5bKtrzVoy1Cbn6S8sTFLfqoXE98HjgOHgXXJ8l8HPE71aUAHgHf3OP8PgdPAS1T/gHwqUw9syZ+m/7XVYGC+7z2w6e9Aph7YlD9TD7yO6pSuJ2rP+VvaMvStBkPyp+mDbTUY2GaSOe6DKovMzMzMzMxslvp0iqCZmZmZmdk55R0sMzMzMzOzjngHy8zMzMzMrCPewTIzMzMzM+uId7DMzMzMzMw64h0sMzMzMzOzjngHy8zMzMzMrCP/AyOAM2+sgA35AAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAKrCAYAAADs7iyrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAB7P0lEQVR4nOz9f5RldX3v+T9fNihIo6IIgQRvqxeSIQm20I3BKHQz6qjDdTQxGFZPLkzUNq4lilmsK4pLwEkyoBn9Rl2KFcxwR1uvCESNwUB0aLxoQBqEbtCIiq2YJsHONQaSFqF5f/84u+RQnh9VXbu6qs5+PtY66+z9eX8+e+/3p6s+1IfPPvukqpAkSZIkzd9jFvsCJEmSJGlSOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiQte0l2J7m173XOAp7rbQt1bEnS8he/B0uStNwlub+qVi7wOQIE+NeFPpckaflyBUuSNLGSXJjk60m2JvnTpuzQJH+Z5Lbm9dym/A+T3N68zmrKViX5RpIPArcAHwH2b1bJNi1WXpKkpcsVLEnSspdkN7Ctr+j/Av4W+DvgV6qqkjypqv4lySeBv6uq/1+SFcBK4D8ClwK/QW+V6kbgfwd+BNwFPLeqbmjOteCrZZKk5Wufxb4ASZJasKuqVvcXJNkH+AlwSZK/Bj7XhE4G/jNAVe0GfpzkecBfVtW/NW2vBJ4PfBb43vTkSpKkcbxFUJI0karqIeB44Arg5cDfjKieEbF/a/GyJEkTzgmWJGkiJVkJPLGqrgLOAlY3oS8Cr2/qrEjyBOBLwMuTPD7JAcArgP8+5NAPJtl3Ia9dkrR8eYugJGkS7J/k1r79vwH+DPhMkv3orVC9uYm9CZhK8mpgN/D6qvq7JJcCX23qXFJVX0uyasC5poCtSW6pqg3tpyJJWs58yIUkSZIktcRbBCVJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJT5FEHzKhyRJktRNo74HcY84wWJ0r5bxRY0vhWswbny+8fWbh8evXTc+vtjX7+/4+PgF5w+Pn3f+4l/fYsfH9c+4A0x6/y72GDCf808fY9L/jZZ7fLF/xpZ6vG3eIihJkiRJLXGCJUmSJEktGTvBSnJukjuSbE1ya5LnNOVnJXn8XE+Y5Iwkh88mluSSJEfP9RySJEmStBhGTrCSnACcAhxbVccALwDubsJnAXOaYCVZAZwBDJxgzYxV1Wuq6utzOYckSZIkLZZxK1iHATur6gGAqtpZVTuSvJHeROjaJNcCJPlQki3NatcF0wdIsj3JO5JcD5wGrAE2Nath+/fVe+XMWJLNSdY08fuTXJTk5iRfSHJ8E78rycuaOiuSvDvJTc2K2+ta6ylJkiRJGmPcBOsa4Igkdyb5YJKTAKrqfcAOYH1VrW/qnltVa4BjgJOSHNN3nJ9U1fOq6mPAFmBDVa2uql3TFarq8mGxxgHA5qo6DrgP+CPghcArgHc2dV4N/Liq1gJrgdcmefrMpJJsbCaDW6ampsZ0gSRJkiTNzsjHtFfV/UmOA54PrAc+meScqrp0QPVTk2xsjnkYcDSwtYl9soVr/SnwN832NuCBqnowyTZgVVP+IuCYZjUM4InAkcB3Z+Q1BUzPrMplLkmSJEltGPs9WFW1G9gMbG4mM6cDl/bXaVaJzgbWVtWPklwK7NdX5d9auNYHq2r6UfUPA9O3LT6cZDqPAGdW1dUtnE+SJEmS5mTcQy5+OcmRfUWrge812/cBBzbbT6A3ifpxkkOBl4w4bH+7ucRm42rg9Un2BUhyVJID5nE8SZIkSZq1cStYK4H3J3kS8BDwbWBjE5sCPp/knqpan+RrwB3AXcCXRxzzUuDiJLuAE2Z81upRsTnmAnAJvdsFb0kS4IfAy/fgOJIkSZI0Z+M+g3Uz8NwhsfcD7+/bP2NIvVUz9q8ArhhSd2ZsXV9sZd/2+TParWzeHwbe1rwkSZIkaa8a+0XDkiRJkqTZcYIlSZIkSS3JIw/m66zOd4AkSZLUUWn7gGMf094Fo3q1jC9qfClcg3HjCx3/1a8Pj99x9OJfn7/j4+Onfmp4/LLfWfzrW+z4uJ/xcfFxJ1js/Jb7GDCf808fw9+B+cUX+mdgsX/Glnq8bd4iKEmSJEktcYIlSZIkSS3ZowlWkt1Jbu17nTPH9tuTHDyg/G0z9r+yJ9cnSZIkSYthTz+DtauqVrd5IY23AX8yvVNVA7+DS5IkSZKWolZvEWxWpi5IckuSbUl+pSl/SpJrknwtyYcZ8FmzJBcC+zcrYpuasvub93VJrktyWZI7k1yYZEOSrzbneWZT76lJrkhyU/P6zTbzkyRJkqRR9nSCNT0Rmn69qi+2s6qOBT4EnN2UnQdcX1XPBj4LPG3mAavqHJqVsaraMOCczwLeBPw68HvAUVV1PHAJcGZT58+A91bVWuC3m9jPSbIxyZYkW6ampuaYuiRJkiQNthC3CF7ZvN8M/FazfeL0dlX9dZIf7cE5b6qqewCSfAe4pinfBqxvtl8AHJ38bIHsCUkOrKr7+g9UVVPA9MyqXrcHFyNJkiRJMy3E92A90LzvnnH8+T5m/oG+7Yf79h/uO89jgBOqatc8zyVJkiRJc7a3HtP+JWADQJKXAAcNqfdgkn3ncZ5rgDdM7yRZPY9jSZIkSdKctPUZrAvH1L8AODHJLcCLgO8PqTcFbJ1+yMUeeCOwJsnWJF8H/mAPjyNJkiRJc7ZHtwhW1Yoh5av6trcA65rtf6Y3sZr25iHt3wK8pW9/ZfO+GdjcV76ub/tnsaraCfQ/cEOSJEmS9pq9dYugJEmSJE28VM332RPLXuc7QJIkSeqon/t+3vlaiKcILj+jurXGho0vYHwpXINx48YXLr4UrqGAg/5lePxHT1r86zNufKnGl8I1GDc+33jbvEVQkiRJklriBEuSJEmSWjKvCVaS3c1j2u9IcluSP0zS2qQtyRlJDu/bvyTJ0W0dX5IkSZLaNN/PYO2qqtUASQ4BPg48EThvtgdIsqKqdg8JnwHcDuwAqKrXzOdiJUmSJGkhtbbaVFX3AhuBN6TnjCQfmI4n+VySdc32/UnemeRG4IQk70hyU5Lbk0w17V8JrAE2Natk+yfZnGRNc4zTkmxr2lzUd577k/xxs6J2Q5JD28pRkiRJkkZp9TNYVXVXc8xDxlQ9ALi9qp5TVdcDH6iqtVX1a8D+wClVdTmwBdhQVauratd04+a2wYuAk4HVwNokL+879g1V9SzgS8BrZ548ycYkW5JsmZqamkfGkiRJkvSIhXhM+2yeJb8buKJvf32S/wI8HngycAfwVyParwU2V9UPAZJsAk4EPg38FPhcU+9m4IUzG1fVFDA9sypeN4srliRJkqQxWp1gJXkGvcnTvcBDPHqFbL++7Z9Mf+4qyX7AB4E1VXV3kvNn1B14qhGxB+uRb0/ejd/1JUmSJGkvafOJf08FLqZ3u18B24HVSR6T5Ajg+CFNpydTO5OsBF7ZF7sPOHBAmxuBk5IcnGQFcBpwXQtpSJIkSdIem+/qzv5JbgX2pbdi9VHgPU3sy8B3gW30ngR4y6ADVNW/JPnzpt524Ka+8KXAxUl2ASf0tbknyVuBa+mtZl1VVZ+ZZy6SJEmSNC955G66zqqRNxzW6PsRC+MLGV8K12DcuPGFiy+FayjgoH8ZHv/Rkxb/+owbX6rxpXANxo3PMz6b50fMSatPEZQkSZKkLuv8ClaSjc1TBTup6/mDfWD+5t/l/ME+MH/z73L+YB+Yf/v5u4LV+3LkLut6/mAfmH+3dT1/sA/Mv9u6nj/YB+bfMidYkiRJktQSJ1iSJEmS1BInWNDZe04bXc8f7APz77au5w/2gfl3W9fzB/vA/FvW+YdcSJIkSVJbXMGSJEmSpJY4wZIkSZKklkzUBCvJi5N8M8m3k5zTlD05yd8m+VbzftBs286l/VIxpA/eneTvk2xN8pdJnjTbtk35sumDYTk0sbOTVJKD59J2EvJPcmZTfkeSd82x7bLOP8nqJDckuTXJliTHz7ZtU76c8v+LJPcmub2vrDNj4JD8OzP+weA+6It1YQwcmH+HxsBBvwNdGgOPSHJtkm80/9Zvaso7MQ6OyL8z4+CwPuiL751xsKom4gWsAL4DPAN4LHAbcDTwLuCcps45wEWzbdvExrZfKq8RffAiYJ+mzkWT2gdjcjgCuBr4HnBwl/IH1gNfAB7X1DukY/lfA7ykqfNSYPMk5t9c34nAscDtfWVdGgMH5d+J8W9UHzTlEz8GjvgZ6MQYOCL/Lo2BhwHHNtsHAnfSob8FR+TfmXFwWB80+3ttHFz0jmixQ08Aru7bf2vz+iZwWF+nf3O2bZvtse2XymtUHn1lrwA2TWIfjMnhcuBZwPYhv1QTmz9wGfCCefTdcs//auBVTdlpwMcnMf++a1/Fo/+46swYOCj/GbGJHf/G9UEXxsBh+XdlDByRf6fGwBl5fQZ4YdfGwZn5zyjrxDg4qA/25jg4SbcI/iJwd9/+D5qyQ6vqHoDm/RCAJIcnuWpMW4a1X6JG5THt94HPw0T2wcAckrwM+Iequq2/clfyB44Cnp/kxiTXJVkLncr/LODdSe4G/pTegDmJ+Q/TpTFwnEke/4bq0Bg4TFfGwGHOooNjYJJVwLOBG+ngODgj/36dGQf7+2Bvj4P7zP/yl4wMKKthlatqB72l8jm3XcJG5pHkXOAhYBNMZB8MyuFxwLn0lscfpSP5F73f84OA3wDWApcleUaH8n898OaquiLJqcBH6P3f7EnLf066ln8Hxr+Bkjye7oyBw3RlDBymc2NgkpXAFcBZVfWvyaD0Jvd3YGb+feWdGQf7+4Beznt1HJykFawf0Lu3ctovATuAf0pyGEDzfu8c2jLL9kvF0DySnA6cAmyoZn1ztm1ZPn0wKIfvA08HbkuyvSm7JckvzKLtJOS/oym/snq+CjwMzPxw5yTnfzpwZVP2KWDQB7wnIf9hujQGDtSR8W+YZ9KdMXCYroyBw3RqDEyyL70/rDdV1XTenRkHh+TfqXFwQB/s9XFwkiZYNwFHJnl6kscCvwt8tnmd3tQ5nd69mLNtyyzbLxUD80jyYuAtwMuq6t/n0raJLZc+GJTDlVV1SFWtqqpV9H55jq2qf5xF20nI/7PAp4GTAZIcRe+Dmztn2RaWf/47gJOaOicD35pDW1g++Q/TpTHw53Ro/BuoqrZ1aAwc5tN0YwwcpjNjYHpLVR8BvlFV7+kLdWIcHJZ/l8bBQX2wKOPgQnygbLFe9Jb47qT3BJBzm7KnAF+kN6B8EXhyU344cNWotqPaL9XXkD74Nr17Sm9tXhdPah8My6Evvp3mg41dyZ/eHxMfA24HbgFO7lj+zwNupvc0oBuB4yY4/08A9wAP0vsPyKu7NAYOyb8z49+wPpgRn/QxcNDPQJfGwEH5d2kMfB69W7q29v3Ov3RYDpPWByPy78w4OKwPZtTZzgKPg2kaSZIkSZLmaZJuEZQkSZKkReUES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSNDGSvDfJWX37Vye5pG///07yh7M81uYkaxbgMiVJE8wJliRpknwFeC5AkscABwO/2hd/LvDlcQdJsmJBrk6SNPGcYEmSJsmXaSZY9CZWtwP3JTkoyeOA/wl4UpKvJdmW5C+acpJsT/KOJNcDvzN9wCSPSfJfk/zRXs5FkrQMOcGSJE2MqtoBPJTkafQmWn8H3AicAKwB7gQuAV5VVb8O7AO8vu8QP6mq51XVf2v29wE2AXdW1dv3UhqSpGXMCZYkadJMr2JNT7D+rm//H4DvVtWdTd3/CpzY1/aTM471YeD2qvrjBb1iSdLEcIIlSZo005/D+nV6twjeQG8F67nALWPa/tuAY61Psl/bFylJmkxOsCRJk+bLwCnA/6iq3VX1P4An0Ztk/T/AqiT/san7e8B1I471EeAq4FNJ9lm4S5YkTQonWJKkSbON3tMDb5hR9uOq+gHwf9CbMG0DHgYuHnWwqnoPvZWvjzZPJpQkaahU1WJfgyRJkiRNBP9PnCRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRJkiS1xEfOgk/5kCRJkropbR/QCRYw9brhsY0fHt3rhfGFjC+FazC+/OPjKiz29d28Znj8uC2w5ubh8S3HLf71+zs+/t9osf8NF/v8xhc3vpA/n7O9BuOLG3/d1PD4hzcu/vUtdrxt3iIoSZIkSS1xgiVJkiRJLRk7wUpybpI7kmxNcmuS5zTlZyV5/FxPmOSMJIfPJpbkkiRHz/UckiRJkrQYRk6wkpwAnAIcW1XHAC8A7m7CZwFzmmAlWQGcAQycYM2MVdVrqurrczmHJEmSJC2WcStYhwE7q+oBgKraWVU7kryR3kTo2iTXAiT5UJItzWrXBdMHSLI9yTuSXA+cBqwBNjWrYfv31XvlzFiSzUnWNPH7k1yU5OYkX0hyfBO/K8nLmjorkrw7yU3NituIx1dIkiRJUrvGTbCuAY5IcmeSDyY5CaCq3gfsANZX1fqm7rlVtQY4BjgpyTF9x/lJVT2vqj4GbAE2VNXqqto1XaGqLh8WaxwAbK6q44D7gD8CXgi8AnhnU+fVwI+rai2wFnhtkqfPTCrJxmYyuGVqasRjVSRJkiRpDkY+pr2q7k9yHPB8YD3wySTnVNWlA6qfmmRjc8zDgKOBrU3sky1c60+Bv2m2twEPVNWDSbYBq5ryFwHHNKthAE8EjgS+OyOvKWB6ZlWjHtMuSZIkSbM19nuwqmo3sBnY3ExmTgcu7a/TrBKdDaytqh8luRTYr6/Kv7VwrQ9W1fSj6h8Gpm9bfDjJdB4Bzqyqq1s4nyRJkiTNybiHXPxykiP7ilYD32u27wMObLafQG8S9eMkhwIvGXHY/nZzic3G1cDrk+wLkOSoJAfM43iSJEmSNGvjVrBWAu9P8iTgIeDbwMYmNgV8Psk9VbU+ydeAO4C7gC+POOalwMVJdgEnzPis1aNic8wF4BJ6twvekiTAD4GX78FxJEmSJGnOxn0G62bguUNi7wfe37d/xpB6q2bsXwFcMaTuzNi6vtjKvu3zZ7Rb2bw/DLyteUmSJEnSXjX2i4YlSZIkSbPjBEuSJEmSWpJHHszXWZ3vAEmSJKmj0vYBxz6mvRNGdWuNDRtfwPhSuIZJiF9w/vD4eefD+s3D49euW/zrNz658aVwDcYXPz5uDFroMWqhz7/Q1z+uwnXrhodP2uzvsHH/DmibtwhKkiRJUkucYEmSJElSS/ZogpVkd5Jb+17nzLH99iQHDyh/24z9r+zJ9UmSJEnSYtjTz2DtqqrVbV5I423An0zvVNXA7+CSJEmSpKWo1VsEm5WpC5LckmRbkl9pyp+S5JokX0vyYQZ81izJhcD+zYrYpqbs/uZ9XZLrklyW5M4kFybZkOSrzXme2dR7apIrktzUvH6zzfwkSZIkaZQ9nWBNT4SmX6/qi+2sqmOBDwFnN2XnAddX1bOBzwJPm3nAqjqHZmWsqjYMOOezgDcBvw78HnBUVR0PXAKc2dT5M+C9VbUW+O0m9nOSbEyyJcmWqampOaYuSZIkSYMtxC2CVzbvNwO/1WyfOL1dVX+d5Ed7cM6bquoegCTfAa5pyrcB65vtFwBHJz9bIHtCkgOr6r7+A1XVFDA9sypetwdXI0mSJEkzLMT3YD3QvO+ecfz5Pmb+gb7th/v2H+47z2OAE6pq1zzPJUmSJElztrce0/4lYANAkpcABw2p92CSfedxnmuAN0zvJFk9j2NJkiRJ0py09RmsC8fUvwA4McktwIuA7w+pNwVsnX7IxR54I7AmydYkXwf+YA+PI0mSJElztke3CFbViiHlq/q2twDrmu1/pjexmvbmIe3fArylb39l874Z2NxXvq5v+2exqtoJ9D9wQ5IkSZL2mr11i6AkSZIkTbxUzffZE8te5ztAkiRJ6qif+37e+VqIpwguO6N6tToQ/9Spw+O/c9niXt/eOEcX+njc+ccdYLH779RPDY9f9jvj4wvdP+POP+74873+5RxfCtdg3LjxPY8vhWswbny+8bZ5i6AkSZIktcQJliRJkiS1ZF4TrCS7m8e035HktiR/mKS1SVuSM5Ic3rd/SZKj2zq+JEmSJLVpvp/B2lVVqwGSHAJ8HHgicN5sD5BkRVXtHhI+A7gd2AFQVa+Zz8VKkiRJ0kJqbbWpqu4FNgJvSM8ZST4wHU/yuSTrmu37k7wzyY3ACUnekeSmJLcnmWravxJYA2xqVsn2T7I5yZrmGKcl2da0uajvPPcn+eNmRe2GJIe2laMkSZIkjdLqZ7Cq6q7mmIeMqXoAcHtVPaeqrgc+UFVrq+rXgP2BU6rqcmALsKGqVlfVrunGzW2DFwEnA6uBtUle3nfsG6rqWcCXgNfOPHmSjUm2JNkyNTU1j4wlSZIk6REL8Zj22TxLfjdwRd/++iT/BXg88GTgDuCvRrRfC2yuqh8CJNkEnAh8Gvgp8Lmm3s3AC2c2rqopYHpmVa+bxQVLkiRJ0jitTrCSPIPe5Ole4CEevUK2X9/2T6Y/d5VkP+CDwJqqujvJ+TPqDjzViNiD9ci3J+/G7/qSJEmStJe0+cS/pwIX07vdr4DtwOokj0lyBHD8kKbTk6mdSVYCr+yL3QccOKDNjcBJSQ5OsgI4DbiuhTQkSZIkaY/Nd3Vn/yS3AvvSW7H6KPCeJvZl4LvANnpPArxl0AGq6l+S/HlTbztwU1/4UuDiJLuAE/ra3JPkrcC19Fazrqqqz8wzF0mSJEmal3lNsKpqxYhYARuGxFbO2H878PYB9a7g0Z/VWtcX+zi9x8IPPXbzoIzLhyYgSZIkSS1q9SmCkiRJktRlTrAkSZIkqSV55IF73ZRkY/PY9k7qev5gH5i/+Xc5f7APzN/8u5w/2Afm337+rmDBxsW+gEXW9fzBPjD/but6/mAfmH+3dT1/sA/Mv2VOsCRJkiSpJU6wJEmSJKklTrCgs/ecNrqeP9gH5t9tXc8f7APz77au5w/2gfm3rPMPuZAkSZKktriCJUmSJEktmagJVpIXJ/lmkm8nOacpe3KSv03yreb9oNm2nUv7pWJIH7w7yd8n2ZrkL5M8abZtm/Jl0wfDcmhiZyepJAfPpe0k5J/kzKb8jiTvmmPbZZ1/ktVJbkhya5ItSY6fbdumfDnl/xdJ7k1ye19ZZ8bAIfl3ZvyDwX3QF+vCGDgw/w6NgYN+B7o0Bh6R5Nok32j+rd/UlHdiHByRf2fGwWF90BffO+NgVU3EC1gBfAd4BvBY4DbgaOBdwDlNnXOAi2bbtomNbb9UXiP64EXAPk2diya1D8bkcARwNfA94OAu5Q+sB74APK6pd0jH8r8GeElT56XA5knMv7m+E4Fjgdv7yro0Bg7KvxPj36g+aMonfgwc8TPQiTFwRP5dGgMPA45ttg8E7qRDfwuOyL8z4+CwPmj299o4uOgd0WKHngBc3bf/1ub1TeCwvk7/5mzbNttj2y+V16g8+speAWyaxD4Yk8PlwLOA7UN+qSY2f+Ay4AXz6Lvlnv/VwKuastOAj09i/n3XvopH/3HVmTFwUP4zYhM7/o3rgy6MgcPy78oYOCL/To2BM/L6DPDCro2DM/OfUdaJcXBQH+zNcXCSbhH8ReDuvv0fNGWHVtU9AM37IQBJDk9y1Zi2DGu/RI3KY9rvA5+HieyDgTkkeRnwD1V1W3/lruQPHAU8P8mNSa5LshY6lf9ZwLuT3A38Kb0BcxLzH6ZLY+A4kzz+DdWhMXCYroyBw5xFB8fAJKuAZwM30sFxcEb+/TozDvb3wd4eB/eZ/+UvGRlQVsMqV9UOekvlc267hI3MI8m5wEPAJpjIPhiUw+OAc+ktjz9KR/Iver/nBwG/AawFLkvyjA7l/3rgzVV1RZJTgY/Q+7/Zk5b/nHQt/w6MfwMleTzdGQOH6coYOEznxsAkK4ErgLOq6l+TQelN7u/AzPz7yjszDvb3Ab2c9+o4OEkrWD+gd2/ltF8CdgD/lOQwgOb93jm0ZZbtl4qheSQ5HTgF2FDN+uZs27J8+mBQDt8Hng7clmR7U3ZLkl+YRdtJyH9HU35l9XwVeBiY+eHOSc7/dODKpuxTwKAPeE9C/sN0aQwcqCPj3zDPpDtj4DBdGQOH6dQYmGRfen9Yb6qq6bw7Mw4Oyb9T4+CAPtjr4+AkTbBuAo5M8vQkjwV+F/hs8zq9qXM6vXsxZ9uWWbZfKgbmkeTFwFuAl1XVv8+lbRNbLn0wKIcrq+qQqlpVVavo/fIcW1X/OIu2k5D/Z4FPAycDJDmK3gc3d86yLSz//HcAJzV1Tga+NYe2sHzyH6ZLY+DP6dD4N1BVbevQGDjMp+nGGDhMZ8bA9JaqPgJ8o6re0xfqxDg4LP8ujYOD+mBRxsGF+EDZYr3oLfHdSe8JIOc2ZU8BvkhvQPki8OSm/HDgqlFtR7Vfqq8hffBteveU3tq8Lp7UPhiWQ198O80HG7uSP70/Jj4G3A7cApzcsfyfB9xM72lANwLHTXD+nwDuAR6k9x+QV3dpDBySf2fGv2F9MCM+6WPgoJ+BLo2Bg/Lv0hj4PHq3dG3t+51/6bAcJq0PRuTfmXFwWB/MqLOdBR4H0zSSJEmSJM3TJN0iKEmSJEmLygmWJEmSJLXECZYkSZIktcQJliRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRp4iQ5N8kdSbYmuTXJc5JsT3LwYl+bJGmy7bPYFyBJUpuSnACcAhxbVQ80k6rHLvJlSZI6whUsSdKkOQzYWVUPAFTVzqra0cTOTHJLkm1JfgUgyZOTfLpZ7bohyTFN+flJPprk/0vyrSSvXZx0JEnLiRMsSdKkuQY4IsmdST6Y5KS+2M6qOhb4EHB2U3YB8LWqOgZ4G/D/9tU/BvhfgROAdyQ5fOEvX5K0nDnBkiRNlKq6HzgO2Aj8EPhkkjOa8JXN+83Aqmb7ecBHm7b/H/CUJE9sYp+pql1VtRO4Fjh+wROQJC1rfgZLkjRxqmo3sBnYnGQbcHoTeqB5380j/w3MoEPMeJ9ZLknSQK5gSZImSpJfTnJkX9Fq4HsjmnwJ2NC0XUfvNsJ/bWL/W5L9kjwFWAfc1Pb1SpImiytYkqRJsxJ4f5InAQ8B36Z3u+ApQ+qfD/w/SbYC/84jq10AXwX+Gnga8H/2PSxDkqSBUuXdDpIkzZTkfOD+qvrTxb4WSdLy4S2CkiRJktQSV7AkSZIkqSWuYEmSJElSS5xgSZIkSVJLfIqg32kiSZIkddWg70KcFydYjO7VMr6o8aVwDcaNG1+4+FK4hjbi6zcPj1+7bvGv74Lzh8fPO3/h2y92fFyFpf7vt5TjS+EajBuf9xjRMm8RlCRJkqSWOMGSJEmSpJY4wZIkSZKkloydYCU5N8kdSbYmuTXJc5rys5I8fq4nTHJGksNnE0tySZKj53oOSZIkSVoMIydYSU4ATgGOrapjgBcAdzfhs4A5TbCSrADOAAZOsGbGquo1VfX1uZxDkiRJkhbLuBWsw4CdVfUAQFXtrKodSd5IbyJ0bZJrAZJ8KMmWZrXrgukDJNme5B1JrgdOA9YAm5rVsP376r1yZizJ5iRrmvj9SS5KcnOSLyQ5vonfleRlTZ0VSd6d5KZmxe11rfWUJEmSJI0xboJ1DXBEkjuTfDDJSQBV9T5gB7C+qtY3dc+tqjXAMcBJSY7pO85Pqup5VfUxYAuwoapWV9Wu6QpVdfmwWOMAYHNVHQfcB/wR8ELgFcA7mzqvBn5cVWuBtcBrkzx9ZlJJNjaTwS1TU1NjukCSJEmSZmfk92BV1f1JjgOeD6wHPpnknKq6dED1U5NsbI55GHA0sLWJfbKFa/0p8DfN9jbggap6MMk2YFVT/iLgmGY1DOCJwJHAd2fkNQVMz6zKZS5JkiRJbRj7RcNVtRvYDGxuJjOnA5f212lWic4G1lbVj5JcCuzXV+XfWrjWB6tq+rvAHgamb1t8OMl0HgHOrKqrWzifJEmSJM3JuIdc/HKSI/uKVgPfa7bvAw5stp9AbxL14ySHAi8Zcdj+dnOJzcbVwOuT7AuQ5KgkB8zjeJIkSZI0a+NWsFYC70/yJOAh4NvAxiY2BXw+yT1VtT7J14A7gLuAL4845qXAxUl2ASfM+KzVo2JzzAXgEnq3C96SJMAPgZfvwXEkSZIkac7GfQbrZuC5Q2LvB97ft3/GkHqrZuxfAVwxpO7M2Lq+2Mq+7fNntFvZvD8MvK15SZIkSdJeNfaLhiVJkiRJs5NHnhvRWZ3vAEmSJKmj0vYBxz5FsAtG9WoZX9T4UrgG48aNL1x8KVyD8fEVFvr8nzp1ePx3Llv485/6qeHxy35nfHyp96+/w8aNj463zVsEJUmSJKklTrAkSZIkqSV7NMFKsjvJrX2vc+bYfnuSgweUv23G/lf25PokSZIkaTHs6WewdlXV6jYvpPE24E+md6pq4CPiJUmSJGkpavUWwWZl6oIktyTZluRXmvKnJLkmydeSfJgBnzVLciGwf7Mitqkpu795X5fkuiSXJbkzyYVJNiT5anOeZzb1nprkiiQ3Na/fbDM/SZIkSRplTydY0xOh6der+mI7q+pY4EPA2U3ZecD1VfVs4LPA02YesKrOoVkZq6oNA875LOBNwK8DvwccVVXHA5cAZzZ1/gx4b1WtBX67if2cJBuTbEmyZWpqao6pS5IkSdJgC3GL4JXN+83AbzXbJ05vV9VfJ/nRHpzzpqq6ByDJd4BrmvJtwPpm+wXA0cnPFsiekOTAqrqv/0BVNQVMz6zqdXtwMZIkSZI000J8D9YDzfvuGcef72PmH+jbfrhv/+G+8zwGOKGqds3zXJIkSZI0Z3vrMe1fAjYAJHkJcNCQeg8m2Xce57kGeMP0TpLV8ziWJEmSJM1JW5/BunBM/QuAE5PcArwI+P6QelPA1umHXOyBNwJrkmxN8nXgD/bwOJIkSZI0Z3t0i2BVrRhSvqpvewuwrtn+Z3oTq2lvHtL+LcBb+vZXNu+bgc195ev6tn8Wq6qdQP8DNyRJkiRpr9lbtwhKkiRJ0sRL1XyfPbHsdb4DJEmSpI76ue/nna+FeIrgsnPqp4bHLvsd+NSpw+O/cxmj/1lqbHje7cdd/7j2Szm+FK7BuHHjCxdfCtdg3LjxPY8vhWswbny+8bZ5i6AkSZIktcQJliRJkiS1ZF4TrCS7m8e035HktiR/mKS1SVuSM5Ic3rd/SZKj2zq+JEmSJLVpvp/B2lVVqwGSHAJ8HHgicN5sD5BkRVXtHhI+A7gd2AFQVa+Zz8VKkiRJ0kJqbbWpqu4FNgJvSM8ZST4wHU/yuSTrmu37k7wzyY3ACUnekeSmJLcnmWravxJYA2xqVsn2T7I5yZrmGKcl2da0uajvPPcn+eNmRe2GJIe2laMkSZIkjdLqZ7Cq6q7mmIeMqXoAcHtVPaeqrgc+UFVrq+rXgP2BU6rqcmALsKGqVlfVrunGzW2DFwEnA6uBtUle3nfsG6rqWcCXgNfOPHmSjUm2JNkyNTU1j4wlSZIk6REL8ZCL2TxLfjdwRd/++iQ3JtlGb9L0q2ParwU2V9UPq+ohYBNwYhP7KfC5ZvtmYNXMxlU1VVVrqmrNxo0bZ3G5kiRJkjReq9+DleQZ9CZP9wIP8egJ3H592z+Z/txVkv2ADwJrquruJOfPqDvwVCNiD9Yj3568G7/rS5IkSdJe0uYT/54KXEzvdr8CtgOrkzwmyRHA8UOaTk+mdiZZCbyyL3YfcOCANjcCJyU5OMkK4DTguhbSkCRJkqQ9Nt/Vnf2T3ArsS2/F6qPAe5rYl4HvAtvoPQnwlkEHqKp/SfLnTb3twE194UuBi5PsAk7oa3NPkrcC19Jbzbqqqj4zz1wkSZIkaV7mNcGqqhUjYgVsGBJbOWP/7cDbB9S7gkd/VmtdX+zj9B4LP/TYzYMyLh+agCRJkiS1aCEeciFJkiRJneQES5IkSZJakkceuNdNSTZWVWe/DKvr+YN9YP7m3+X8wT4wf/Pvcv5gH5h/+/m7ggVd/yKsrucP9oH5d1vX8wf7wPy7rev5g31g/i1zgiVJkiRJLXGCJUmSJEktcYIFnb3ntNH1/ME+MP9u63r+YB+Yf7d1PX+wD8y/ZZ1/yIUkSZIktcUVLEmSJElqiRMsSZIkSWrJRE2wkrw4yTeTfDvJOU3Zk5P8bZJvNe8HzbbtXNovFUP64N1J/j7J1iR/meRJs23blC+bPhiWQxM7O0klOXgubSch/yRnNuV3JHnXHNsu6/yTrE5yQ5Jbk2xJcvxs2zblyyn/v0hyb5Lb+8o6MwYOyb8z4x8M7oO+WBfGwIH5d2gMHPQ70KUx8Igk1yb5RvNv/aamvBPj4Ij8OzMODuuDvvjeGQeraiJewArgO8AzgMcCtwFHA+8CzmnqnANcNNu2TWxs+6XyGtEHLwL2aepcNKl9MCaHI4Crge8BB3cpf2A98AXgcU29QzqW/zXAS5o6LwU2T2L+zfWdCBwL3N5X1qUxcFD+nRj/RvVBUz7xY+CIn4FOjIEj8u/SGHgYcGyzfSBwJx36W3BE/p0ZB4f1QbO/18bBRe+IFjv0BODqvv23Nq9vAof1dfo3Z9u22R7bfqm8RuXRV/YKYNMk9sGYHC4HngVsH/JLNbH5A5cBL5hH3y33/K8GXtWUnQZ8fBLz77v2VTz6j6vOjIGD8p8Rm9jxb1wfdGEMHJZ/V8bAEfl3agyckddngBd2bRycmf+Msk6Mg4P6YG+Og5N0i+AvAnf37f+gKTu0qu4BaN4PAUhyeJKrxrRlWPslalQe034f+DxMZB8MzCHJy4B/qKrb+it3JX/gKOD5SW5Mcl2StdCp/M8C3p3kbuBP6Q2Yk5j/MF0aA8eZ5PFvqA6NgcN0ZQwc5iw6OAYmWQU8G7iRDo6DM/Lv15lxsL8P9vY4uM/8L3/JyICyGla5qnbQWyqfc9slbGQeSc4FHgI2wUT2waAcHgecS295/FE6kn/R+z0/CPgNYC1wWZJndCj/1wNvrqorkpwKfITe/82etPznpGv5d2D8GyjJ4+nOGDhMV8bAYTo3BiZZCVwBnFVV/5oMSm9yfwdm5t9X3plxsL8P6OW8V8fBSVrB+gG9eyun/RKwA/inJIcBNO/3zqEts2y/VAzNI8npwCnAhmrWN2fbluXTB4Ny+D7wdOC2JNubsluS/MIs2k5C/jua8iur56vAw8DMD3dOcv6nA1c2ZZ8CBn3AexLyH6ZLY+BAHRn/hnkm3RkDh+nKGDhMp8bAJPvS+8N6U1VN592ZcXBI/p0aBwf0wV4fBydpgnUTcGSSpyd5LPC7wGeb1+lNndPp3Ys527bMsv1SMTCPJC8G3gK8rKr+fS5tm9hy6YNBOVxZVYdU1aqqWkXvl+fYqvrHWbSdhPw/C3waOBkgyVH0Pri5c5ZtYfnnvwM4qalzMvCtObSF5ZP/MF0aA39Oh8a/gapqW4fGwGE+TTfGwGE6Mwamt1T1EeAbVfWevlAnxsFh+XdpHBzUB4syDi7EB8oW60Vvie9Oek8AObcpewrwRXoDyheBJzflhwNXjWo7qv1SfQ3pg2/Tu6f01uZ18aT2wbAc+uLbaT7Y2JX86f0x8THgduAW4OSO5f884GZ6TwO6EThugvP/BHAP8CC9/4C8uktj4JD8OzP+DeuDGfFJHwMH/Qx0aQwclH+XxsDn0bula2vf7/xLh+UwaX0wIv/OjIPD+mBGne0s8DiYppEkSZIkaZ4m6RZBSZIkSVpUTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJy06SSvLRvv19kvwwyefmeJzNSdY021cledIeXMsZST4w13aSpMm0z2JfgCRJe+DfgF9Lsn9V7QJeCPzDfA5YVS9t5cokSZ3mCpYkabn6PPC/NtunAZ+YDiQ5IMlfJLkpydeS/G9N+f5J/luSrUk+Cezf12Z7koOb7f/c1LlteqUsyX9KcmNzvC8kOXRvJSpJWj6cYEmSlqv/Bvxukv2AY4Ab+2LnAv9fVa0F1gPvTnIA8Hrg36vqGOCPgeNmHjTJrzbtT66qZwFvakLXA79RVc9uzv1fFiYtSdJy5i2CkqRlqaq2JllFb/XqqhnhFwEvS3J2s78f8DTgROB9fe23Djj0ycDlVbWzqfc/mvJfAj6Z5DDgscB3W0xHkjQhnGBJkpazzwJ/CqwDntJXHuC3q+qb/ZWTANSYY2ZInfcD76mqzyZZB5y/JxcsSZps3iIoSVrO/gJ4Z1Vtm1F+NXBmmhlVkmc35V8CNjRlv0bv1sKZvgicmuQpTb0nN+VP5JEHaZzeWgaSpIniBEuStGxV1Q+q6s8GhP5PYF9ga5Lbm32ADwErm1sD/wvw1QHHvIPe57OuS3Ib8J4mdD7wqST/HdjZaiKSpImRqnF3SkiSJEmSZsMVLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqid+DNf77UCRJkiRNprR9QCdYjO7VMr6o8aVwDcaNG1+4+FK4BuPj4+MqLPb1GV+8+FK4BuPG5z3GtcxbBCVJkiSpJU6wJEmSJKklTrAkSZIkqSVjJ1hJzk1yR5KtSW5N8pym/Kwkj5/rCZOckeTw2cSSXJLk6LmeQ5IkSZIWw8gJVpITgFOAY6vqGOAFwN1N+CxgThOsJCuAM4CBE6yZsap6TVV9fS7nkCRJkqTFMm4F6zBgZ1U9AFBVO6tqR5I30psIXZvkWoAkH0qypVntumD6AEm2J3lHkuuB04A1wKZmNWz/vnqvnBlLsjnJmiZ+f5KLktyc5AtJjm/idyV5WVNnRZJ3J7mpWXF7XWs9JUmSJEljjJtgXQMckeTOJB9MchJAVb0P2AGsr6r1Td1zq2oNcAxwUpJj+o7zk6p6XlV9DNgCbKiq1VW1a7pCVV0+LNY4ANhcVccB9wF/BLwQeAXwzqbOq4EfV9VaYC3w2iRPn5lUko3NZHDL1NTUmC6QJEmSpNkZ+T1YVXV/kuOA5wPrgU8mOaeqLh1Q/dQkG5tjHgYcDWxtYp9s4Vp/CvxNs70NeKCqHkyyDVjVlL8IOKZZDQN4InAk8N0ZeU0B0zOrcplLkiRJUhvGftFwVe0GNgObm8nM6cCl/XWaVaKzgbVV9aMklwL79VX5txau9cGqmv4usIeB6dsWH04ynUeAM6vq6hbOJ0mSJElzMu4hF7+c5Mi+otXA95rt+4ADm+0n0JtE/TjJocBLRhy2v91cYrNxNfD6JPsCJDkqyQHzOJ4kSZIkzdq4FayVwPuTPAl4CPg2sLGJTQGfT3JPVa1P8jXgDuAu4MsjjnkpcHGSXcAJMz5r9ajYHHMBuITe7YK3JAnwQ+Dle3AcSZIkSZqzPHLXXWdVRgXp3XdofHHiS+EajBs3vnDxpXANxsfHx1VY7OszvnjxpXANxo3PMz7uR3zOxn7RsCRJkiRpdlzBav7nnCRJkqTOaX0Fa+xTBLtgiS9bdjq+FK7BuHHjCxdfCtdg3Li3UO55fClcg3Hj8/4dbpm3CEqSJElSS5xgSZIkSVJL9miClWR3klv7XufMsf32JAcPKH/bjP2v7Mn1SZIkSdJi2NPPYO2qqtVtXkjjbcCfTO9U1XMX4BySJEmStCBavUWwWZm6IMktSbYl+ZWm/ClJrknytSQfZsBnzZJcCOzfrIhtasrub97XJbkuyWVJ7kxyYZINSb7anOeZTb2nJrkiyU3N6zfbzE+SJEmSRtnTCdb0RGj69aq+2M6qOhb4EHB2U3YecH1VPRv4LPC0mQesqnNoVsaqasOAcz4LeBPw68DvAUdV1fHAJcCZTZ0/A95bVWuB325iPyfJxiRbkmyZmpqaY+qSJEmSNNhC3CJ4ZfN+M/BbzfaJ09tV9ddJfrQH57ypqu4BSPId4JqmfBuwvtl+AXB08rMFsickObCq7us/UFVNAdMzq3rdHlyMJEmSJM20EN+D9UDzvnvG8ef7mPkH+rYf7tt/uO88jwFOqKpd8zyXJEmSJM3Z3npM+5eADQBJXgIcNKTeg0n2ncd5rgHeML2TZPU8jiVJkiRJc9LWZ7AuHFP/AuDEJLcALwK+P6TeFLB1+iEXe+CNwJokW5N8HfiDPTyOJEmSJM1ZquZ7596yVz/3SMP+IAMeeWh8r8WXwjUYN2584eJL4RqMG59vfFyFxb4+f4eNGx8ZH/cjPmd76xZBSZIkSZp4rmDN/+EbkiRJkpan1lewFuIpgsvOEl+2XPT4Yt760MYxjBs3vnTjS+EajBs3vufxpXANxo3P+2/dlnmLoCRJkiS1xAmWJEmSJLVkXhOsJLubx7TfkeS2JH+YpLVJW5Izkhzet39JkqPbOr4kSZIktWm+n8HaVVWrAZIcAnwceCJw3mwPkGRFVe0eEj4DuB3YAVBVr5nPxUqSJEnSQmpttamq7gU2Am9IzxlJPjAdT/K5JOua7fuTvDPJjcAJSd6R5KYktyeZatq/ElgDbGpWyfZPsjnJmuYYpyXZ1rS5qO889yf542ZF7YYkh7aVoyRJkiSN0upnsKrqruaYh4ypegBwe1U9p6quBz5QVWur6teA/YFTqupyYAuwoapWV9Wu6cbNbYMXAScDq4G1SV7ed+wbqupZwJeA1848eZKNSbYk2TI1NTWPjCVJkiTpEQvxmPbZPEt+N3BF3/76JP8FeDzwZOAO4K9GtF8LbK6qHwIk2QScCHwa+CnwuabezcALZzauqilgemZVr5vFBUuSJEnSOK1OsJI8g97k6V7gIR69QrZf3/ZPpj93lWQ/4IPAmqq6O8n5M+oOPNWI2IP1yLcn78bv+pIkSZK0l7T5xL+nAhfTu92vgO3A6iSPSXIEcPyQptOTqZ1JVgKv7IvdBxw4oM2NwElJDk6yAjgNuK6FNCRJkiRpj813dWf/JLcC+9Jbsfoo8J4m9mXgu8A2ek8CvGXQAarqX5L8eVNvO3BTX/hS4OIku4AT+trck+StwLX0VrOuqqrPzDMXSZIkSZqXPHI3XWfVqPsNi9H3I3YhPq7CQp6/jWMYN2586caXwjUYN258z+NL4RqMG59nfDbPj5iTVp8iKEmSJEld5gRLkiRJklrS+VsEk2xsHtveSV3PH+wD8zf/LucP9oH5m3+X8wf7wPzbz98VLNi42BewyLqeP9gH5t9tXc8f7APz77au5w/2gfm3zAmWJEmSJLXECZYkSZIktcQJFnT2ntNG1/MH+8D8u63r+YN9YP7d1vX8wT4w/5Z1/iEXkiRJktQWV7AkSZIkqSVOsCRJkiSpJRM1wUry4iTfTPLtJOc0ZU9O8rdJvtW8HzTbtnNpv1QM6YN3J/n7JFuT/GWSJ822bVO+bPpgWA5N7OwkleTgubSdhPyTnNmU35HkXXNsu6zzT7I6yQ1Jbk2yJcnxs23blC+n/P8iyb1Jbu8r68wYOCT/zox/MLgP+mJdGAMH5t+hMXDQ70CXxsAjklyb5BvNv/WbmvJOjIMj8u/MODisD/rie2ccrKqJeAErgO8AzwAeC9wGHA28CzinqXMOcNFs2zaxse2XymtEH7wI2Kepc9Gk9sGYHI4Arga+BxzcpfyB9cAXgMc19Q7pWP7XAC9p6rwU2DyJ+TfXdyJwLHB7X1mXxsBB+Xdi/BvVB035xI+BI34GOjEGjsi/S2PgYcCxzfaBwJ106G/BEfl3Zhwc1gfN/l4bBxe9I1rs0BOAq/v239q8vgkc1tfp35xt22Z7bPul8hqVR1/ZK4BNk9gHY3K4HHgWsH3IL9XE5g9cBrxgHn233PO/GnhVU3Ya8PFJzL/v2lfx6D+uOjMGDsp/Rmxix79xfdCFMXBY/l0ZA0fk36kxcEZenwFe2LVxcGb+M8o6MQ4O6oO9OQ5O0i2Cvwjc3bf/g6bs0Kq6B6B5PwQgyeFJrhrTlmHtl6hReUz7feDzMJF9MDCHJC8D/qGqbuuv3JX8gaOA5ye5Mcl1SdZCp/I/C3h3kruBP6U3YE5i/sN0aQwcZ5LHv6E6NAYO05UxcJiz6OAYmGQV8GzgRjo4Ds7Iv19nxsH+Ptjb4+A+87/8JSMDympY5araQW+pfM5tl7CReSQ5F3gI2AQT2QeDcngccC695fFH6Uj+Re/3/CDgN4C1wGVJntGh/F8PvLmqrkhyKvARev83e9Lyn5Ou5d+B8W+gJI+nO2PgMF0ZA4fp3BiYZCVwBXBWVf1rMii9yf0dmJl/X3lnxsH+PqCX814dBydpBesH9O6tnPZLwA7gn5IcBtC83zuHtsyy/VIxNI8kpwOnABuqWd+cbVuWTx8MyuH7wNOB25Jsb8puSfILs2g7CfnvaMqvrJ6vAg8DMz/cOcn5nw5c2ZR9Chj0Ae9JyH+YLo2BA3Vk/BvmmXRnDBymK2PgMJ0aA5PsS+8P601VNZ13Z8bBIfl3ahwc0Ad7fRycpAnWTcCRSZ6e5LHA7wKfbV6nN3VOp3cv5mzbMsv2S8XAPJK8GHgL8LKq+ve5tG1iy6UPBuVwZVUdUlWrqmoVvV+eY6vqH2fRdhLy/yzwaeBkgCRH0fvg5s5ZtoXln/8O4KSmzsnAt+bQFpZP/sN0aQz8OR0a/waqqm0dGgOH+TTdGAOH6cwYmN5S1UeAb1TVe/pCnRgHh+XfpXFwUB8syji4EB8oW6wXvSW+O+k9AeTcpuwpwBfpDShfBJ7clB8OXDWq7aj2S/U1pA++Te+e0lub18WT2gfDcuiLb6f5YGNX8qf3x8THgNuBW4CTO5b/84Cb6T0N6EbguAnO/xPAPcCD9P4D8uoujYFD8u/M+DesD2bEJ30MHPQz0KUxcFD+XRoDn0fvlq6tfb/zLx2Ww6T1wYj8OzMODuuDGXW2s8DjYJpGkiRJkqR5mqRbBCVJkiRpUTnBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJE2MJL+U5DNJvpXkO0n+LMljk6xO8tK+eucnOXsxr1WSNJmcYEmSJkKSAFcCn66qI4GjgJXAHwOrgZcObz3nc61o61iSpMniBEuSNClOBn5SVf8PQFXtBt4MvAZ4F/CqJLcmeVVT/+gkm5PcleSN0wdJ8r8n+WpT98PTk6kk9yd5Z5IbgRP2amaSpGXDCZYkaVL8KnBzf0FV/SuwHfgj4JNVtbqqPtmEfwX4X4DjgfOS7JvkfwJeBfxmVa0GdgMbmvoHALdX1XOq6vqFTkaStDzts9gXIElSSwLUHMr/uqoeAB5Ici9wKPA/A8cBN/XuOGR/4N6m/m7girYvWpI0WZxgSZImxR3Ab/cXJHkCcAS9ydFMD/Rt76b338QA/7Wq3jqg/k+a2w4lSRrKWwQlSZPii8Djk/xn+NmDKP5v4FLgn4ADZ3mMVyY5pDnGk5P8h4W5XEnSJHKCJUmaCFVVwCuA30nyLeBO4CfA24Br6T3Uov8hF4OO8XXg7cA1SbYCfwsctuAXL0maGOn990iSJEmSNF+uYEmSJElSS5xgSZIkSVJLnGBJkiRJUkucYEmSJElSS/werMFfPilJkiRp8qXtAzrBYnSvlvFFjS+FazBu3PjCxZfCNcwmPq7CUj/+BecPj593/vj4Yve/8aUbXwrXsDfi6zcPj1+7bukf3/joeNu8RVCSJEmSWuIES5IkSZJa4gRLkiRJkloydoKV5NwkdyTZmuTWJM9pys9K8vi5njDJGUkOn00sySVJjp7rOSRJkiRpMYycYCU5ATgFOLaqjgFeANzdhM8C5jTBSrICOAMYOMGaGauq11TV1+dyDkmSJElaLONWsA4DdlbVAwBVtbOqdiR5I72J0LVJrgVI8qEkW5rVrgumD5Bke5J3JLkeOA1YA2xqVsP276v3ypmxJJuTrGni9ye5KMnNSb6Q5PgmfleSlzV1ViR5d5KbmhW317XWU5IkSZI0xrgJ1jXAEUnuTPLBJCcBVNX7gB3A+qpa39Q9t6rWAMcAJyU5pu84P6mq51XVx4AtwIaqWl1Vu6YrVNXlw2KNA4DNVXUccB/wR8ALgVcA72zqvBr4cVWtBdYCr03y9JlJJdnYTAa3TE1NjekCSZIkSZqdkd+DVVX3JzkOeD6wHvhkknOq6tIB1U9NsrE55mHA0cDWJvbJFq71p8DfNNvbgAeq6sEk24BVTfmLgGOa1TCAJwJHAt+dkdcUMD2zKpe5JEmSJLVh7BcNV9VuYDOwuZnMnA5c2l+nWSU6G1hbVT9KcimwX1+Vf2vhWh+squnvAnsYmL5t8eEk03kEOLOqrm7hfJIkSZI0J+MecvHLSY7sK1oNfK/Zvg84sNl+Ar1J1I+THAq8ZMRh+9vNJTYbVwOvT7IvQJKjkhwwj+NJkiRJ0qyNW8FaCbw/yZOAh4BvAxub2BTw+ST3VNX6JF8D7gDuAr484piXAhcn2QWcMOOzVo+KzTEXgEvo3S54S5IAPwRevgfHkSRJkqQ5G/cZrJuB5w6JvR94f9/+GUPqrZqxfwVwxZC6M2Pr+mIr+7bPn9FuZfP+MPC25iVJkiRJe9XYLxqWJEmSJM1OHnluRGd1vgMkSZKkjkrbBxz7FMEuWL95eOzadaN7vTC+kPGlcA3GjRtfuPhSuIa9ER9XYbGv74Lzh8fPO398fNL7x/hoi30NkxD3b9HFjbfNWwQlSZIkqSVOsCRJkiSpJXs0wUqyO8mtfa9z5th+e5KDB5S/bcb+V/bk+iRJkiRpMezpZ7B2VdXqNi+k8TbgT6Z3qmrgI+IlSZIkaSlq9RbBZmXqgiS3JNmW5Fea8qckuSbJ15J8mAGfNUtyIbB/syK2qSm7v3lfl+S6JJcluTPJhUk2JPlqc55nNvWemuSKJDc1r99sMz9JkiRJGmVPJ1jTE6Hp16v6Yjur6ljgQ8DZTdl5wPVV9Wzgs8DTZh6wqs6hWRmrqg0Dzvks4E3ArwO/BxxVVccDlwBnNnX+DHhvVa0FfruJ/ZwkG5NsSbJlampqjqlLkiRJ0mALcYvglc37zcBvNdsnTm9X1V8n+dEenPOmqroHIMl3gGua8m3A+mb7BcDRyc8WyJ6Q5MCquq//QFU1BUzPrOoTm/fgaiRJkiRphoX4HqwHmvfdM44/38fMP9C3/XDf/sN953kMcEJV7ZrnuSRJkiRpzvbWY9q/BGwASPIS4KAh9R5Msu88znMN8IbpnSSr53EsSZIkSZqTtj6DdeGY+hcAJya5BXgR8P0h9aaArdMPudgDbwTWJNma5OvAH+zhcSRJkiRpzvboFsGqWjGkfFXf9hZgXbP9z/QmVtPePKT9W4C39O2vbN43A5v7ytf1bf8sVlU7gf4HbkiSJEnSXrO3bhGUJEmSpImXqvk+e2LZ63wHSJIkSR31c9/PO18L8RTBZeeC84fHzjt/fHzkP0vB+s3Dw9euG9t8wePjKsz3+PPJf7bnMG7c+PKML4VrMG7c+J7Hl8I1GDc+77+FW+YtgpIkSZLUEidYkiRJktSSeU2wkuxuHtN+R5LbkvxhktYmbUnOSHJ43/4lSY5u6/iSJEmS1Kb5fgZrV1WtBkhyCPBx4InAebM9QJIVVbV7SPgM4HZgB0BVvWY+FytJkiRJC6m11aaquhfYCLwhPWck+cB0PMnnkqxrtu9P8s4kNwInJHlHkpuS3J5kqmn/SmANsKlZJds/yeYka5pjnJZkW9Pmor7z3J/kj5sVtRuSHNpWjpIkSZI0Squfwaqqu5pjHjKm6gHA7VX1nKq6HvhAVa2tql8D9gdOqarLgS3AhqpaXVW7phs3tw1eBJwMrAbWJnl537FvqKpnAV8CXjvz5Ek2JtmSZMvU1NQ8MpYkSZKkRyzEQy5m8yz53cAVffvrk9yYZBu9SdOvjmm/FthcVT+sqoeATcCJTeynwOea7ZuBVTMbV9VUVa2pqjUbN26cxeVKkiRJ0nitfg9WkmfQmzzdCzzEoydw+/Vt/2T6c1dJ9gM+CKypqruTnD+j7sBTjYg9WI98e/Ju/K4vSZIkSXtJm0/8eypwMb3b/QrYDqxO8pgkRwDHD2k6PZnamWQl8Mq+2H3AgQPa3AiclOTgJCuA04DrWkhDkiRJkvbYfFd39k9yK7AvvRWrjwLvaWJfBr4LbKP3JMBbBh2gqv4lyZ839bYDN/WFLwUuTrILOKGvzT1J3gpcS28166qq+sw8c5EkSZKkeZnXBKuqVoyIFbBhSGzljP23A28fUO8KHv1ZrXV9sY/Teyz80GM3D8q4fGgCkiRJktSihXjIhSRJkiR1khMsSZIkSWpJHnngXjcl2VhVnf0yrK7nD/aB+Zt/l/MH+8D8zb/L+YN9YP7t5+8KFnT9i7C6nj/YB+bfbV3PH+wD8++2rucP9oH5t8wJliRJkiS1xAmWJEmSJLXECRZ09p7TRtfzB/vA/Lut6/mDfWD+3db1/ME+MP+Wdf4hF5IkSZLUFlewJEmSJKklTrAkSZIkqSUTNcFK8uIk30zy7STnNGVPTvK3Sb7VvB8027Zzab9UDOmDdyf5+yRbk/xlkifNtm1Tvmz6YFgOTezsJJXk4Lm0nYT8k5zZlN+R5F1zbLus80+yOskNSW5NsiXJ8bNt25Qvp/z/Ism9SW7vK+vMGDgk/86MfzC4D/piXRgDB+bfoTFw0O9Al8bAI5Jcm+Qbzb/1m5ryToyDI/LvzDg4rA/64ntnHKyqiXgBK4DvAM8AHgvcBhwNvAs4p6lzDnDRbNs2sbHtl8prRB+8CNinqXPRpPbBmByOAK4Gvgcc3KX8gfXAF4DHNfUO6Vj+1wAvaeq8FNg8ifk313cicCxwe19Zl8bAQfl3Yvwb1QdN+cSPgSN+BjoxBo7Iv0tj4GHAsc32gcCddOhvwRH5d2YcHNYHzf5eGwcXvSNa7NATgKv79t/avL4JHNbX6d+cbdtme2z7pfIalUdf2SuATZPYB2NyuBx4FrB9yC/VxOYPXAa8YB59t9zzvxp4VVN2GvDxScy/79pX8eg/rjozBg7Kf0ZsYse/cX3QhTFwWP5dGQNH5N+pMXBGXp8BXti1cXBm/jPKOjEODuqDvTkOTtItgr8I3N23/4Om7NCqugegeT8EIMnhSa4a05Zh7ZeoUXlM+33g8zCRfTAwhyQvA/6hqm7rr9yV/IGjgOcnuTHJdUnWQqfyPwt4d5K7gT+lN2BOYv7DdGkMHGeSx7+hOjQGDtOVMXCYs+jgGJhkFfBs4EY6OA7OyL9fZ8bB/j7Y2+PgPvO//CUjA8pqWOWq2kFvqXzObZewkXkkORd4CNgEE9kHg3J4HHAuveXxR+lI/kXv9/wg4DeAtcBlSZ7RofxfD7y5qq5IcirwEXr/N3vS8p+TruXfgfFvoCSPpztj4DBdGQOH6dwYmGQlcAVwVlX9azIovcn9HZiZf195Z8bB/j6gl/NeHQcnaQXrB/TurZz2S8AO4J+SHAbQvN87h7bMsv1SMTSPJKcDpwAbqlnfnG1blk8fDMrh+8DTgduSbG/KbknyC7NoOwn572jKr6yerwIPAzM/3DnJ+Z8OXNmUfQoY9AHvSch/mC6NgQN1ZPwb5pl0Zwwcpitj4DCdGgOT7EvvD+tNVTWdd2fGwSH5d2ocHNAHe30cnKQJ1k3AkUmenuSxwO8Cn21epzd1Tqd3L+Zs2zLL9kvFwDySvBh4C/Cyqvr3ubRtYsulDwblcGVVHVJVq6pqFb1fnmOr6h9n0XYS8v8s8GngZIAkR9H74ObOWbaF5Z//DuCkps7JwLfm0BaWT/7DdGkM/DkdGv8GqqptHRoDh/k03RgDh+nMGJjeUtVHgG9U1Xv6Qp0YB4fl36VxcFAfLMo4uBAfKFusF70lvjvpPQHk3KbsKcAX6Q0oXwSe3JQfDlw1qu2o9kv1NaQPvk3vntJbm9fFk9oHw3Loi2+n+WBjV/Kn98fEx4DbgVuAkzuW//OAm+k9DehG4LgJzv8TwD3Ag/T+A/LqLo2BQ/LvzPg3rA9mxCd9DBz0M9ClMXBQ/l0aA59H75aurX2/8y8dlsOk9cGI/DszDg7rgxl1trPA42CaRpIkSZKkeZqkWwQlSZIkaVE5wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRNnCSbk/wvM8rOSnJXknNGtFuT5H3N9rokz13oa5UkTZZ9FvsCJElaAJ8Afhe4uq/sd4HTq+q/D2tUVVuALc3uOuB+4CsLdI2SpAnkCpYkaRJdDpyS5HEASVYBhwP/MckHmrLfSXJ7ktuSfKkpW5fkc039PwDenOTWJM9flCwkScuOK1iSpIlTVf+c5KvAi4HP0Fu9+iRQfdXeAfwvVfUPSZ40o/32JBcD91fVn+6ly5YkTQBXsCRJk2r6NkGa90/MiH8ZuDTJa4EVe/PCJEmTywmWJGlSfRr4n5McC+xfVbf0B6vqD4C3A0cAtyZ5yt6/REnSpPEWQUnSRKqq+5NsBv6Cn1+9Iskzq+pG4MYk/4neRKvffcATFvxCJUkTxRUsSdIk+wTwLOC/DYi9O8m2JLcDXwJumxH/K+AVPuRCkjQXqarxtSRJkiRJY7mCJUmSJEktcYIlSZIkSS1xgiVJkiRJLXGCJUmSJEkt8THt4FM+JEmSpG5K2wd0gsXoXi3jixpfCtdg3HjX4+s3D49fu27v/I6Pq7DYfXTB+cPj550/Pj7uBOPaL/X8F/v6lnp8oX++l8LvsHHjSzneNm8RlCRJkqSWOMGSJEmSpJY4wZIkSZKkloydYCU5N8kdSbYmuTXJc5rys5I8fq4nTHJGksNnE0tySZKj53oOSZIkSVoMIydYSU4ATgGOrapjgBcAdzfhs4A5TbCSrADOAAZOsGbGquo1VfX1uZxDkiRJkhbLuBWsw4CdVfUAQFXtrKodSd5IbyJ0bZJrAZJ8KMmWZrXrgukDJNme5B1JrgdOA9YAm5rVsP376r1yZizJ5iRrmvj9SS5KcnOSLyQ5vonfleRlTZ0VSd6d5KZmxe11rfWUJEmSJI0xboJ1DXBEkjuTfDDJSQBV9T5gB7C+qtY3dc+tqjXAMcBJSY7pO85Pqup5VfUxYAuwoapWV9Wu6QpVdfmwWOMAYHNVHQfcB/wR8ELgFcA7mzqvBn5cVWuBtcBrkzx9ZlJJNjaTwS1TU1NjukCSJEmSZmfk92BV1f1JjgOeD6wHPpnknKq6dED1U5NsbI55GHA0sLWJfbKFa/0p8DfN9jbggap6MMk2YFVT/iLgmGY1DOCJwJHAd2fkNQVMz6zKZS5JkiRJbRj7RcNVtRvYDGxuJjOnA5f212lWic4G1lbVj5JcCuzXV+XfWrjWB6tq+rvAHgamb1t8OMl0HgHOrKqrWzifJEmSJM3JuIdc/HKSI/uKVgPfa7bvAw5stp9AbxL14ySHAi8Zcdj+dnOJzcbVwOuT7AuQ5KgkB8zjeJIkSZI0a+NWsFYC70/yJOAh4NvAxiY2BXw+yT1VtT7J14A7gLuAL4845qXAxUl2ASfM+KzVo2JzzAXgEnq3C96SJMAPgZfvwXEkSZIkac7GfQbrZuC5Q2LvB97ft3/GkHqrZuxfAVwxpO7M2Lq+2Mq+7fNntFvZvD8MvK15SZIkSdJeNfaLhiVJkiRJs5NHnhvRWZ3vAEmSJKmj0vYBxz5FsAtG9WoZX9T4UrgG48aNL1y8rXOsuXl4fMtx49vfvGZ4/LgtC99HrxvxlYwf3rjw7Rc6Pu7fZ2rE96Vs/PDiX/+kx+fT/9PHGHeSxc6x6/H5jpGTHm+btwhKkiRJUkucYEmSJElSS/ZogpVkd5Jb+17nzLH99iQHDyh/24z9r+zJ9UmSJEnSYtjTz2DtqqrVbV5I423An0zvVNXAR8RLkiRJ0lLU6i2CzcrUBUluSbItya805U9Jck2SryX5MAM+a5bkQmD/ZkVsU1N2f/O+Lsl1SS5LcmeSC5NsSPLV5jzPbOo9NckVSW5qXr/ZZn6SJEmSNMqeTrCmJ0LTr1f1xXZW1bHAh4Czm7LzgOur6tnAZ4GnzTxgVZ1DszJWVRsGnPNZwJuAXwd+Dziqqo4HLgHObOr8GfDeqloL/HYT+zlJNibZkmTL1NSIRy9JkiRJ0hwsxC2CVzbvNwO/1WyfOL1dVX+d5Ed7cM6bquoegCTfAa5pyrcB65vtFwBHJz9bIHtCkgOr6r7+A1XVFDA9s6oRTyeVJEmSpFlbiO/BeqB53z3j+PN9zPwDfdsP9+0/3HeexwAnVNWueZ5LkiRJkuZsbz2m/UvABoAkLwEOGlLvwST7zuM81wBvmN5Jsnoex5IkSZKkOWnrM1gXjql/AXBikluAFwHfH1JvCtg6/ZCLPfBGYE2SrUm+DvzBHh5HkiRJkuZsj24RrKoVQ8pX9W1vAdY12/9Mb2I17c1D2r8FeEvf/srmfTOwua98Xd/2z2JVtRPof+CGJEmSJO01e+sWQUmSJEmaeKma77Mnlr3Od4AkSZLUUT/3/bzztRBPEVx2Xvr54bGrXjI+PvKfpeCN7x8eft+ZY5tz5LeHx7/1H8e3n298XP4Lef42jrE34ov9b/T+Nw6Pn/m+xe8f48ZHWexrMG7c+J7Hl8I1GDc+33jbvEVQkiRJklriBEuSJEmSWjKvCVaS3c1j2u9IcluSP0zS2qQtyRlJDu/bvyTJ0W0dX5IkSZLaNN/PYO2qqtUASQ4BPg48EThvtgdIsqKqdg8JnwHcDuwAqKrXzOdiJUmSJGkhtbbaVFX3AhuBN6TnjCQfmI4n+VySdc32/UnemeRG4IQk70hyU5Lbk0w17V8JrAE2Natk+yfZnGRNc4zTkmxr2lzUd577k/xxs6J2Q5JD28pRkiRJkkZp9TNYVXVXc8xDxlQ9ALi9qp5TVdcDH6iqtVX1a8D+wClVdTmwBdhQVauratd04+a2wYuAk4HVwNokL+879g1V9SzgS8BrZ548ycYkW5JsmZqamkfGkiRJkvSIhXjIxWyeJb8buKJvf32SG5Nsozdp+tUx7dcCm6vqh1X1ELAJOLGJ/RT4XLN9M7BqZuOqmqqqNVW1ZuPGjbO4XEmSJEkar9XvwUryDHqTp3uBh3j0BG6/vu2fTH/uKsl+wAeBNVV1d5LzZ9QdeKoRsQfrkW9P3o3f9SVJkiRpL2nziX9PBS6md7tfAduB1Ukek+QI4PghTacnUzuTrARe2Re7DzhwQJsbgZOSHJxkBXAacF0LaUiSJEnSHpvv6s7+SW4F9qW3YvVR4D1N7MvAd4Ft9J4EeMugA1TVvyT586beduCmvvClwMVJdgEn9LW5J8lbgWvprWZdVVWfmWcukiRJkjQv85pgVdWKEbECNgyJrZyx/3bg7QPqXcGjP6u1ri/2cXqPhR967OZBGZcPTUCSJEmSWrQQD7mQJEmSpE5ygiVJkiRJLckjD9zrpiQbq6qzX4bV9fzBPjB/8+9y/mAfmL/5dzl/sA/Mv/38XcGCrn8RVtfzB/vA/Lut6/mDfWD+3db1/ME+MP+WOcGSJEmSpJY4wZIkSZKkljjBgs7ec9roev5gH5h/t3U9f7APzL/bup4/2Afm37LOP+RCkiRJktriCpYkSZIktcQJliRJkiS1ZKImWElenOSbSb6d5Jym7MlJ/jbJt5r3g2bbdi7tl4ohffDuJH+fZGuSv0zypNm2bcqXTR8My6GJnZ2kkhw8l7aTkH+SM5vyO5K8a45tl3X+SVYnuSHJrUm2JDl+tm2b8uWU/18kuTfJ7X1lnRkDh+TfmfEPBvdBX6wLY+DA/Ds0Bg76HejSGHhEkmuTfKP5t35TU96JcXBE/p0ZB4f1QV9874yDVTURL2AF8B3gGcBjgduAo4F3Aec0dc4BLppt2yY2tv1SeY3ogxcB+zR1LprUPhiTwxHA1cD3gIO7lD+wHvgC8Lim3iEdy/8a4CVNnZcCmycx/+b6TgSOBW7vK+vSGDgo/06Mf6P6oCmf+DFwxM9AJ8bAEfl3aQw8DDi22T4QuJMO/S04Iv/OjIPD+qDZ32vj4KJ3RIsdegJwdd/+W5vXN4HD+jr9m7Nt22yPbb9UXqPy6Ct7BbBpEvtgTA6XA88Ctg/5pZrY/IHLgBfMo++We/5XA69qyk4DPj6J+fdd+yoe/cdVZ8bAQfnPiE3s+DeuD7owBg7Lvytj4Ij8OzUGzsjrM8ALuzYOzsx/RlknxsFBfbA3x8FJukXwF4G7+/Z/0JQdWlX3ADTvhwAkOTzJVWPaMqz9EjUqj2m/D3weJrIPBuaQ5GXAP1TVbf2Vu5I/cBTw/CQ3JrkuyVroVP5nAe9Ocjfwp/QGzEnMf5gujYHjTPL4N1SHxsBhujIGDnMWHRwDk6wCng3cSAfHwRn59+vMONjfB3t7HNxn/pe/ZGRAWQ2rXFU76C2Vz7ntEjYyjyTnAg8Bm2Ai+2BQDo8DzqW3PP4oHcm/6P2eHwT8BrAWuCzJMzqU/+uBN1fVFUlOBT5C7/9mT1r+c9K1/Dsw/g2U5PF0Zwwcpitj4DCdGwOTrASuAM6qqn9NBqU3ub8DM/PvK+/MONjfB/Ry3qvj4CStYP2A3r2V034J2AH8U5LDAJr3e+fQllm2XyqG5pHkdOAUYEM165uzbcvy6YNBOXwfeDpwW5LtTdktSX5hFm0nIf8dTfmV1fNV4GFg5oc7Jzn/04Erm7JPAYM+4D0J+Q/TpTFwoI6Mf8M8k+6MgcN0ZQwcplNjYJJ96f1hvamqpvPuzDg4JP9OjYMD+mCvj4OTNMG6CTgyydOTPBb4XeCzzev0ps7p9O7FnG1bZtl+qRiYR5IXA28BXlZV/z6Xtk1sufTBoByurKpDqmpVVa2i98tzbFX94yzaTkL+nwU+DZwMkOQoeh/c3DnLtrD8898BnNTUORn41hzawvLJf5gujYE/p0Pj30BVta1DY+Awn6YbY+AwnRkD01uq+gjwjap6T1+oE+PgsPy7NA4O6oNFGQcX4gNli/Wit8R3J70ngJzblD0F+CK9AeWLwJOb8sOBq0a1HdV+qb6G9MG36d1TemvzunhS+2BYDn3x7TQfbOxK/vT+mPgYcDtwC3Byx/J/HnAzvacB3QgcN8H5fwK4B3iQ3n9AXt2lMXBI/p0Z/4b1wYz4pI+Bg34GujQGDsq/S2Pg8+jd0rW173f+pcNymLQ+GJF/Z8bBYX0wo852FngcTNNIkiRJkjRPk3SLoCRJkiQtKidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSpImQ5P4Z+2ck+cBiXY8kqZucYEmSJElSS5xgSZImXpL/kOSLSbY2709ryi9N8qEk1ya5K8lJSf4iyTeSXNrX/kVJ/i7JLUk+lWTloiUjSVrSnGBJkibF/klunX4B7+yLfQD4f6vqGGAT8L6+2EHAycCbgb8C3gv8KvDrSVYnORh4O/CCqjoW2AL84YJnI0lalvZZ7AuQJKklu6pq9fROkjOANc3uCcBvNdsfBd7V1+6vqqqSbAP+qaq2Ne3vAFYBvwQcDXw5CcBjgb9bsCwkScuaEyxJUhdV3/YDzfvDfdvT+/sAu4G/rarT9tK1SZKWMW8RlCR1wVeA3222NwDXz6HtDcBvJvmPAEken+Solq9PkjQhnGBJkrrgjcD/kWQr8HvAm2bbsKp+CJwBfKJpfwPwKwtxkZKk5S9VNb6WJEmSJGksV7AkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJX7R8KO/bFKSJElSd6TtAzrBgtHdWmPDxhcwvhSuYRLiT/zX4fEfPwH2e2B4/CePW/zr73p8kv999tY1jOvDpd7HS/365nv948ao3/zK8PiXnwtrbh4e33Lcwl/fQh9/vv/+8z3/0+4ecQLg+0eMrvP9I+DX7hgev/1XF/9ndKnH5/sz4N8Bo+Nt8xZBSZIkSWqJEyxJkiRJasnYCVaSc5PckWRrkluTPKcpPyvJ4+d6wiRnJDl8NrEklyQ5eq7nkCRJkqTFMHKCleQE4BTg2Ko6BngBMH2X7VnAnCZYSVYAZwADJ1gzY1X1mqr6+lzOIUmSJEmLZdwK1mHAzqp6AKCqdlbVjiRvpDcRujbJtQBJPpRkS7PadcH0AZJsT/KOJNcDpwFrgE3Natj+ffVeOTOWZHOSNU38/iQXJbk5yReSHN/E70rysqbOiiTvTnJTs+L2utZ6SpIkSZLGGDfBugY4IsmdST6Y5CSAqnofsANYX1Xrm7rnVtUa4BjgpCTH9B3nJ1X1vKr6GLAF2FBVq6tq13SFqrp8WKxxALC5qo4D7gP+CHgh8ArgnU2dVwM/rqq1wFrgtUmePjOpJBubyeCWqampMV0gSZIkSbMz8jHtVXV/kuOA5wPrgU8mOaeqLh1Q/dQkG5tjHgYcDWxtYp9s4Vp/CvxNs70NeKCqHkyyDVjVlL8IOKZZDQN4InAk8N0ZeU0B0zOrwnUuSZIkSS0Y+z1YVbUb2AxsbiYzpwOX9tdpVonOBtZW1Y+SXArs11fl31q41geravpR9Q8D07ctPpxkOo8AZ1bV1S2cT5IkSZLmZNxDLn45yZF9RauB7zXb9wEHNttPoDeJ+nGSQ4GXjDhsf7u5xGbjauD1SfYFSHJUkgPmcTxJkiRJmrVxK1grgfcneRLwEPBtYGMTmwI+n+Seqlqf5GvAHcBdwJdHHPNS4OIku4ATZnzW6lGxOeYCcAm92wVvSRLgh8DL9+A4kiRJkjRn4z6DdTPw3CGx9wPv79s/Y0i9VTP2rwCuGFJ3ZmxdX2xl3/b5M9qtbN4fBt7WvCRJkiRprxr7RcOSJEmSpNnJI8+N6KzOd4AkSZLUUWn7gGOfItgJo7q1xoaNL2B8KVyD8cWPH/Wt4fE7j1z65/8P3x8e/97Txrff74Hh8Z88bum3b+N3fL59ON8cx53/ST8eHv+XJy789Y87/7j85vtvPO78C/07uti/Y0u9f+b78zGq/fQxFvu/EwsdX+ifkYW+vsX+GVzq8bZ5i6AkSZIktcQJliRJkiS1ZI8mWEl2J7m173XOHNtvT3LwgPK3zdj/yp5cnyRJkiQthj39DNauqlrd5oU03gb8yfROVQ18RLwkSZIkLUWt3iLYrExdkOSWJNuS/EpT/pQk1yT5WpIPM+CzZkkuBPZvVsQ2NWX3N+/rklyX5LIkdya5MMmGJF9tzvPMpt5Tk1yR5Kbm9Ztt5idJkiRJo+zpBGt6IjT9elVfbGdVHQt8CDi7KTsPuL6qng18FnjazANW1Tk0K2NVtWHAOZ8FvAn4deD3gKOq6njgEuDMps6fAe+tqrXAbzexn5NkY5ItSbZMTU3NMXVJkiRJGmwhbhG8snm/GfitZvvE6e2q+uskP9qDc95UVfcAJPkOcE1Tvg1Y32y/ADg6+dkC2ROSHFhV9/UfqKqmgOmZVfG6PbgaSZIkSZphIb4Ha/pJ/LtnHH++j5nvf8L/w337D/ed5zHACVW1a57nkiRJkqQ521uPaf8SsAEgyUuAg4bUezDJvvM4zzXAG6Z3kqyex7EkSZIkaU7a+gzWhWPqXwCcmOQW4EXAsO9cnwK2Tj/kYg+8EViTZGuSrwN/sIfHkSRJkqQ526NbBKtqxZDyVX3bW4B1zfY/05tYTXvzkPZvAd7St7+yed8MbO4rX9e3/bNYVe0E+h+4IUmSJEl7zd66RVCSJEmSJl6q5vvsiWWv8x0gSZIkddTPfT/vfC3EUwSXnT987/DYe948uteL+ceP+MHw+N2/NL79qZ8aHr/sd8bHT7hhePzvfmP89S1kfLrOQv8bLPS/0bj4p04dHv+dy8b/jI6Lj/s3Hnd9820/35+R9/7h8Pib37Pw/z7jKsz332+x+38x28/2GPPtw3E5jOvj+Y6j49rP92d0ocfxxR6Dl/sYP8nxpXANxo3P+7/zLfMWQUmSJElqiRMsSZIkSWqJEyxJkiRJasm8JlhJdjffg3VHktuS/GGS1iZtSc5Icnjf/iVJjm7r+JIkSZLUpvk+5GJXVa0GSHII8HHgicB5sz1AkhVVtXtI+AzgdmAHQFW9Zj4XK0mSJEkLqbXVpqq6F9gIvCE9ZyT5wHQ8yeeSrGu270/yziQ3AickeUeSm5LcnmSqaf9KYA2wqVkl2z/J5iRrmmOclmRb0+aivvPcn+SPmxW1G5Ic2laOkiRJkjRKq5/Bqqq7mmMeMqbqAcDtVfWcqroe+EBVra2qXwP2B06pqsuBLcCGqlpdVbumGze3DV4EnAysBtYmeXnfsW+oqmcBXwJeO/PkSTYm2ZJky9TU1DwyliRJkqRHLMRDLmbzZV27gSv69tcnuTHJNnqTpl8d034tsLmqflhVDwGbgBOb2E+BzzXbNwOrZjauqqmqWlNVazZu3DiLy5UkSZKk8Vr9ouEkz6A3eboXeIhHT+D269v+yfTnrpLsB3wQWFNVdyc5f0bdgacaEXuwqqa/M2w3fpmyJEmSpL2kzSf+PRW4mN7tfgVsB1YneUySI4DjhzSdnkztTLISeGVf7D7gwAFtbgROSnJwkhXAacB1LaQhSZIkSXtsvqs7+ye5FdiX3orVR4H3NLEvA98FttF7EuAtgw5QVf+S5M+betuBm/rClwIXJ9kFnNDX5p4kbwWupbeadVVVfWaeuUiSJEnSvMxrglVVK0bECtgwJLZyxv7bgbcPqHcFj/6s1rq+2MfpPRZ+6LGbB2VcPjQBSZIkSWrRQjzkQpIkSZI6KY88D6Kbkmysqs4+q73r+YN9YP7m3+X8wT4wf/Pvcv5gH5h/+/m7gtX7cuQu63r+YB+Yf7d1PX+wD8y/27qeP9gH5t8yJ1iSJEmS1BInWJIkSZLUEidY0Nl7Thtdzx/sA/Pvtq7nD/aB+Xdb1/MH+8D8W9b5h1xIkiRJUltcwZIkSZKkljjBkiRJkqSWTNQEK8mLk3wzybeTnNOUPTnJ3yb5VvN+0GzbzqX9UjGkD96d5O+TbE3yl0meNNu2Tfmy6YNhOTSxs5NUkoPn0nYS8k9yZlN+R5J3zbHtss4/yeokNyS5NcmWJMfPtm1Tvpzy/4sk9ya5va+sM2PgkPw7M/7B4D7oi3VhDByYf4fGwEG/A10aA49Icm2SbzT/1m9qyjsxDo7IvzPj4LA+6IvvnXGwqibiBawAvgM8A3gscBtwNPAu4JymzjnARbNt28TGtl8qrxF98CJgn6bORZPaB2NyOAK4GvgecHCX8gfWA18AHtfUO6Rj+V8DvKSp81Jg8yTm31zficCxwO19ZV0aAwfl34nxb1QfNOUTPwaO+BnoxBg4Iv8ujYGHAcc22wcCd9KhvwVH5N+ZcXBYHzT7e20cXPSOaLFDTwCu7tt/a/P6JnBYX6d/c7Ztm+2x7ZfKa1QefWWvADZNYh+MyeFy4FnA9iG/VBObP3AZ8IJ59N1yz/9q4FVN2WnAxycx/75rX8Wj/7jqzBg4KP8ZsYkd/8b1QRfGwGH5d2UMHJF/p8bAGXl9Bnhh18bBmfnPKOvEODioD/bmODhJtwj+InB33/4PmrJDq+oegOb9EIAkhye5akxbhrVfokblMe33gc/DRPbBwBySvAz4h6q6rb9yV/IHjgKen+TGJNclWQudyv8s4N1J7gb+lN6AOYn5D9OlMXCcSR7/hurQGDhMV8bAYc6ig2NgklXAs4Eb6eA4OCP/fp0ZB/v7YG+Pg/vM//KXjAwoq2GVq2oHvaXyObddwkbmkeRc4CFgE0xkHwzK4XHAufSWxx+lI/kXvd/zg4DfANYClyV5Rofyfz3w5qq6IsmpwEfo/d/sSct/TrqWfwfGv4GSPJ7ujIHDdGUMHKZzY2CSlcAVwFlV9a/JoPQm93dgZv595Z0ZB/v7gF7Oe3UcnKQVrB/Qu7dy2i8BO4B/SnIYQPN+7xzaMsv2S8XQPJKcDpwCbKhmfXO2bVk+fTAoh+8DTwduS7K9KbslyS/Mou0k5L+jKb+yer4KPAzM/HDnJOd/OnBlU/YpYNAHvCch/2G6NAYO1JHxb5hn0p0xcJiujIHDdGoMTLIvvT+sN1XVdN6dGQeH5N+pcXBAH+z1cXCSJlg3AUcmeXqSxwK/C3y2eZ3e1Dmd3r2Ys23LLNsvFQPzSPJi4C3Ay6rq3+fStoktlz4YlMOVVXVIVa2qqlX0fnmOrap/nEXbScj/s8CngZMBkhxF74ObO2fZFpZ//juAk5o6JwPfmkNbWD75D9OlMfDndGj8G6iqtnVoDBzm03RjDBymM2NgektVHwG+UVXv6Qt1Yhwcln+XxsFBfbAo4+BCfKBssV70lvjupPcEkHObsqcAX6Q3oHwReHJTfjhw1ai2o9ov1deQPvg2vXtKb21eF09qHwzLoS++neaDjV3Jn94fEx8DbgduAU7uWP7PA26m9zSgG4HjJjj/TwD3AA/S+w/Iq7s0Bg7JvzPj37A+mBGf9DFw0M9Al8bAQfl3aQx8Hr1burb2/c6/dFgOk9YHI/LvzDg4rA9m1NnOAo+DaRpJkiRJkuZpkm4RlCRJkqRF5QRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5K0pCXZneTWvtc5A+qsS/K5ls+7Lslz+/b/IMl/bvMckqTJs89iX4AkSWPsqqrVi3DedcD9wFcAquriRbgGSdIy4wqWJGlZSvLiJH+f5Hrgt/rKz09ydt/+7UlWNdv/OcnWJLcl+WhT9p+S3Jjka0m+kOTQpv4fAG9uVs2e33/cJKuT3NAc6y+THNSUb05yUZKvJrkzyfP3WodIkpYEJ1iSpKVu/xm3CL4qyX7AnwP/CXg+8AvjDpLkV4FzgZOr6lnAm5rQ9cBvVNWzgf8G/Jeq2g5cDLy3qlZX1X+fcbj/F3hLVR0DbAPO64vtU1XHA2fNKJckdYC3CEqSlrqfu0UwyWrgu1X1rWb/Y8DGMcc5Gbi8qnYCVNX/aMp/CfhkksOAxwLfHXWQJE8EnlRV1zVF/xX4VF+VK5v3m4FVY65JkjRhXMGSJC1XNaT8IR7937f9mvcMafN+4ANV9evA6/rq76kHmvfd+D8yJalznGBJkpajvweenuSZzf5pfbHtwLEASY4Fnt6UfxE4NclTmtiTm/InAv/QbJ/ed5z7gANnnriqfgz8qO/zVb8HXDezniSpm5xgSZKWupmfwbqwqn5C75bAv24ecvG9vvpXAE9OcivweuBOgKq6A/hj4LoktwHvaeqfD3wqyX8HdvYd56+AV0w/5GLGNZ0OvDvJVmA18M720pUkLWepGnaHhSRJkiRpLlzBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSW+P0cw79HRZIkSdJkS9sHdIIFo7u1xoaNL2B8KVyDcePzjc/3AIt9/f6OGzdufJTFvgbjxuf93+mWeYugJEmSJLXECZYkSZIktWTsBCvJuUnuSLK1+Tb75zTlZyV5/FxPmOSMJIfPJpbkkiRHz/UckiRJkrQYRk6wkpwAnAIcW1XHAC8A7m7CZwFzmmAlWQGcAQycYM2MVdVrqurrczmHJEmSJC2WcStYhwE7q+oBgKraWVU7kryR3kTo2iTXAiT5UJItzWrXBdMHSLI9yTuSXA+cBqwBNjWrYfv31XvlzFiSzUnWNPH7k1yU5OYkX0hyfBO/K8nLmjorkrw7yU3NitvrWuspSZIkSRpj3ATrGuCIJHcm+WCSkwCq6n3ADmB9Va1v6p5bVWuAY4CTkhzTd5yfVNXzqupjwBZgQ1Wtrqpd0xWq6vJhscYBwOaqOg64D/gj4IXAK4B3NnVeDfy4qtYCa4HXJnn6zKSSbGwmg1umpqbGdIEkSZIkzc7Ix7RX1f1JjgOeD6wHPpnknKq6dED1U5NsbI55GHA0sLWJfbKFa/0p8DfN9jbggap6MMk2YFVT/iLgmGY1DOCJwJHAd2fkNQVMz6wK17kkSZIktWDs92BV1W5gM7C5mcycDlzaX6dZJTobWFtVP0pyKbBfX5V/a+FaH6yq6UfVPwxM37b4cJLpPAKcWVVXt3A+SZIkSZqTcQ+5+OUkR/YVrQa+12zfBxzYbD+B3iTqx0kOBV4y4rD97eYSm42rgdcn2RcgyVFJDpjH8SRJkiRp1satYK0E3p/kScBDwLeBjU1sCvh8knuqan2SrwF3AHcBXx5xzEuBi5PsAk6Y8VmrR8XmmAvAJfRuF7wlSYAfAi/fg+NIkiRJ0pzlkbvuOqvIyOi4sPEFjC+FazBufL7x+R5gsa/f33Hjxo2PstjXYNz4Av5ndo+M/aJhSZIkSdLsuILV/A9mSZIkSZ3T+grW2KcIdsESX7bsdHwpXINx48YXLr4UrsH40o93+TbapR5fCtdg3Pi8x5iWeYugJEmSJLXECZYkSZIktWSPJlhJdie5te91zhzbb09y8IDyt83Y/8qeXJ8kSZIkLYY9/QzWrqpa3eaFNN4G/Mn0TlU9dwHOIUmSJEkLotVbBJuVqQuS3JJkW5JfacqfkuSaJF9L8mEGfNYsyYXA/s2K2Kam7P7mfV2S65JcluTOJBcm2ZDkq815ntnUe2qSK5Lc1Lx+s838JEmSJGmUPZ1gTU+Epl+v6ovtrKpjgQ8BZzdl5wHXV9Wzgc8CT5t5wKo6h2ZlrKo2DDjns4A3Ab8O/B5wVFUdD1wCnNnU+TPgvVW1FvjtJvZzkmxMsiXJlqmpqTmmLkmSJEmDLcQtglc27zcDv9Vsnzi9XVV/neRHe3DOm6rqHoAk3wGuacq3Aeub7RcARyc/WyB7QpIDq+q+/gNV1RQwPbOq1+3BxUiSJEnSTAvxPVgPNO+7Zxx/vo+Zf6Bv++G+/Yf7zvMY4ISq2jXPc0mSJEnSnO2tx7R/CdgAkOQlwEFD6j2YZN95nOca4A3TO0lWz+NYkiRJkjQnbX0G68Ix9S8ATkxyC/Ai4PtD6k0BW6cfcrEH3gisSbI1ydeBP9jD40iSJEnSnKVqvnfuLXv1c4807A8y4JGHxvdafClcg3HjxhcuvhSuwfjSj4+rsNjX1+X4UrgG48bnGR/3Iz5ne+sWQUmSJEmaeK5gzf/hG5IkSZKWp9ZXsBbiKYLLzhJftux0fClcg/HxFRb7+owv3/hSuAbjSz9+wfnD4+edv/jX1+X4UrgG48bn/XdOy7xFUJIkSZJa4gRLkiRJklriBEuSJEmSWjKvCVaS3c33YN2R5LYkf5iktUlbkjOSHN63f0mSo9s6viRJkiS1ab4PudhVVasBkhwCfBx4InDebA+QZEVV7R4SPgO4HdgBUFWvmc/FSpIkSf//9u4vRK6zjOP492f/prZgY0xNNZBG7IUIjTGpBmprg5VaSlEoauhFRDEiKEYQTQloFLxIK70qEiIVQaNQm5jWEolamopCYtKQNCk1bdXV1ERjL0SLFdv6eHHepSfjObOz7snu7Hl+Hxh2533PO3t+TzJP9uScmTE7lzo72xQRZ4ANwGdU+ZikeyfnJT0s6b3l+xckfU3SAWCNpC9LOijpuKTtZf3twCpgRzlLtkDSPkmrymOsk3SsrNla+zkvSPp6OaO2X9IVXWU0MzMzMzMbptPXYEXE78pjLp5i09cCxyPiXRHxS+DeiFgdEW8HFgC3RsQDwCHgjohYEREvTi4ulw1uBdYCK4DVkj5Ye+z9EXEN8Avgk4M/XNIGSYckHdq+ffsMEpuZmZmZmb3qXHwO1igf1vUKsLN2/0ZJXwQuARYCTwI/HrJ+NbAvIv4KIGkHcD2wG/g38HDZ7nHgpsHFEbEdmDyyik+NsMNmZmZmZmZT6fQAS9JyqoOnM8DLnH2G7OLa9/+afN2VpIuBbwKrIuKkpC0D2zb+qCFzL0XE5GeGvYI/TNnMzMzMzGZJl+/49wZgG9XlfgFMACskvUbSUuDalqWTB1PPS7oUuL029w/gsoY1B4AbJC2SdB6wDnisgxhmZmZmZmb/t5me3Vkg6QhwAdUZq+8C95S5XwG/B45RvRPg4aYHiIi/SfpW2W4COFib/g6wTdKLwJramtOS7gQepTqbtSciHpxhFjMzMzMzsxnRq1fTpRXDrjcMhl+P6PlzOz8O++D5qTeY6/3z/PydH4d98Pz4z391S/v8V7bM/f5lnh+HffC852c4P8r7R0xLp+8iaGZmZmZmlln6M1iSNpR3FUwpe35wDZzf+TPnB9fA+Z0/c35wDZy/+/w+g1V9OHJm2fODa+D8uWXPD66B8+eWPT+4Bs7fMR9gmZmZmZmZdcQHWGZmZmZmZh3xARakvea0yJ4fXAPnzy17fnANnD+37PnBNXD+jqV/kwszMzMzM7Ou+AyWmZmZmZlZR3yAZWZmZmZm1pFeHWBJulnSCUnPStpUxhZK+pmkZ8rXy0ddO53146KlBndL+o2kJyT9SNLrRl1bxudNDdoylLkvSApJi6aztg/5JX22jD8p6a5prp3X+SWtkLRf0hFJhyRdO+raMj6f8n9b0hlJx2tjaXpgS/40/Q+aa1Cby9ADG/Mn6oFNz4FMPXCppEclPVX+rD9XxlP0wSH50/TBthrU5menD0ZEL27AecBvgeXAhcBR4G3AXcCmss0mYOuoa8vclOvH5TakBu8Hzi/bbO1rDabIsBTYC/wBWJQpP3Aj8HPgorLd4mT5fwp8oGxzC7Cvj/nL/l0PrASO18Yy9cCm/Cn637AalPHe98AhfwdS9MAh+TP1wCXAyvL9ZcDTJPpdcEj+NH2wrQbl/qz1wTkvRIcFXQPsrd2/s9xOAEtqRT8x6try/ZTrx+U2LEdt7EPAjj7WYIoMDwDXABMtT6re5gfuB943g9rN9/x7gY+UsXXA9/uYv7bvyzj7l6s0PbAp/8Bcb/vfVDXI0APb8mfpgUPyp+qBA7keBG7K1gcH8w+MpeiDTTWYzT7Yp0sE3wScrN1/roxdERGnAcrXxQCSrpS0Z4q1tK0fU8NyTPo48BPoZQ0aM0i6DfhTRBytb5wlP3A18B5JByQ9Jmk1pMq/Ebhb0kngG1QNs4/522TqgVPpc/9rlagHtsnSA9tsJGEPlLQMeAdwgIR9cCB/XZo+WK/BbPfB82e++2NDDWPRtnFEnKI6VT7ttWNsaA5Jm4GXgR3Qyxo0ZbgI2Ex1evwsSfIH1fP8cuDdwGrgfknLE+X/NPD5iNgp6cPAfVT/m923/NOSLX+C/tdI0iXk6YFtsvTANul6oKRLgZ3Axoj4u9QUr7/PgcH8tfE0fbBeA6rMs9oH+3QG6zmqaysnvRk4BfxF0hKA8vXMNNYy4vpx0ZpD0nrgVuCOKOc3R13L/KlBU4Y/AlcBRyVNlLHDkt44wto+5D9VxndF5dfAf4DBF3f2Of96YFcZ+yHQ9ALvPuRvk6kHNkrS/9q8hTw9sE2WHtgmVQ+UdAHVL9Y7ImIyd5o+2JI/VR9sqMGs98E+HWAdBN4q6SpJFwIfBR4qt/Vlm/VU12KOupYR14+LxhySbga+BNwWEf+cztoyN19q0JRhV0QsjohlEbGM6smzMiL+PMLaPuR/CNgNrAWQdDXVCzefH3EtzP/8p4AbyjZrgWemsRbmT/42mXrg/0jU/xpFxLFEPbDNbnL0wDZpeqCqU1X3AU9FxD21qRR9sC1/pj7YVIM56YPn4gVlc3WjOsX3NNU7gGwuY68HHqFqKI8AC8v4lcCeYWuHrR/XW0sNnqW6pvRIuW3raw3aMtTmJygvbMySn+qXie8Bx4HDwNpk+a8DHqd6N6ADwDt7nP8HwGngJap/QD6RqQe25E/T/9pqMDDf9x7Y9HcgUw9syp+pB15HdUnXE7Xn/C1tGfpWgyH50/TBthoMbDPBOe6DKovMzMzMzMxshvp0iaCZmZmZmdmc8gGWmZmZmZlZR3yAZWZmZmZm1hEfYJmZmZmZmXXEB1hmZmZmZmYd8QGWmZmZmZlZR3yAZWZmZmZm1pH/AvbyM28ml/kJAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 864x691.2 with 8 Axes>"
       ]
@@ -4108,7 +3382,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAKrCAYAAADs7iyrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAB7P0lEQVR4nOz9f5RldX3v+T9fNihIo6IIgQRvqxeSIQm20I3BKHQz6qjDdTQxGFZPLkzUNq4lilmsK4pLwEkyoBn9Rl2KFcxwR1uvCESNwUB0aLxoQBqEbtCIiq2YJsHONQaSFqF5f/84u+RQnh9VXbu6qs5+PtY66+z9eX8+e+/3p6s+1IfPPvukqpAkSZIkzd9jFvsCJEmSJGlSOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiQte0l2J7m173XOAp7rbQt1bEnS8he/B0uStNwlub+qVi7wOQIE+NeFPpckaflyBUuSNLGSXJjk60m2JvnTpuzQJH+Z5Lbm9dym/A+T3N68zmrKViX5RpIPArcAHwH2b1bJNi1WXpKkpcsVLEnSspdkN7Ctr+j/Av4W+DvgV6qqkjypqv4lySeBv6uq/1+SFcBK4D8ClwK/QW+V6kbgfwd+BNwFPLeqbmjOteCrZZKk5Wufxb4ASZJasKuqVvcXJNkH+AlwSZK/Bj7XhE4G/jNAVe0GfpzkecBfVtW/NW2vBJ4PfBb43vTkSpKkcbxFUJI0karqIeB44Arg5cDfjKieEbF/a/GyJEkTzgmWJGkiJVkJPLGqrgLOAlY3oS8Cr2/qrEjyBOBLwMuTPD7JAcArgP8+5NAPJtl3Ia9dkrR8eYugJGkS7J/k1r79vwH+DPhMkv3orVC9uYm9CZhK8mpgN/D6qvq7JJcCX23qXFJVX0uyasC5poCtSW6pqg3tpyJJWs58yIUkSZIktcRbBCVJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJT5FEHzKhyRJktRNo74HcY84wWJ0r5bxRY0vhWswbny+8fWbh8evXTc+vtjX7+/4+PgF5w+Pn3f+4l/fYsfH9c+4A0x6/y72GDCf808fY9L/jZZ7fLF/xpZ6vG3eIihJkiRJLXGCJUmSJEktGTvBSnJukjuSbE1ya5LnNOVnJXn8XE+Y5Iwkh88mluSSJEfP9RySJEmStBhGTrCSnACcAhxbVccALwDubsJnAXOaYCVZAZwBDJxgzYxV1Wuq6utzOYckSZIkLZZxK1iHATur6gGAqtpZVTuSvJHeROjaJNcCJPlQki3NatcF0wdIsj3JO5JcD5wGrAE2Nath+/fVe+XMWJLNSdY08fuTXJTk5iRfSHJ8E78rycuaOiuSvDvJTc2K2+ta6ylJkiRJGmPcBOsa4Igkdyb5YJKTAKrqfcAOYH1VrW/qnltVa4BjgJOSHNN3nJ9U1fOq6mPAFmBDVa2uql3TFarq8mGxxgHA5qo6DrgP+CPghcArgHc2dV4N/Liq1gJrgdcmefrMpJJsbCaDW6ampsZ0gSRJkiTNzsjHtFfV/UmOA54PrAc+meScqrp0QPVTk2xsjnkYcDSwtYl9soVr/SnwN832NuCBqnowyTZgVVP+IuCYZjUM4InAkcB3Z+Q1BUzPrMplLkmSJEltGPs9WFW1G9gMbG4mM6cDl/bXaVaJzgbWVtWPklwK7NdX5d9auNYHq2r6UfUPA9O3LT6cZDqPAGdW1dUtnE+SJEmS5mTcQy5+OcmRfUWrge812/cBBzbbT6A3ifpxkkOBl4w4bH+7ucRm42rg9Un2BUhyVJID5nE8SZIkSZq1cStYK4H3J3kS8BDwbWBjE5sCPp/knqpan+RrwB3AXcCXRxzzUuDiJLuAE2Z81upRsTnmAnAJvdsFb0kS4IfAy/fgOJIkSZI0Z+M+g3Uz8NwhsfcD7+/bP2NIvVUz9q8ArhhSd2ZsXV9sZd/2+TParWzeHwbe1rwkSZIkaa8a+0XDkiRJkqTZcYIlSZIkSS3JIw/m66zOd4AkSZLUUWn7gGMf094Fo3q1jC9qfClcg3HjCx3/1a8Pj99x9OJfn7/j4+Onfmp4/LLfWfzrW+z4uJ/xcfFxJ1js/Jb7GDCf808fw9+B+cUX+mdgsX/Glnq8bd4iKEmSJEktcYIlSZIkSS3ZowlWkt1Jbu17nTPH9tuTHDyg/G0z9r+yJ9cnSZIkSYthTz+DtauqVrd5IY23AX8yvVNVA7+DS5IkSZKWolZvEWxWpi5IckuSbUl+pSl/SpJrknwtyYcZ8FmzJBcC+zcrYpuasvub93VJrktyWZI7k1yYZEOSrzbneWZT76lJrkhyU/P6zTbzkyRJkqRR9nSCNT0Rmn69qi+2s6qOBT4EnN2UnQdcX1XPBj4LPG3mAavqHJqVsaraMOCczwLeBPw68HvAUVV1PHAJcGZT58+A91bVWuC3m9jPSbIxyZYkW6ampuaYuiRJkiQNthC3CF7ZvN8M/FazfeL0dlX9dZIf7cE5b6qqewCSfAe4pinfBqxvtl8AHJ38bIHsCUkOrKr7+g9UVVPA9MyqXrcHFyNJkiRJMy3E92A90LzvnnH8+T5m/oG+7Yf79h/uO89jgBOqatc8zyVJkiRJc7a3HtP+JWADQJKXAAcNqfdgkn3ncZ5rgDdM7yRZPY9jSZIkSdKctPUZrAvH1L8AODHJLcCLgO8PqTcFbJ1+yMUeeCOwJsnWJF8H/mAPjyNJkiRJc7ZHtwhW1Yoh5av6trcA65rtf6Y3sZr25iHt3wK8pW9/ZfO+GdjcV76ub/tnsaraCfQ/cEOSJEmS9pq9dYugJEmSJE28VM332RPLXuc7QJIkSeqon/t+3vlaiKcILj+jurXGho0vYHwpXINx48YXLr4UrqGAg/5lePxHT1r86zNufKnGl8I1GDc+33jbvEVQkiRJklriBEuSJEmSWjKvCVaS3c1j2u9IcluSP0zS2qQtyRlJDu/bvyTJ0W0dX5IkSZLaNN/PYO2qqtUASQ4BPg48EThvtgdIsqKqdg8JnwHcDuwAqKrXzOdiJUmSJGkhtbbaVFX3AhuBN6TnjCQfmI4n+VySdc32/UnemeRG4IQk70hyU5Lbk0w17V8JrAE2Natk+yfZnGRNc4zTkmxr2lzUd577k/xxs6J2Q5JD28pRkiRJkkZp9TNYVXVXc8xDxlQ9ALi9qp5TVdcDH6iqtVX1a8D+wClVdTmwBdhQVauratd04+a2wYuAk4HVwNokL+879g1V9SzgS8BrZ548ycYkW5JsmZqamkfGkiRJkvSIhXhM+2yeJb8buKJvf32S/wI8HngycAfwVyParwU2V9UPAZJsAk4EPg38FPhcU+9m4IUzG1fVFDA9sypeN4srliRJkqQxWp1gJXkGvcnTvcBDPHqFbL++7Z9Mf+4qyX7AB4E1VXV3kvNn1B14qhGxB+uRb0/ejd/1JUmSJGkvafOJf08FLqZ3u18B24HVSR6T5Ajg+CFNpydTO5OsBF7ZF7sPOHBAmxuBk5IcnGQFcBpwXQtpSJIkSdIem+/qzv5JbgX2pbdi9VHgPU3sy8B3gW30ngR4y6ADVNW/JPnzpt524Ka+8KXAxUl2ASf0tbknyVuBa+mtZl1VVZ+ZZy6SJEmSNC955G66zqqRNxzW6PsRC+MLGV8K12DcuPGFiy+FayjgoH8ZHv/Rkxb/+owbX6rxpXANxo3PMz6b50fMSatPEZQkSZKkLuv8ClaSjc1TBTup6/mDfWD+5t/l/ME+MH/z73L+YB+Yf/v5u4LV+3LkLut6/mAfmH+3dT1/sA/Mv9u6nj/YB+bfMidYkiRJktQSJ1iSJEmS1BInWNDZe04bXc8f7APz77au5w/2gfl3W9fzB/vA/FvW+YdcSJIkSVJbXMGSJEmSpJY4wZIkSZKklkzUBCvJi5N8M8m3k5zTlD05yd8m+VbzftBs286l/VIxpA/eneTvk2xN8pdJnjTbtk35sumDYTk0sbOTVJKD59J2EvJPcmZTfkeSd82x7bLOP8nqJDckuTXJliTHz7ZtU76c8v+LJPcmub2vrDNj4JD8OzP+weA+6It1YQwcmH+HxsBBvwNdGgOPSHJtkm80/9Zvaso7MQ6OyL8z4+CwPuiL751xsKom4gWsAL4DPAN4LHAbcDTwLuCcps45wEWzbdvExrZfKq8RffAiYJ+mzkWT2gdjcjgCuBr4HnBwl/IH1gNfAB7X1DukY/lfA7ykqfNSYPMk5t9c34nAscDtfWVdGgMH5d+J8W9UHzTlEz8GjvgZ6MQYOCL/Lo2BhwHHNtsHAnfSob8FR+TfmXFwWB80+3ttHFz0jmixQ08Aru7bf2vz+iZwWF+nf3O2bZvtse2XymtUHn1lrwA2TWIfjMnhcuBZwPYhv1QTmz9wGfCCefTdcs//auBVTdlpwMcnMf++a1/Fo/+46swYOCj/GbGJHf/G9UEXxsBh+XdlDByRf6fGwBl5fQZ4YdfGwZn5zyjrxDg4qA/25jg4SbcI/iJwd9/+D5qyQ6vqHoDm/RCAJIcnuWpMW4a1X6JG5THt94HPw0T2wcAckrwM+Iequq2/clfyB44Cnp/kxiTXJVkLncr/LODdSe4G/pTegDmJ+Q/TpTFwnEke/4bq0Bg4TFfGwGHOooNjYJJVwLOBG+ngODgj/36dGQf7+2Bvj4P7zP/yl4wMKKthlatqB72l8jm3XcJG5pHkXOAhYBNMZB8MyuFxwLn0lscfpSP5F73f84OA3wDWApcleUaH8n898OaquiLJqcBH6P3f7EnLf066ln8Hxr+Bkjye7oyBw3RlDBymc2NgkpXAFcBZVfWvyaD0Jvd3YGb+feWdGQf7+4Beznt1HJykFawf0Lu3ctovATuAf0pyGEDzfu8c2jLL9kvF0DySnA6cAmyoZn1ztm1ZPn0wKIfvA08HbkuyvSm7JckvzKLtJOS/oym/snq+CjwMzPxw5yTnfzpwZVP2KWDQB7wnIf9hujQGDtSR8W+YZ9KdMXCYroyBw3RqDEyyL70/rDdV1XTenRkHh+TfqXFwQB/s9XFwkiZYNwFHJnl6kscCvwt8tnmd3tQ5nd69mLNtyyzbLxUD80jyYuAtwMuq6t/n0raJLZc+GJTDlVV1SFWtqqpV9H55jq2qf5xF20nI/7PAp4GTAZIcRe+Dmztn2RaWf/47gJOaOicD35pDW1g++Q/TpTHw53Ro/BuoqrZ1aAwc5tN0YwwcpjNjYHpLVR8BvlFV7+kLdWIcHJZ/l8bBQX2wKOPgQnygbLFe9Jb47qT3BJBzm7KnAF+kN6B8EXhyU344cNWotqPaL9XXkD74Nr17Sm9tXhdPah8My6Evvp3mg41dyZ/eHxMfA24HbgFO7lj+zwNupvc0oBuB4yY4/08A9wAP0vsPyKu7NAYOyb8z49+wPpgRn/QxcNDPQJfGwEH5d2kMfB69W7q29v3Ov3RYDpPWByPy78w4OKwPZtTZzgKPg2kaSZIkSZLmaZJuEZQkSZKkReUES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSNHGSnJvkjiRbk9ya5DlJtic5eLGvTZI02fZZ7AuQJKlNSU4ATgGOraoHmknVYxf5siRJHeEKliRp0hwG7KyqBwCqamdV7WhiZya5Jcm2JL8CkOTJST7drHbdkOSYpvz8JB9N8v8l+VaS1y5OOpKk5cQJliRp0lwDHJHkziQfTHJSX2xnVR0LfAg4uym7APhaVR0DvA34f/vqHwP8r8AJwDuSHL7wly9JWs6cYEmSJkpV3Q8cB2wEfgh8MskZTfjK5v1mYFWz/Tzgo03b/w94SpInNrHPVNWuqtoJXAscv+AJSJKWNT+DJUmaOFW1G9gMbE6yDTi9CT3QvO/mkf8GZtAhZrzPLJckaSBXsCRJEyXJLyc5sq9oNfC9EU2+BGxo2q6jdxvhvzax/y3JfkmeAqwDbmr7eiVJk8UVLEnSpFkJvD/Jk4CHgG/Tu13wlCH1zwf+nyRbgX/nkdUugK8Cfw08Dfg/+x6WIUnSQKnybgdJkmZKcj5wf1X96WJfiyRp+fAWQUmSJElqiStYkiRJktQSV7AkSZIkqSVOsCRJkiSpJT5F0O80kSRJkrpq0HchzosTLEb3ahlf1PhSuAbjxo0vXHwpXEMb8fWbh8evXbf413fB+cPj552/8O0XOz6uwlL/91vK8aVwDcaNz3uMaJm3CEqSJElSS5xgSZIkSVJLxk6wkpyb5I4kW5PcmuQ5TflZSR4/1xMmOSPJ4bOJJbkkydFzPYckSZIkLYaRE6wkJwCnAMdW1THAC4C7m/BZwJwmWElWAGcAAydYM2NV9Zqq+vpcziFJkiRJi2XcCtZhwM6qegCgqnZW1Y4kb6Q3Ebo2ybUAST6UZEuz2nXB9AGSbE/yjiTXA6cBa4BNzWrY/n31XjkzlmRzkjVN/P4kFyW5OckXkhzfxO9K8rKmzook705yU7Pi9rrWekqSJEmSxhg3wboGOCLJnUk+mOQkgKp6H7ADWF9V65u651bVGuAY4KQkx/Qd5ydV9byq+hiwBdhQVauratd0haq6fFiscQCwuaqOA+4D/gh4IfAK4J1NnVcDP66qtcBa4LVJnj4zqSQbm8nglqmpqTFdIEmSJEmzM/Ix7VV1f5LjgOcD64FPJjmnqi4dUP3UJBubYx4GHA1sbWKfbOFafwr8TbO9DXigqh5Msg1Y1ZS/CDimWQ0DeCJwJPDdGXlNAdMzq3KZS5IkSVIbxn4PVlXtBjYDm5vJzOnApf11mlWis4G1VfWjJJcC+/VV+bcWrvXBqpp+VP3DwPRtiw8nmc4jwJlVdXUL55MkSZKkORn3kItfTnJkX9Fq4HvN9n3Agc32E+hNon6c5FDgJSMO299uLrHZuBp4fZJ9AZIcleSAeRxPkiRJkmZt3ArWSuD9SZ4EPAR8G9jYxKaAzye5p6rWJ/kacAdwF/DlEce8FLg4yS7ghBmftXpUbI65AFxC73bBW5IE+CHw8j04jiRJkiTN2bjPYN0MPHdI7P3A+/v2zxhSb9WM/SuAK4bUnRlb1xdb2bd9/ox2K5v3h4G3NS9JkiRJ2qvGftGwJEmSJGl2nGBJkiRJUkvyyIP5OqvzHSBJkiR1VNo+4NjHtHfBqF4t44saXwrXYNy48YWLL4VrMD6+wkKf/1OnDo//zmULf/5TPzU8ftnvjI8v9f71d9i48dHxtnmLoCRJkiS1xAmWJEmSJLVkjyZYSXYnubXvdc4c229PcvCA8rfN2P/KnlyfJEmSJC2GPf0M1q6qWt3mhTTeBvzJ9E5VDfwOLkmSJElailq9RbBZmbogyS1JtiX5lab8KUmuSfK1JB9mwGfNklwI7N+siG1qyu5v3tcluS7JZUnuTHJhkg1Jvtqc55lNvacmuSLJTc3rN9vMT5IkSZJG2dMJ1vREaPr1qr7Yzqo6FvgQcHZTdh5wfVU9G/gs8LSZB6yqc2hWxqpqw4BzPgt4E/DrwO8BR1XV8cAlwJlNnT8D3ltVa4HfbmI/J8nGJFuSbJmamppj6pIkSZI02ELcInhl834z8FvN9onT21X110l+tAfnvKmq7gFI8h3gmqZ8G7C+2X4BcHTyswWyJyQ5sKru6z9QVU0B0zOret0eXIwkSZIkzbQQ34P1QPO+e8bx5/uY+Qf6th/u23+47zyPAU6oql3zPJckSZIkzdneekz7l4ANAEleAhw0pN6DSfadx3muAd4wvZNk9TyOJUmSJElz0tZnsC4cU/8C4MQktwAvAr4/pN4UsHX6IRd74I3AmiRbk3wd+IM9PI4kSZIkzdke3SJYVSuGlK/q294CrGu2/5nexGram4e0fwvwlr79lc37ZmBzX/m6vu2fxapqJ9D/wA1JkiRJ2mv21i2CkiRJkjTxUjXfZ08se53vAEmSJKmjfu77eedrIZ4iuOyc+qnhsct+Bz516vD471zG6H+WGhued/tx1z+u/VKOL4VrMG7c+MLFl8I1GDdufM/jS+EajBufb7xt3iIoSZIkSS1xgiVJkiRJLZnXBCvJ7uYx7XckuS3JHyZpbdKW5Iwkh/ftX5Lk6LaOL0mSJEltmu9nsHZV1WqAJIcAHweeCJw32wMkWVFVu4eEzwBuB3YAVNVr5nOxkiRJkrSQWlttqqp7gY3AG9JzRpIPTMeTfC7Jumb7/iTvTHIjcEKSdyS5KcntSaaa9q8E1gCbmlWy/ZNsTrKmOcZpSbY1bS7qO8/9Sf64WVG7IcmhbeUoSZIkSaO0+hmsqrqrOeYhY6oeANxeVc+pquuBD1TV2qr6NWB/4JSquhzYAmyoqtVVtWu6cXPb4EXAycBqYG2Sl/cd+4aqehbwJeC1M0+eZGOSLUm2TE1NzSNjSZIkSXrEQjzkYjbPkt8NXNG3vz7JjUm20Zs0/eqY9muBzVX1w6p6CNgEnNjEfgp8rtm+GVg1s3FVTVXVmqpas3HjxllcriRJkiSN1+r3YCV5Br3J073AQzx6Ardf3/ZPpj93lWQ/4IPAmqq6O8n5M+oOPNWI2IP1yLcn78bv+pIkSZK0l7T5xL+nAhfTu92vgO3A6iSPSXIEcPyQptOTqZ1JVgKv7IvdBxw4oM2NwElJDk6yAjgNuK6FNCRJkiRpj813dWf/JLcC+9Jbsfoo8J4m9mXgu8A2ek8CvGXQAarqX5L8eVNvO3BTX/hS4OIku4AT+trck+StwLX0VrOuqqrPzDMXSZIkSZqXeU2wqmrFiFgBG4bEVs7Yfzvw9gH1ruDRn9Va1xf7OL3Hwg89dvOgjMuHJiBJkiRJLVqIh1xIkiRJUic5wZIkSZKkluSRB+51U5KNVdXZL8Pqev5gH5i/+Xc5f7APzN/8u5w/2Afm337+rmBB178Iq+v5g31g/t3W9fzBPjD/but6/mAfmH/LnGBJkiRJUkucYEmSJElSS5xgQWfvOW10PX+wD8y/27qeP9gH5t9tXc8f7APzb1nnH3IhSZIkSW1xBUuSJEmSWjJRE6wkL07yzSTfTnJOU/bkJH+b5FvN+0GzbTuX9kvFkD54d5K/T7I1yV8medJs2zbly6YPhuXQxM5OUkkOnkvbScg/yZlN+R1J3jXHtss6/ySrk9yQ5NYkW5IcP9u2Tflyyv8vktyb5Pa+ss6MgUPy78z4B4P7oC/WhTFwYP4dGgMH/Q50aQw8Ism1Sb7R/Fu/qSnvxDg4Iv/OjIPD+qAvvnfGwaqaiBewAvgO8AzgscBtwNHAu4BzmjrnABfNtm0TG9t+qbxG9MGLgH2aOhdNah+MyeEI4Grge8DBXcofWA98AXhcU++QjuV/DfCSps5Lgc2TmH9zfScCxwK395V1aQwclH8nxr9RfdCUT/wYOOJnoBNj4Ij8uzQGHgYc22wfCNxJh/4WHJF/Z8bBYX3Q7O+1cXDRO6LFDj0BuLpv/63N65vAYX2d/s3Ztm22x7ZfKq9RefSVvQLYNIl9MCaHy4FnAduH/FJNbP7AZcAL5tF3yz3/q4FXNWWnAR+fxPz7rn0Vj/7jqjNj4KD8Z8Qmdvwb1wddGAOH5d+VMXBE/p0aA2fk9RnghV0bB2fmP6OsE+PgoD7Ym+PgJN0i+IvA3X37P2jKDq2qewCa90MAkhye5KoxbRnWfokalce03wc+DxPZBwNzSPIy4B+q6rb+yl3JHzgKeH6SG5Ncl2QtdCr/s4B3J7kb+FN6A+Yk5j9Ml8bAcSZ5/BuqQ2PgMF0ZA4c5iw6OgUlWAc8GbqSD4+CM/Pt1Zhzs74O9PQ7uM//LXzIyoKyGVa6qHfSWyufcdgkbmUeSc4GHgE0wkX0wKIfHAefSWx5/lI7kX/R+zw8CfgNYC1yW5Bkdyv/1wJur6ookpwIfofd/syct/znpWv4dGP8GSvJ4ujMGDtOVMXCYzo2BSVYCVwBnVdW/JoPSm9zfgZn595V3Zhzs7wN6Oe/VcXCSVrB+QO/eymm/BOwA/inJYQDN+71zaMss2y8VQ/NIcjpwCrChmvXN2bZl+fTBoBy+DzwduC3J9qbsliS/MIu2k5D/jqb8yur5KvAwMPPDnZOc/+nAlU3Zp4BBH/CehPyH6dIYOFBHxr9hnkl3xsBhujIGDtOpMTDJvvT+sN5UVdN5d2YcHJJ/p8bBAX2w18fBSZpg3QQcmeTpSR4L/C7w2eZ1elPndHr3Ys62LbNsv1QMzCPJi4G3AC+rqn+fS9smtlz6YFAOV1bVIVW1qqpW0fvlObaq/nEWbSch/88CnwZOBkhyFL0Pbu6cZVtY/vnvAE5q6pwMfGsObWH55D9Ml8bAn9Oh8W+gqtrWoTFwmE/TjTFwmM6MgektVX0E+EZVvacv1IlxcFj+XRoHB/XBooyDC/GBssV60Vviu5PeE0DObcqeAnyR3oDyReDJTfnhwFWj2o5qv1RfQ/rg2/TuKb21eV08qX0wLIe++HaaDzZ2JX96f0x8DLgduAU4uWP5Pw+4md7TgG4Ejpvg/D8B3AM8SO8/IK/u0hg4JP/OjH/D+mBGfNLHwEE/A10aAwfl36Ux8Hn0buna2vc7/9JhOUxaH4zIvzPj4LA+mFFnOws8DqZpJEmSJEmap0m6RVCSJEmSFpUTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJ0pKWZHeSW/te5wyosy7J51o+77okz+3b/4Mk/7nNc0iSJs8+i30BkiSNsauqVi/CedcB9wNfAaiqixfhGiRJy4wrWJKkZSnJi5P8fZLrgd/qKz8/ydl9+7cnWdVs/+ckW5PcluSjTdl/SnJjkq8l+UKSQ5v6fwC8uVk1e37/cZOsTnJDc6y/THJQU745yUVJvprkziTP32sdIklaEpxgSZKWuv1n3CL4qiT7AX8O/Cfg+cAvjDtIkl8FzgVOrqpnAW9qQtcDv1FVzwb+G/Bfqmo7cDHw3qpaXVX/fcbh/l/gLVV1DLANOK8vtk9VHQ+cNaNcktQB3iIoSVrqfu4WwSSrge9W1bea/Y8BG8cc52Tg8qraCVBV/6Mp/yXgk0kOAx4LfHfUQZI8EXhSVV3XFP1X4FN9Va5s3m8GVo25JknShHEFS5K0XNWQ8od49H/f9mveM6TN+4EPVNWvA6/rq7+nHmjed+P/yJSkznGCJUlajv4eeHqSZzb7p/XFtgPHAiQ5Fnh6U/5F4NQkT2liT27Knwj8Q7N9et9x7gMOnHniqvox8KO+z1f9HnDdzHqSpG5ygiVJWupmfgbrwqr6Cb1bAv+6ecjF9/rqXwE8OcmtwOuBOwGq6g7gj4HrktwGvKepfz7wqST/HdjZd5y/Al4x/ZCLGdd0OvDuJFuB1cA720tXkrScpWrYHRaSJEmSpLlwBUuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuL3cwz/HhVJkiRJky1tH9AJFozu1hobNr6A8aVwDcaNzzc+3wMs9vX7O27cuPFRFvsajBuf93+nW+YtgpIkSZLUEidYkiRJktQSJ1iSJEmS1JKxE6wk5ya5I8nWJLcmeU5TflaSx8/1hEnOSHL4bGJJLkly9FzPIUmSJEmLYeQEK8kJwCnAsVV1DPAC4O4mfBYwpwlWkhXAGcDACdbMWFW9pqq+PpdzSJIkSdJiGbeCdRiws6oeAKiqnVW1I8kb6U2Erk1yLUCSDyXZ0qx2XTB9gCTbk7wjyfXAacAaYFOzGrZ/X71Xzowl2ZxkTRO/P8lFSW5O8oUkxzfxu5K8rKmzIsm7k9zUrLi9rrWekiRJkqQxxk2wrgGOSHJnkg8mOQmgqt4H7ADWV9X6pu65VbUGOAY4Kckxfcf5SVU9r6o+BmwBNlTV6qraNV2hqi4fFmscAGyuquOA+4A/Al4IvAJ4Z1Pn1cCPq2otsBZ4bZKnz0wqycZmMrhlampqTBdIkiRJ0uyM/B6sqro/yXHA84H1wCeTnFNVlw6ofmqSjc0xDwOOBrY2sU+2cK0/Bf6m2d4GPFBVDybZBqxqyl8EHNOshgE8ETgS+O6MvKaA6ZlV4TqXJEmSpBaM/aLhqtoNbAY2N5OZ04FL++s0q0RnA2ur6kdJLgX266vyby1c64NVNf1dYA8D07ctPpxkOo8AZ1bV1S2cT5IkSZLmZNxDLn45yZF9RauB7zXb9wEHNttPoDeJ+nGSQ4GXjDhsf7u5xGbjauD1SfYFSHJUkgPmcTxJkiRJmrVxK1grgfcneRLwEPBtYGMTmwI+n+Seqlqf5GvAHcBdwJdHHPNS4OIku4ATZnzW6lGxOeYCcAm92wVvSRLgh8DL9+A4kiRJkjRneeSuu84qMjI6Lmx8AeNL4RqMG59vfL4HWOzr93fcuHHjoyz2NRg3voD/md0jY79oWJIkSZI0O65gNf+DWZIkSVLntL6CNfYpgl2wxJctOx1fCtdg3LjxhYsvhWswvvTjXb6NdqnHl8I1GDc+7zGmZd4iKEmSJEktcYIlSZIkSS3ZowlWkt1Jbu17nTPH9tuTHDyg/G0z9r+yJ9cnSZIkSYthTz+DtauqVrd5IY23AX8yvVNVz12Ac0iSJEnSgmj1FsFmZeqCJLck2ZbkV5rypyS5JsnXknyYAZ81S3IhsH+zIrapKbu/eV+X5LoklyW5M8mFSTYk+Wpznmc29Z6a5IokNzWv32wzP0mSJEkaZU8nWNMToenXq/piO6vqWOBDwNlN2XnA9VX1bOCzwNNmHrCqzqFZGauqDQPO+SzgTcCvA78HHFVVxwOXAGc2df4MeG9VrQV+u4n9nCQbk2xJsmVqamqOqUuSJEnSYAtxi+CVzfvNwG812ydOb1fVXyf50R6c86aqugcgyXeAa5rybcD6ZvsFwNHJzxbInpDkwKq6r/9AVTUFTM+s6nV7cDGSJEmSNNNCfA/WA8377hnHn+9j5h/o2364b//hvvM8BjihqnbN81ySJEmSNGd76zHtXwI2ACR5CXDQkHoPJtl3Hue5BnjD9E6S1fM4liRJkiTNSVufwbpwTP0LgBOT3AK8CPj+kHpTwNbph1zsgTcCa5JsTfJ14A/28DiSJEmSNGepmu+de8te/dwjDfuDDHjkofG9Fl8K12DcuPGFiy+FazC+9OPjKiz29XU5vhSuwbjxecbH/YjP2d66RVCSJEmSJp4rWPN/+IYkSZKk5an1FayFeIrgsrPEly07HV8K12B8fIXFvj7jyze+FK7B+NKPX3D+8Ph55y/+9XU5vhSuwbjxef+d0zJvEZQkSZKkljjBkiRJkqSWzGuClWR385j2O5LcluQPk7Q2aUtyRpLD+/YvSXJ0W8eXJEmSpDbN9zNYu6pqNUCSQ4CPA08EzpvtAZKsqKrdQ8JnALcDOwCq6jXzuVhJkiRJWkitrTZV1b3ARuAN6TkjyQem40k+l2Rds31/kncmuRE4Ick7ktyU5PYkU037VwJrgE3NKtn+STYnWdMc47Qk25o2F/Wd5/4kf9ysqN2Q5NC2cpQkSZKkUVr9DFZV3dUc85AxVQ8Abq+q51TV9cAHqmptVf0asD9wSlVdDmwBNlTV6qraNd24uW3wIuBkYDWwNsnL+459Q1U9C/gS8NqZJ0+yMcmWJFumpqbmkbEkSZIkPWIhHtM+m2fJ7wau6Ntfn+S/AI8HngzcAfzViPZrgc1V9UOAJJuAE4FPAz8FPtfUuxl44czGVTUFTM+s6nWzuGBJkiRJGqfVCVaSZ9CbPN0LPMSjV8j269v+yfTnrpLsB3wQWFNVdyc5f0bdgacaEXuwHvn25N34XV+SJEmS9pI2n/j3VOBierf7FbAdWJ3kMUmOAI4f0nR6MrUzyUrglX2x+4ADB7S5ETgpycFJVgCnAde1kIYkSZIk7bH5ru7sn+RWYF96K1YfBd7TxL4MfBfYRu9JgLcMOkBV/UuSP2/qbQdu6gtfClycZBdwQl+be5K8FbiW3mrWVVX1mXnmIkmSJEnzkkfupuusGnW/YTH6fkTjCxtfCtdgfHyFxb4+48s3vhSuwfjSj19w/vD4eecv/vV1Ob4UrsG48XnGZ/P8iDlp9SmCkiRJktRlTrAkSZIkqSWdv0Uwycbmse2d1PX8wT4wf/Pvcv5gH5i/+Xc5f7APzL/9/F3Bgo2LfQGLrOv5g31g/t3W9fzBPjD/but6/mAfmH/LnGBJkiRJUkucYEmSJElSS5xgQWfvOW10PX+wD8y/27qeP9gH5t9tXc8f7APzb1nnH3IhSZIkSW1xBUuSJEmSWuIES5IkSZJaMlETrCQvTvLNJN9Ock5T9uQkf5vkW837QbNtO5f2S8WQPnh3kr9PsjXJXyZ50mzbNuXLpg+G5dDEzk5SSQ6eS9tJyD/JmU35HUneNce2yzr/JKuT3JDk1iRbkhw/27ZN+XLK/y+S3Jvk9r6yzoyBQ/LvzPgHg/ugL9aFMXBg/h0aAwf9DnRpDDwiybVJvtH8W7+pKe/EODgi/86Mg8P6oC++d8bBqpqIF7AC+A7wDOCxwG3A0cC7gHOaOucAF822bRMb236pvEb0wYuAfZo6F01qH4zJ4QjgauB7wMFdyh9YD3wBeFxT75CO5X8N8JKmzkuBzZOYf3N9JwLHArf3lXVpDByUfyfGv1F90JRP/Bg44megE2PgiPy7NAYeBhzbbB8I3EmH/hYckX9nxsFhfdDs77VxcNE7osUOPQG4um//rc3rm8BhfZ3+zdm2bbbHtl8qr1F59JW9Atg0iX0wJofLgWcB24f8Uk1s/sBlwAvm0XfLPf+rgVc1ZacBH5/E/PuufRWP/uOqM2PgoPxnxCZ2/BvXB10YA4fl35UxcET+nRoDZ+T1GeCFXRsHZ+Y/o6wT4+CgPtib4+Ak3SL4i8Ddffs/aMoOrap7AJr3QwCSHJ7kqjFtGdZ+iRqVx7TfBz4PE9kHA3NI8jLgH6rqtv7KXckfOAp4fpIbk1yXZC10Kv+zgHcnuRv4U3oD5iTmP0yXxsBxJnn8G6pDY+AwXRkDhzmLDo6BSVYBzwZupIPj4Iz8+3VmHOzvg709Du4z/8tfMjKgrIZVrqod9JbK59x2CRuZR5JzgYeATTCRfTAoh8cB59JbHn+UjuRf9H7PDwJ+A1gLXJbkGR3K//XAm6vqiiSnAh+h93+zJy3/Oela/h0Y/wZK8ni6MwYO05UxcJjOjYFJVgJXAGdV1b8mg9Kb3N+Bmfn3lXdmHOzvA3o579VxcJJWsH5A797Kab8E7AD+KclhAM37vXNoyyzbLxVD80hyOnAKsKGa9c3ZtmX59MGgHL4PPB24Lcn2puyWJL8wi7aTkP+OpvzK6vkq8DAw88Odk5z/6cCVTdmngEEf8J6E/Ifp0hg4UEfGv2GeSXfGwGG6MgYO06kxMMm+9P6w3lRV03l3Zhwckn+nxsEBfbDXx8FJmmDdBByZ5OlJHgv8LvDZ5nV6U+d0evdizrYts2y/VAzMI8mLgbcAL6uqf59L2ya2XPpgUA5XVtUhVbWqqlbR++U5tqr+cRZtJyH/zwKfBk4GSHIUvQ9u7pxlW1j++e8ATmrqnAx8aw5tYfnkP0yXxsCf06Hxb6Cq2tahMXCYT9ONMXCYzoyB6S1VfQT4RlW9py/UiXFwWP5dGgcH9cGijIML8YGyxXrRW+K7k94TQM5typ4CfJHegPJF4MlN+eHAVaPajmq/VF9D+uDb9O4pvbV5XTypfTAsh774dpoPNnYlf3p/THwMuB24BTi5Y/k/D7iZ3tOAbgSOm+D8PwHcAzxI7z8gr+7SGDgk/86Mf8P6YEZ80sfAQT8DXRoDB+XfpTHwefRu6dra9zv/0mE5TFofjMi/M+PgsD6YUWc7CzwOpmkkSZIkSZqnSbpFUJIkSZIWlRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqiRMsSZIkSWqJEyxJ0sRJsjnJ/zKj7KwkdyU5Z0S7NUne12yvS/Lchb5WSdJk2WexL0CSpAXwCeB3gav7yn4XOL2q/vuwRlW1BdjS7K4D7ge+skDXKEmaQK5gSZIm0eXAKUkeB5BkFXA48B+TfKAp+50ktye5LcmXmrJ1ST7X1P8D4M1Jbk3y/EXJQpK07LiCJUmaOFX1z0m+CrwY+Ay91atPAtVX7R3A/1JV/5DkSTPab09yMXB/Vf3pXrpsSdIEcAVLkjSppm8TpHn/xIz4l4FLk7wWWLE3L0ySNLmcYEmSJtWngf85ybHA/lV1S3+wqv4AeDtwBHBrkqfs/UuUJE0abxGUJE2kqro/yWbgL/j51SuSPLOqbgRuTPKf6E20+t0HPGHBL1SSNFFcwZIkTbJPAM8C/tuA2LuTbEtyO/Al4LYZ8b8CXuFDLiRJc5GqGl9LkiRJkjSWK1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BIf0w4+5UOSJEnqprR9QCdYjO7VMr6o8aVwDcaNdz2+fvPw+LXr9s7v+LgKi91HF5w/PH7e+ePj404wrv1Sz3+xr2+pxxf653sp/A4bN76U423zFkFJkiRJaokTLEmSJElqiRMsSZIkSWrJ2AlWknOT3JFka5JbkzynKT8ryePnesIkZyQ5fDaxJJckOXqu55AkSZKkxTBygpXkBOAU4NiqOgZ4AXB3Ez4LmNMEK8kK4Axg4ARrZqyqXlNVX5/LOSRJkiRpsYxbwToM2FlVDwBU1c6q2pHkjfQmQtcmuRYgyYeSbGlWuy6YPkCS7UnekeR64DRgDbCpWQ3bv6/eK2fGkmxOsqaJ35/koiQ3J/lCkuOb+F1JXtbUWZHk3UlualbcXtdaT0mSJEnSGOMmWNcARyS5M8kHk5wEUFXvA3YA66tqfVP33KpaAxwDnJTkmL7j/KSqnldVHwO2ABuqanVV7ZquUFWXD4s1DgA2V9VxwH3AHwEvBF4BvLOp82rgx1W1FlgLvDbJ02cmlWRjMxncMjU1NaYLJEmSJGl2Rn4PVlXdn+Q44PnAeuCTSc6pqksHVD81ycbmmIcBRwNbm9gnW7jWnwJ/02xvAx6oqgeTbANWNeUvAo5pVsMAnggcCXx3Rl5TwPTMqlzmkiRJktSGsV80XFW7gc3A5mYyczpwaX+dZpXobGBtVf0oyaXAfn1V/q2Fa32wqqa/C+xhYPq2xYeTTOcR4MyqurqF80mSJEnSnIx7yMUvJzmyr2g18L1m+z7gwGb7CfQmUT9OcijwkhGH7W83l9hsXA28Psm+AEmOSnLAPI4nSZIkSbM2bgVrJfD+JE8CHgK+DWxsYlPA55PcU1Xrk3wNuAO4C/jyiGNeClycZBdwwozPWj0qNsdcAC6hd7vgLUkC/BB4+R4cR5IkSZLmbNxnsG4Gnjsk9n7g/X37Zwypt2rG/hXAFUPqzoyt64ut7Ns+f0a7lc37w8DbmpckSZIk7VVjv2hYkiRJkjQ7eeS5EZ3V+Q6QJEmSOiptH3DsUwS7YFSvlvFFjS+FazBu3PjCxds6x5qbh8e3HDe+/c1rhseP27LwffS6EV/J+OGNC99+oePj/n2mRnxfysYPL/71T3p8Pv0/fYxxJ1nsHLsen+8YOenxtnmLoCRJkiS1xAmWJEmSJLVkjyZYSXYnubXvdc4c229PcvCA8rfN2P/KnlyfJEmSJC2GPf0M1q6qWt3mhTTeBvzJ9E5VDXxEvCRJkiQtRa3eItisTF2Q5JYk25L8SlP+lCTXJPlakg8z4LNmSS4E9m9WxDY1Zfc37+uSXJfksiR3JrkwyYYkX23O88ym3lOTXJHkpub1m23mJ0mSJEmj7OkEa3oiNP16VV9sZ1UdC3wIOLspOw+4vqqeDXwWeNrMA1bVOTQrY1W1YcA5nwW8Cfh14PeAo6rqeOAS4Mymzp8B762qtcBvN7Gfk2Rjki1JtkxNjXj0kiRJkiTNwULcInhl834z8FvN9onT21X110l+tAfnvKmq7gFI8h3gmqZ8G7C+2X4BcHTyswWyJyQ5sKru6z9QVU0B0zOrGvF0UkmSJEmatYX4HqwHmvfdM44/38fMP9C3/XDf/sN953kMcEJV7ZrnuSRJkiRpzvbWY9q/BGwASPIS4KAh9R5Msu88znMN8IbpnSSr53EsSZIkSZqTtj6DdeGY+hcAJya5BXgR8P0h9aaArdMPudgDbwTWJNma5OvAH+zhcSRJkiRpzvboFsGqWjGkfFXf9hZgXbP9z/QmVtPePKT9W4C39O2vbN43A5v7ytf1bf8sVlU7gf4HbkiSJEnSXrO3bhGUJEmSpImXqvk+e2LZ63wHSJIkSR31c9/PO18L8RTBZeelnx8eu+ol4+Mj/1kK3vj+4eH3nTm2OUd+e3j8W/9xfPv5xsflv5Dnb+MYeyO+2P9G73/j8PiZ71v8/jFufJTFvgbjxo3veXwpXINx4/ONt81bBCVJkiSpJU6wJEmSJKkl85pgJdndPKb9jiS3JfnDJK1N2pKckeTwvv1Lkhzd1vElSZIkqU3z/QzWrqpaDZDkEODjwBOB82Z7gCQrqmr3kPAZwO3ADoCqes18LlaSJEmSFlJrq01VdS+wEXhDes5I8oHpeJLPJVnXbN+f5J1JbgROSPKOJDcluT3JVNP+lcAaYFOzSrZ/ks1J1jTHOC3JtqbNRX3nuT/JHzcrajckObStHCVJkiRplFY/g1VVdzXHPGRM1QOA26vqOVV1PfCBqlpbVb8G7A+cUlWXA1uADVW1uqp2TTdubhu8CDgZWA2sTfLyvmPfUFXPAr4EvHbmyZNsTLIlyZapqal5ZCxJkiRJj1iIh1zM5lnyu4Er+vbXJ7kxyTZ6k6ZfHdN+LbC5qn5YVQ8Bm4ATm9hPgc812zcDq2Y2rqqpqlpTVWs2btw4i8uVJEmSpPFa/R6sJM+gN3m6F3iIR0/g9uvb/sn0566S7Ad8EFhTVXcnOX9G3YGnGhF7sB759uTd+F1fkiRJkvaSNp/491TgYnq3+xWwHVid5DFJjgCOH9J0ejK1M8lK4JV9sfuAAwe0uRE4KcnBSVYApwHXtZCGJEmSJO2x+a7u7J/kVmBfeitWHwXe08S+DHwX2EbvSYC3DDpAVf1Lkj9v6m0HbuoLXwpcnGQXcEJfm3uSvBW4lt5q1lVV9Zl55iJJkiRJ8zKvCVZVrRgRK2DDkNjKGftvB94+oN4VPPqzWuv6Yh+n91j4ocduHpRx+dAEJEmSJKlFC/GQC0mSJEnqJCdYkiRJktSSPPLAvW5KsrGqOvtlWF3PH+wD8zf/LucP9oH5m3+X8wf7wPzbz98VLOj6F2F1PX+wD8y/27qeP9gH5t9tXc8f7APzb5kTLEmSJElqiRMsSZIkSWqJEyzo7D2nja7nD/aB+Xdb1/MH+8D8u63r+YN9YP4t6/xDLiRJkiSpLa5gSZIkSVJLnGBJkiRJUksmaoKV5MVJvpnk20nOacqenORvk3yreT9otm3n0n6pGNIH707y90m2JvnLJE+abdumfNn0wbAcmtjZSSrJwXNpOwn5JzmzKb8jybvm2HZZ559kdZIbktyaZEuS42fbtilfTvn/RZJ7k9zeV9aZMXBI/p0Z/2BwH/TFujAGDsy/Q2PgoN+BLo2BRyS5Nsk3mn/rNzXlnRgHR+TfmXFwWB/0xffOOFhVE/ECVgDfAZ4BPBa4DTgaeBdwTlPnHOCi2bZtYmPbL5XXiD54EbBPU+eiSe2DMTkcAVwNfA84uEv5A+uBLwCPa+od0rH8rwFe0tR5KbB5EvNvru9E4Fjg9r6yLo2Bg/LvxPg3qg+a8okfA0f8DHRiDByRf5fGwMOAY5vtA4E76dDfgiPy78w4OKwPmv29Ng4ueke02KEnAFf37b+1eX0TOKyv078527bN9tj2S+U1Ko++slcAmyaxD8bkcDnwLGD7kF+qic0fuAx4wTz6brnnfzXwqqbsNODjk5h/37Wv4tF/XHVmDByU/4zYxI5/4/qgC2PgsPy7MgaOyL9TY+CMvD4DvLBr4+DM/GeUdWIcHNQHe3McnKRbBH8RuLtv/wdN2aFVdQ9A834IQJLDk1w1pi3D2i9Ro/KY9vvA52Ei+2BgDkleBvxDVd3WX7kr+QNHAc9PcmOS65KshU7lfxbw7iR3A39Kb8CcxPyH6dIYOM4kj39DdWgMHKYrY+AwZ9HBMTDJKuDZwI10cByckX+/zoyD/X2wt8fBfeZ/+UtGBpTVsMpVtYPeUvmc2y5hI/NIci7wELAJJrIPBuXwOOBcesvjj9KR/Ive7/lBwG8Aa4HLkjyjQ/m/HnhzVV2R5FTgI/T+b/ak5T8nXcu/A+PfQEkeT3fGwGG6MgYO07kxMMlK4ArgrKr612RQepP7OzAz/77yzoyD/X1AL+e9Og5O0grWD+jdWzntl4AdwD8lOQygeb93Dm2ZZfulYmgeSU4HTgE2VLO+Odu2LJ8+GJTD94GnA7cl2d6U3ZLkF2bRdhLy39GUX1k9XwUeBmZ+uHOS8z8duLIp+xQw6APek5D/MF0aAwfqyPg3zDPpzhg4TFfGwGE6NQYm2ZfeH9abqmo6786Mg0Py79Q4OKAP9vo4OEkTrJuAI5M8Pcljgd8FPtu8Tm/qnE7vXszZtmWW7ZeKgXkkeTHwFuBlVfXvc2nbxJZLHwzK4cqqOqSqVlXVKnq/PMdW1T/Oou0k5P9Z4NPAyQBJjqL3wc2ds2wLyz//HcBJTZ2TgW/NoS0sn/yH6dIY+HM6NP4NVFXbOjQGDvNpujEGDtOZMTC9paqPAN+oqvf0hToxDg7Lv0vj4KA+WJRxcCE+ULZYL3pLfHfSewLIuU3ZU4Av0htQvgg8uSk/HLhqVNtR7Zfqa0gffJvePaW3Nq+LJ7UPhuXQF99O88HGruRP74+JjwG3A7cAJ3cs/+cBN9N7GtCNwHETnP8ngHuAB+n9B+TVXRoDh+TfmfFvWB/MiE/6GDjoZ6BLY+Cg/Ls0Bj6P3i1dW/t+5186LIdJ64MR+XdmHBzWBzPqbGeBx8E0jSRJkiRJ8zRJtwhKkiRJ0qJygiVJkiRJLXGCJUmSJEktcYIlSZIkSS1xgiVJkiRJLXGCJUmSJEktcYIlSZIkSS1xgiVJkiRJLXGCJUmSJEktcYIlSZIkSS1xgiVJkiRJLXGCJUmaCEnun7F/RpIPLNb1SJK6yQmWJEmSJLXECZYkaeIl+Q9Jvphka/P+tKb80iQfSnJtkruSnJTkL5J8I8mlfe1flOTvktyS5FNJVi5aMpKkJc0JliRpUuyf5NbpF/DOvtgHgP+3qo4BNgHv64sdBJwMvBn4K+C9wK8Cv55kdZKDgbcDL6iqY4EtwB8ueDaSpGVpn8W+AEmSWrKrqlZP7yQ5A1jT7J4A/Faz/VHgXX3t/qqqKsk24J+qalvT/g5gFfBLwNHAl5MAPBb4uwXLQpK0rDnBkiR1UfVtP9C8P9y3Pb2/D7Ab+NuqOm0vXZskaRnzFkFJUhd8BfjdZnsDcP0c2t4A/GaS/wiQ5PFJjmr5+iRJE8IJliSpC94I/B9JtgK/B7xptg2r6ofAGcAnmvY3AL+yEBcpSVr+UlXja0mSJEmSxnIFS5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4vdgPfq7UCRJkiR1R9o+oBMsGN2tNTZsfAHjS+EaJiH+xH8dHv/xE2C/B4bHf/K4xb/+rscn+d9nb13DuD5c6n281K9vvtc/boz6za8Mj3/5ubDm5uHxLcct/PUt9PHn++8/3/M/7e4RJwC+f8ToOt8/An7tjuHx23918X9Gl3p8vj8D/h0wOt42bxGUJEmSpJY4wZIkSZKkljjBkiRJkqSWjJ1gJTk3yR1Jtia5NclzmvKzkjx+ridMckaSw2cTS3JJkqPneg5JkiRJWgwjJ1hJTgBOAY6tqmOAFwDTH2M8C5jTBCvJCuAMYOAEa2asql5TVV+fyzkkSZIkabGMW8E6DNhZVQ8AVNXOqtqR5I30JkLXJrkWIMmHkmxpVrsumD5Aku1J3pHkeuA0YA2wqVkN27+v3itnxpJsTrKmid+f5KIkNyf5QpLjm/hdSV7W1FmR5N1JbmpW3F7XWk9JkiRJ0hjjJljXAEckuTPJB5OcBFBV7wN2AOuran1T99yqWgMcA5yU5Ji+4/ykqp5XVR8DtgAbqmp1Ve2arlBVlw+LNQ4ANlfVccB9wB8BLwReAbyzqfNq4MdVtRZYC7w2ydNnJpVkYzMZ3DI1NTWmCyRJkiRpdkZ+D1ZV3Z/kOOD5wHrgk0nOqapLB1Q/NcnG5piHAUcDW5vYJ1u41p8Cf9NsbwMeqKoHk2wDVjXlLwKOaVbDAJ4IHAl8d0ZeU8D0zKpwnUuSJElSC8Z+0XBV7QY2A5ubyczpwKX9dZpVorOBtVX1oySXAvv1Vfm3Fq71waqa/i6wh4Hp2xYfTjKdR4Azq+rqFs4nSZIkSXMy7iEXv5zkyL6i1cD3mu37gAOb7SfQm0T9OMmhwEtGHLa/3Vxis3E18Pok+wIkOSrJAfM4niRJkiTN2rgVrJXA+5M8CXgI+DawsYlNAZ9Pck9VrU/yNeAO4C7gyyOOeSlwcZJdwAkzPmv1qNgccwG4hN7tgrckCfBD4OV7cBxJkiRJmrNxn8G6GXjukNj7gff37Z8xpN6qGftXAFcMqTsztq4vtrJv+/wZ7VY27w8Db2tekiRJkrRXjf2iYUmSJEnS7OSR50Z0Vuc7QJIkSeqotH3AsU8R7IRR3Vpjw8YXML4UrsH44seP+tbw+J1HLv3z/4fvD49/72nj2+/3wPD4Tx639Nu38Ts+3z6cb47jzv+kHw+P/8sTF/76x51/XH7z/Tced/6F/h1d7N+xpd4/8/35GNV++hiL/d+JhY4v9M/IQl/fYv8MLvV427xFUJIkSZJa4gRLkiRJklqyRxOsJLuT3Nr3OmeO7bcnOXhA+dtm7H9lT65PkiRJkhbDnn4Ga1dVrW7zQhpvA/5keqeqBj4iXpIkSZKWolZvEWxWpi5IckuSbUl+pSl/SpJrknwtyYcZ8FmzJBcC+zcrYpuasvub93VJrktyWZI7k1yYZEOSrzbneWZT76lJrkhyU/P6zTbzkyRJkqRR9nSCNT0Rmn69qi+2s6qOBT4EnN2UnQdcX1XPBj4LPG3mAavqHJqVsaraMOCczwLeBPw68HvAUVV1PHAJcGZT58+A91bVWuC3m9jPSbIxyZYkW6ampuaYuiRJkiQNthC3CF7ZvN8M/FazfeL0dlX9dZIf7cE5b6qqewCSfAe4pinfBqxvtl8AHJ38bIHsCUkOrKr7+g9UVVPA9MyqeN0eXI0kSZIkzbAQ34M1/ST+3TOOP9/HzPc/4f/hvv2H+87zGOCEqto1z3NJkiRJ0pztrce0fwnYAJDkJcBBQ+o9mGTfeZznGuAN0ztJVs/jWJIkSZI0J219BuvCMfUvAE5McgvwImDYd65PAVunH3KxB94IrEmyNcnXgT/Yw+NIkiRJ0pzt0S2CVbViSPmqvu0twLpm+5/pTaymvXlI+7cAb+nbX9m8bwY295Wv69v+WayqdgL9D9yQJEmSpL1mb90iKEmSJEkTL1XzffbEstf5DpAkSZI66ue+n3e+FuIpgsvOH753eOw9bx7d68X840f8YHj87l8a3/7UTw2PX/Y74+Mn3DA8/ne/Mf76FjI+XWeh/w0W+t9oXPxTpw6P/85l439Gx8XH/RuPu775tp/vz8h7/3B4/M3vWfh/n3EV5vvvt9j9v5jtZ3uM+fbhuBzG9fF8x9Fx7ef7M7rQ4/hij8HLfYyf5PhSuAbjxuf93/mWeYugJEmSJLXECZYkSZIktWReE6wku5vHtN+R5LYkf5iktUlbkjOSHN63f0mSo9s6viRJkiS1ab6fwdpVVasBkhwCfBx4InDebA+QZEVV7R4SPgO4HdgBUFWvmc/FSpIkSdJCam21qaruBTYCb0jPGUk+MB1P8rkk65rt+5O8M8mNwAlJ3pHkpiS3J5lq2r8SWANsalbJ9k+yOcma5hinJdnWtLmo7zz3J/njZkXthiSHtpWjJEmSJI3S6mewququ5piHjKl6AHB7VT2nqq4HPlBVa6vq14D9gVOq6nJgC7ChqlZX1a7pxs1tgxcBJwOrgbVJXt537Buq6lnAl4DXzjx5ko1JtiTZMjU1NY+MJUmSJOkRC/GQi9k8S343cEXf/vokNybZRm/S9Ktj2q8FNlfVD6vqIWATcGIT+ynwuWb7ZmDVzMZVNVVVa6pqzcaNG2dxuZIkSZI0Xqvfg5XkGfQmT/cCD/HoCdx+fds/mf7cVZL9gA8Ca6rq7iTnz6g78FQjYg/WI9+evBu/60uSJEnSXtLmE/+eClxM73a/ArYDq5M8JskRwPFDmk5PpnYmWQm8si92H3DggDY3AiclOTjJCuA04LoW0pAkSZKkPTbf1Z39k9wK7EtvxeqjwHua2JeB7wLb6D0J8JZBB6iqf0ny50297cBNfeFLgYuT7AJO6GtzT5K3AtfSW826qqo+M89cJEmSJGle5jXBqqoVI2IFbBgSWzlj/+3A2wfUu4JHf1ZrXV/s4/QeCz/02M2DMi4fmoAkSZIktWghHnIhSZIkSZ3kBEuSJEmSWpJHHrjXTUk2VlVnvwyr6/mDfWD+5t/l/ME+MH/z73L+YB+Yf/v5u4IFXf8irK7nD/aB+Xdb1/MH+8D8u63r+YN9YP4tc4IlSZIkSS1xgiVJkiRJLXGCBZ2957TR9fzBPjD/but6/mAfmH+3dT1/sA/Mv2Wdf8iFJEmSJLXFFSxJkiRJaokTLEmSJElqyURNsJK8OMk3k3w7yTlN2ZOT/G2SbzXvB8227VzaLxVD+uDdSf4+ydYkf5nkSbNt25Qvmz4YlkMTOztJJTl4Lm0nIf8kZzbldyR51xzbLuv8k6xOckOSW5NsSXL8bNs25csp/79Icm+S2/vKOjMGDsm/M+MfDO6DvlgXxsCB+XdoDBz0O9ClMfCIJNcm+Ubzb/2mprwT4+CI/DszDg7rg7743hkHq2oiXsAK4DvAM4DHArcBRwPvAs5p6pwDXDTbtk1sbPul8hrRBy8C9mnqXDSpfTAmhyOAq4HvAQd3KX9gPfAF4HFNvUM6lv81wEuaOi8FNk9i/s31nQgcC9zeV9alMXBQ/p0Y/0b1QVM+8WPgiJ+BToyBI/Lv0hh4GHBss30gcCcd+ltwRP6dGQeH9UGzv9fGwUXviBY79ATg6r79tzavbwKH9XX6N2fbttke236pvEbl0Vf2CmDTJPbBmBwuB54FbB/ySzWx+QOXAS+YR98t9/yvBl7VlJ0GfHwS8++79lU8+o+rzoyBg/KfEZvY8W9cH3RhDByWf1fGwBH5d2oMnJHXZ4AXdm0cnJn/jLJOjIOD+mBvjoOTdIvgLwJ39+3/oCk7tKruAWjeDwFIcniSq8a0ZVj7JWpUHtN+H/g8TGQfDMwhycuAf6iq2/ordyV/4Cjg+UluTHJdkrXQqfzPAt6d5G7gT+kNmJOY/zBdGgPHmeTxb6gOjYHDdGUMHOYsOjgGJlkFPBu4kQ6OgzPy79eZcbC/D/b2OLjP/C9/yciAshpWuap20Fsqn3PbJWxkHknOBR4CNsFE9sGgHB4HnEtvefxROpJ/0fs9Pwj4DWAtcFmSZ3Qo/9cDb66qK5KcCnyE3v/NnrT856Rr+Xdg/BsoyePpzhg4TFfGwGE6NwYmWQlcAZxVVf+aDEpvcn8HZubfV96ZcbC/D+jlvFfHwUlawfoBvXsrp/0SsAP4pySHATTv986hLbNsv1QMzSPJ6cApwIZq1jdn25bl0weDcvg+8HTgtiTbm7JbkvzCLNpOQv47mvIrq+erwMPAzA93TnL+pwNXNmWfAgZ9wHsS8h+mS2PgQB0Z/4Z5Jt0ZA4fpyhg4TKfGwCT70vvDelNVTefdmXFwSP6dGgcH9MFeHwcnaYJ1E3BkkqcneSzwu8Bnm9fpTZ3T6d2LOdu2zLL9UjEwjyQvBt4CvKyq/n0ubZvYcumDQTlcWVWHVNWqqlpF75fn2Kr6x1m0nYT8Pwt8GjgZIMlR9D64uXOWbWH5578DOKmpczLwrTm0heWT/zBdGgN/TofGv4GqaluHxsBhPk03xsBhOjMGprdU9RHgG1X1nr5QJ8bBYfl3aRwc1AeLMg4uxAfKFutFb4nvTnpPADm3KXsK8EV6A8oXgSc35YcDV41qO6r9Un0N6YNv07un9NbmdfGk9sGwHPri22k+2NiV/On9MfEx4HbgFuDkjuX/POBmek8DuhE4boLz/wRwD/Agvf+AvLpLY+CQ/Dsz/g3rgxnxSR8DB/0MdGkMHJR/l8bA59G7pWtr3+/8S4flMGl9MCL/zoyDw/pgRp3tLPA4mKaRJEmSJGmeJukWQUmSJElaVE6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSRMjyS8l+UySbyX5TpI/S/LYJKuTvLSv3vlJzl7Ma5UkTSYnWJKkiZAkwJXAp6vqSOAoYCXwx8Bq4KXDW8/5XCvaOpYkabI4wZIkTYqTgZ9U1f8DUFW7gTcDrwHeBbwqya1JXtXUPzrJ5iR3JXnj9EGS/O9JvtrU/fD0ZCrJ/UnemeRG4IS9mpkkadlwgiVJmhS/CtzcX1BV/wpsB/4I+GRVra6qTzbhXwH+F+B44Lwk+yb5n4BXAb9ZVauB3cCGpv4BwO1V9Zyqun6hk5EkLU/7LPYFSJLUkgA1h/K/rqoHgAeS3AscCvzPwHHATb07DtkfuLepvxu4ou2LliRNFidYkqRJcQfw2/0FSZ4AHEFvcjTTA33bu+n9NzHAf62qtw6o/5PmtkNJkobyFkFJ0qT4IvD4JP8ZfvYgiv8buBT4J+DAWR7jlUkOaY7x5CT/YWEuV5I0iZxgSZImQlUV8Argd5J8C7gT+AnwNuBaeg+16H/IxaBjfB14O3BNkq3A3wKHLfjFS5ImRnr/PZIkSZIkzZcrWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEr8Ha/CXT0qSJEmafGn7gE6wGN2rZXxR40vhGowbN75w8aVwDbOJj6uw1I9/wfnD4+edPz6+2P1vfOnGl8I17I34+s3D49euW/rHNz463jZvEZQkSZKkljjBkiRJkqSWOMGSJEmSpJaMnWAlOTfJHUm2Jrk1yXOa8rOSPH6uJ0xyRpLDZxNLckmSo+d6DkmSJElaDCMnWElOAE4Bjq2qY4AXAHc34bOAOU2wkqwAzgAGTrBmxqrqNVX19bmcQ5IkSZIWy7gVrMOAnVX1AEBV7ayqHUneSG8idG2SawGSfCjJlma164LpAyTZnuQdSa4HTgPWAJua1bD9++q9cmYsyeYka5r4/UkuSnJzki8kOb6J35XkZU2dFUneneSmZsXtda31lCRJkiSNMW6CdQ1wRJI7k3wwyUkAVfU+YAewvqrWN3XPrao1wDHASUmO6TvOT6rqeVX1MWALsKGqVlfVrukKVXX5sFjjAGBzVR0H3Af8EfBC4BXAO5s6rwZ+XFVrgbXAa5M8fWZSSTY2k8EtU1NTY7pAkiRJkmZn5PdgVdX9SY4Dng+sBz6Z5JyqunRA9VOTbGyOeRhwNLC1iX2yhWv9KfA3zfY24IGqejDJNmBVU/4i4JhmNQzgicCRwHdn5DUFTM+symUuSZIkSW0Y+0XDVbUb2AxsbiYzpwOX9tdpVonOBtZW1Y+SXArs11fl31q41geravq7wB4Gpm9bfDjJdB4Bzqyqq1s4nyRJkiTNybiHXPxykiP7ilYD32u27wMObLafQG8S9eMkhwIvGXHY/nZzic3G1cDrk+wLkOSoJAfM43iSJEmSNGvjVrBWAu9P8iTgIeDbwMYmNgV8Psk9VbU+ydeAO4C7gC+POOalwMVJdgEnzPis1aNic8wF4BJ6twvekiTAD4GX78FxJEmSJGnOxn0G62bguUNi7wfe37d/xpB6q2bsXwFcMaTuzNi6vtjKvu3zZ7Rb2bw/DLyteUmSJEnSXjX2i4YlSZIkSbOTR54b0Vmd7wBJkiSpo9L2Acc+RbAL1m8eHrt23eheL4wvZHwpXINx48YXLr4UrmFvxMdVWOzru+D84fHzzh8fn/T+MT7aYl/DJMT9W3Rx423zFkFJkiRJaokTLEmSJElqyR5NsJLsTnJr3+ucObbfnuTgAeVvm7H/lT25PkmSJElaDHv6GaxdVbW6zQtpvA34k+mdqhr4iHhJkiRJWopavUWwWZm6IMktSbYl+ZWm/ClJrknytSQfZsBnzZJcCOzfrIhtasrub97XJbkuyWVJ7kxyYZINSb7anOeZTb2nJrkiyU3N6zfbzE+SJEmSRtnTCdb0RGj69aq+2M6qOhb4EHB2U3YecH1VPRv4LPC0mQesqnNoVsaqasOAcz4LeBPw68DvAUdV1fHAJcCZTZ0/A95bVWuB325iPyfJxiRbkmyZmpqaY+qSJEmSNNhC3CJ4ZfN+M/BbzfaJ09tV9ddJfrQH57ypqu4BSPId4JqmfBuwvtl+AXB08rMFsickObCq7us/UFVNAdMzq/rE5j24GkmSJEmaYSG+B+uB5n33jOPP9zHzD/RtP9y3/3DfeR4DnFBVu+Z5LkmSJEmas731mPYvARsAkrwEOGhIvQeT7DuP81wDvGF6J8nqeRxLkiRJkuakrc9gXTim/gXAiUluAV4EfH9IvSlg6/RDLvbAG4E1SbYm+TrwB3t4HEmSJEmasz26RbCqVgwpX9W3vQVY12z/M72J1bQ3D2n/FuAtffsrm/fNwOa+8nV92z+LVdVOoP+BG5IkSZK01+ytWwQlSZIkaeKlar7Pnlj2Ot8BkiRJUkf93PfzztdCPEVw2bng/OGx884fHx/5z1KwfvPw8LXrxjZf8Pi4CvM9/nzyn+05jBs3vjzjS+EajBs3vufxpXANxo3P+2/hlnmLoCRJkiS1xAmWJEmSJLVkXhOsJLubx7TfkeS2JH+YpLVJW5Izkhzet39JkqPbOr4kSZIktWm+n8HaVVWrAZIcAnwceCJw3mwPkGRFVe0eEj4DuB3YAVBVr5nPxUqSJEnSQmpttamq7gU2Am9IzxlJPjAdT/K5JOua7fuTvDPJjcAJSd6R5KYktyeZatq/ElgDbGpWyfZPsjnJmuYYpyXZ1rS5qO889yf542ZF7YYkh7aVoyRJkiSN0upnsKrqruaYh4ypegBwe1U9p6quBz5QVWur6teA/YFTqupyYAuwoapWV9Wu6cbNbYMXAScDq4G1SV7ed+wbqupZwJeA1848eZKNSbYk2TI1NTWPjCVJkiTpEQvxkIvZPEt+N3BF3/76JDcm2UZv0vSrY9qvBTZX1Q+r6iFgE3BiE/sp8Llm+2Zg1czGVTVVVWuqas3GjRtncbmSJEmSNF6r34OV5Bn0Jk/3Ag/x6Ancfn3bP5n+3FWS/YAPAmuq6u4k58+oO/BUI2IP1iPfnrwbv+tLkiRJ0l7S5hP/ngpcTO92vwK2A6uTPCbJEcDxQ5pOT6Z2JlkJvLIvdh9w4IA2NwInJTk4yQrgNOC6FtKQJEmSpD0239Wd/ZPcCuxLb8Xqo8B7mtiXge8C2+g9CfCWQQeoqn9J8udNve3ATX3hS4GLk+wCTuhrc0+StwLX0lvNuqqqPjPPXCRJkiRpXuY1waqqFSNiBWwYEls5Y//twNsH1LuCR39Wa11f7OP0Hgs/9NjNgzIuH5qAJEmSJLVoIR5yIUmSJEmd5ARLkiRJklqSRx64101JNlZVZ78Mq+v5g31g/ubf5fzBPjB/8+9y/mAfmH/7+buCBV3/Iqyu5w/2gfl3W9fzB/vA/Lut6/mDfWD+LXOCJUmSJEktcYIlSZIkSS1xggWdvee00fX8wT4w/27rev5gH5h/t3U9f7APzL9lnX/IhSRJkiS1xRUsSZIkSWqJEyxJkiRJaslETbCSvDjJN5N8O8k5TdmTk/xtkm817wfNtu1c2i8VQ/rg3Un+PsnWJH+Z5EmzbduUL5s+GJZDEzs7SSU5eC5tJyH/JGc25Xckedcc2y7r/JOsTnJDkluTbEly/GzbNuXLKf+/SHJvktv7yjozBg7JvzPjHwzug75YF8bAgfl3aAwc9DvQpTHwiCTXJvlG82/9pqa8E+PgiPw7Mw4O64O++N4ZB6tqIl7ACuA7wDOAxwK3AUcD7wLOaeqcA1w027ZNbGz7pfIa0QcvAvZp6lw0qX0wJocjgKuB7wEHdyl/YD3wBeBxTb1DOpb/NcBLmjovBTZPYv7N9Z0IHAvc3lfWpTFwUP6dGP9G9UFTPvFj4IifgU6MgSPy79IYeBhwbLN9IHAnHfpbcET+nRkHh/VBs7/XxsFF74gWO/QE4Oq+/bc2r28Ch/V1+jdn27bZHtt+qbxG5dFX9gpg0yT2wZgcLgeeBWwf8ks1sfkDlwEvmEffLff8rwZe1ZSdBnx8EvPvu/ZVPPqPq86MgYPynxGb2PFvXB90YQwcln9XxsAR+XdqDJyR12eAF3ZtHJyZ/4yyToyDg/pgb46Dk3SL4C8Cd/ft/6ApO7Sq7gFo3g8BSHJ4kqvGtGVY+yVqVB7Tfh/4PExkHwzMIcnLgH+oqtv6K3clf+Ao4PlJbkxyXZK10Kn8zwLeneRu4E/pDZiTmP8wXRoDx5nk8W+oDo2Bw3RlDBzmLDo4BiZZBTwbuJEOjoMz8u/XmXGwvw/29ji4z/wvf8nIgLIaVrmqdtBbKp9z2yVsZB5JzgUeAjbBRPbBoBweB5xLb3n8UTqSf9H7PT8I+A1gLXBZkmd0KP/XA2+uqiuSnAp8hN7/zZ60/Oeka/l3YPwbKMnj6c4YOExXxsBhOjcGJlkJXAGcVVX/mgxKb3J/B2bm31femXGwvw/o5bxXx8FJWsH6Ab17K6f9ErAD+KckhwE07/fOoS2zbL9UDM0jyenAKcCGatY3Z9uW5dMHg3L4PvB04LYk25uyW5L8wizaTkL+O5ryK6vnq8DDwMwPd05y/qcDVzZlnwIGfcB7EvIfpktj4EAdGf+GeSbdGQOH6coYOEynxsAk+9L7w3pTVU3n3ZlxcEj+nRoHB/TBXh8HJ2mCdRNwZJKnJ3ks8LvAZ5vX6U2d0+ndiznbtsyy/VIxMI8kLwbeArysqv59Lm2b2HLpg0E5XFlVh1TVqqpaRe+X59iq+sdZtJ2E/D8LfBo4GSDJUfQ+uLlzlm1h+ee/AzipqXMy8K05tIXlk/8wXRoDf06Hxr+Bqmpbh8bAYT5NN8bAYTozBqa3VPUR4BtV9Z6+UCfGwWH5d2kcHNQHizIOLsQHyhbrRW+J7056TwA5tyl7CvBFegPKF4EnN+WHA1eNajuq/VJ9DemDb9O7p/TW5nXxpPbBsBz64ttpPtjYlfzp/THxMeB24Bbg5I7l/zzgZnpPA7oROG6C8/8EcA/wIL3/gLy6S2PgkPw7M/4N64MZ8UkfAwf9DHRpDByUf5fGwOfRu6Vra9/v/EuH5TBpfTAi/86Mg8P6YEad7SzwOJimkSRJkiRpnibpFkFJkiRJWlROsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEkTI8l7k5zVt391kkv69v/vJH84y2NtTrJmAS5TkjTBnGBJkibJV4DnAiR5DHAw8Kt98ecCXx53kCQrFuTqJEkTzwmWJGmSfJlmgkVvYnU7cF+Sg5I8DvifgCcl+VqSbUn+oiknyfYk70hyPfA70wdM8pgk/zXJH+3lXCRJy5ATLEnSxKiqHcBDSZ5Gb6L1d8CNwAnAGuBO4BLgVVX168A+wOv7DvGTqnpeVf23Zn8fYBNwZ1W9fS+lIUlaxpxgSZImzfQq1vQE6+/69v8B+G5V3dnU/a/AiX1tPznjWB8Gbq+qP17QK5YkTQwnWJKkSTP9Oaxfp3eL4A30VrCeC9wypu2/DTjW+iT7tX2RkqTJ5ARLkjRpvgycAvyPqtpdVf8DeBK9Sdb/A6xK8h+bur8HXDfiWB8BrgI+lWSfhbtkSdKkcIIlSZo02+g9PfCGGWU/rqofAP8HvQnTNuBh4OJRB6uq99Bb+fpo82RCSZKGSlUt9jVIkiRJ0kTw/8RJkiRJUkucYEmSJElSS5xgSZIkSVJLnGBJkiRJUkucYEmSJElSS/xOD/AxipIkSVI3pe0DOsECpl43PLbxw6N7vTC+kPGlcA3Gl398XIXFvr6b1wyPH7cF1tw8PL7luMW/fn/Hx/8bLfa/4WKf3/jixhfy53O212B8ceOvmxoe//DGxb++xY63zVsEJUmSJKklTrAkSZIkqSVjJ1hJzk1yR5KtSW5N8pym/Kwkj5/rCZOckeTw2cSSXJLk6LmeQ5IkSZIWw8gJVpITgFOAY6vqGOAFwN1N+CxgThOsJCuAM4CBE6yZsap6TVV9fS7nkCRJkqTFMm4F6zBgZ1U9AFBVO6tqR5I30psIXZvkWoAkH0qypVntumD6AEm2J3lHkuuB04A1wKZmNWz/vnqvnBlLsjnJmiZ+f5KLktyc5AtJjm/idyV5WVNnRZJ3J7mpWXEb8fgKSZIkSWrXuAnWNcARSe5M8sEkJwFU1fuAHcD6qlrf1D23qtYAxwAnJTmm7zg/qarnVdXHgC3AhqpaXVW7pitU1eXDYo0DgM1VdRxwH/BHwAuBVwDvbOq8GvhxVa0F1gKvTfL0mUkl2dhMBrdMTY14rIokSZIkzcHIx7RX1f1JjgOeD6wHPpnknKq6dED1U5NsbI55GHA0sLWJfbKFa/0p8DfN9jbggap6MMk2YFVT/iLgmGY1DOCJwJHAd2fkNQVMz6xq1GPaJUmSJGm2xn4PVlXtBjYDm5vJzOnApf11mlWis4G1VfWjJJcC+/VV+bcWrvXBqpp+VP3DwPRtiw8nmc4jwJlVdXUL55MkSZKkORn3kItfTnJkX9Fq4HvN9n3Agc32E+hNon6c5FDgJSMO299uLrHZuBp4fZJ9AZIcleSAeRxPkiRJkmZt3ArWSuD9SZ4EPAR8G9jYxKaAzye5p6rWJ/kacAdwF/DlEce8FLg4yS7ghBmftXpUbI65AFxC73bBW5IE+CHw8j04jiRJkiTN2bjPYN0MPHdI7P3A+/v2zxhSb9WM/SuAK4bUnRlb1xdb2bd9/ox2K5v3h4G3NS9JkiRJ2qvGftGwJEmSJGl28shzIzqr8x0gSZIkdVTaPuDYpwh2wqhurbFh4wsYXwrXMAnxC84fHj/vfFi/eXj82nWLf/3GJze+FK7B+OLHx41BCz1GLfT5F/r6x1W4bt3w8Emb/R027t8BbfMWQUmSJElqiRMsSZIkSWrJHk2wkuxOcmvf65w5tt+e5OAB5W+bsf+VPbk+SZIkSVoMe/oZrF1VtbrNC2m8DfiT6Z2qGviIeEmSJElailq9RbBZmbogyS1JtiX5lab8KUmuSfK1JB9mwGfNklwI7N+siG1qyu5v3tcluS7JZUnuTHJhkg1Jvtqc55lNvacmuSLJTc3rN9vMT5IkSZJG2dMJ1vREaPr1qr7Yzqo6FvgQcHZTdh5wfVU9G/gs8LSZB6yqc2hWxqpqw4BzPgt4E/DrwO8BR1XV8cAlwJlNnT8D3ltVa4HfbmI/J8nGJFuSbJmamppj6pIkSZI02ELcInhl834z8FvN9onT21X110l+tAfnvKmq7gFI8h3gmqZ8G7C+2X4BcHTyswWyJyQ5sKru6z9QVU0B0zOr4nV7cDWSJEmSNMNCfA/WA8377hnHn+9j5h/o2364b//hvvM8BjihqnbN81ySJEmSNGd76zHtXwI2ACR5CXDQkHoPJtl3Hue5BnjD9E6S1fM4liRJkiTNSVufwbpwTP0LgBOT3AK8CPj+kHpTwNbph1zsgTcCa5JsTfJ14A/28DiSJEmSNGd7dItgVa0YUr6qb3sLsK7Z/md6E6tpbx7S/i3AW/r2Vzbvm4HNfeXr+rZ/FquqnUD/AzckSZIkaa/ZW7cISpIkSdLES9V8nz2x7HW+AyRJkqSO+rnv552vhXiK4LIzqlerA/FPnTo8/juXLe717Y1zdKGPx51/3AEWu/9O/dTw+GW/Mz6+0P0z7vzjjj/f61/O8aVwDcaNG9/z+FK4BuPG5xtvm7cISpIkSVJLnGBJkiRJUkucYEmSJElSS+Y1wUqyu/kerDuS3JbkD5O0NmlLckaSw/v2L0lydFvHlyRJkqQ2zfchF7uqajVAkkOAjwNPBM6b7QGSrKiq3UPCZwC3AzsAquo187lYSZIkSVpIra02VdW9wEbgDek5I8kHpuNJPpdkXbN9f5J3JrkROCHJO5LclOT2JFNN+1cCa4BNzSrZ/kk2J1nTHOO0JNuaNhf1nef+JH/crKjdkOTQtnKUJEmSpFFa/QxWVd3VHPOQMVUPAG6vqudU1fXAB6pqbVX9GrA/cEpVXQ5sATZU1eqq2jXduLlt8CLgZGA1sDbJy/uOfUNVPQv4EvDamSdPsjHJliRbpqam5pGxJEmSJD1iIb4HazZf1rUbuKJvf32S/wI8HngycAfwVyParwU2V9UPAZJsAk4EPg38FPhcU+9m4IUzG1fVFDA9s6rXzeKCJUmSJGmcVidYSZ5Bb/J0L/AQj14h269v+yfTn7tKsh/wQWBNVd2d5PwZdQeeakTswaqa/s6w3fhlypIkSZL2kjaf+PdU4GJ6t/sVsB1YneQxSY4Ajh/SdHoytTPJSuCVfbH7gAMHtLkROCnJwUlWAKcB17WQhiRJkiTtsfmu7uyf5FZgX3orVh8F3tPEvgx8F9hG70mAtww6QFX9S5I/b+ptB27qC18KXJxkF3BCX5t7krwVuJbeatZVVfWZeeYiSZIkSfMyrwlWVa0YEStgw5DYyhn7bwfePqDeFTz6s1rr+mIfp/dY+KHHbh6UcfnQBCRJkiSpRa0+RVCSJEmSuiyPPA+im5JsbJ4q2Eldzx/sA/M3/y7nD/aB+Zt/l/MH+8D828/fFazelyN3WdfzB/vA/Lut6/mDfWD+3db1/ME+MP+WOcGSJEmSpJY4wZIkSZKkljjBgs7ec9roev5gH5h/t3U9f7APzL/bup4/2Afm37LOP+RCkiRJktriCpYkSZIktcQJliRJkiS1ZKImWElenOSbSb6d5Jym7MlJ/jbJt5r3g2bbdi7tl4ohffDuJH+fZGuSv0zypNm2bcqXTR8My6GJnZ2kkhw8l7aTkH+SM5vyO5K8a45tl3X+SVYnuSHJrUm2JDl+tm2b8uWU/18kuTfJ7X1lnRkDh+TfmfEPBvdBX6wLY+DA/Ds0Bg76HejSGHhEkmuTfKP5t35TU96JcXBE/p0ZB4f1QV9874yDVTURL2AF8B3gGcBjgduAo4F3Aec0dc4BLppt2yY2tv1SeY3ogxcB+zR1LprUPhiTwxHA1cD3gIO7lD+wHvgC8Lim3iEdy/8a4CVNnZcCmycx/+b6TgSOBW7vK+vSGDgo/06Mf6P6oCmf+DFwxM9AJ8bAEfl3aQw8DDi22T4QuJMO/S04Iv/OjIPD+qDZ32vj4KJ3RIsdegJwdd/+W5vXN4HD+jr9m7Nt22yPbb9UXqPy6Ct7BbBpEvtgTA6XA88Ctg/5pZrY/IHLgBfMo++We/5XA69qyk4DPj6J+fdd+yoe/cdVZ8bAQfnPiE3s+DeuD7owBg7Lvytj4Ij8OzUGzsjrM8ALuzYOzsx/RlknxsFBfbA3x8FJukXwF4G7+/Z/0JQdWlX3ADTvhwAkOTzJVWPaMqz9EjUqj2m/D3weJrIPBuaQ5GXAP1TVbf2Vu5I/cBTw/CQ3JrkuyVroVP5nAe9Ocjfwp/QGzEnMf5gujYHjTPL4N1SHxsBhujIGDnMWHRwDk6wCng3cSAfHwRn59+vMONjfB3t7HNxn/pe/ZGRAWQ2rXFU76C2Vz7ntEjYyjyTnAg8Bm2Ai+2BQDo8DzqW3PP4oHcm/6P2eHwT8BrAWuCzJMzqU/+uBN1fVFUlOBT5C7/9mT1r+c9K1/Dsw/g2U5PF0Zwwcpitj4DCdGwOTrASuAM6qqn9NBqU3ub8DM/PvK+/MONjfB/Ry3qvj4CStYP2A3r2V034J2AH8U5LDAJr3e+fQllm2XyqG5pHkdOAUYEM165uzbcvy6YNBOXwfeDpwW5LtTdktSX5hFm0nIf8dTfmV1fNV4GFg5oc7Jzn/04Erm7JPAYM+4D0J+Q/TpTFwoI6Mf8M8k+6MgcN0ZQwcplNjYJJ96f1hvamqpvPuzDg4JP9OjYMD+mCvj4OTNMG6CTgyydOTPBb4XeCzzev0ps7p9O7FnG1bZtl+qRiYR5IXA28BXlZV/z6Xtk1sufTBoByurKpDqmpVVa2i98tzbFX94yzaTkL+nwU+DZwMkOQoeh/c3DnLtrD8898BnNTUORn41hzawvLJf5gujYE/p0Pj30BVta1DY+Awn6YbY+AwnRkD01uq+gjwjap6T1+oE+PgsPy7NA4O6oNFGQcX4gNli/Wit8R3J70ngJzblD0F+CK9AeWLwJOb8sOBq0a1HdV+qb6G9MG36d1TemvzunhS+2BYDn3x7TQfbOxK/vT+mPgYcDtwC3Byx/J/HnAzvacB3QgcN8H5fwK4B3iQ3n9AXt2lMXBI/p0Z/4b1wYz4pI+Bg34GujQGDsq/S2Pg8+jd0rW173f+pcNymLQ+GJF/Z8bBYX0wo852FngcTNNIkiRJkjRPk3SLoCRJkiQtKidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJKkZSdJJflo3/4+SX6Y5HNzPM7mJGua7auSPGkPruWMJB+YaztJ0mTaZ7EvQJKkPfBvwK8l2b+qdgEvBP5hPgesqpe2cmWSpE5zBUuStFx9Hvhfm+3TgE9MB5IckOQvktyU5GtJ/remfP8k/y3J1iSfBPbva7M9ycHN9n9u6tw2vVKW5D8lubE53heSHLq3EpUkLR9OsCRJy9V/A343yX7AMcCNfbFzgf+vqtYC64F3JzkAeD3w71V1DPDHwHEzD5rkV5v2J1fVs4A3NaHrgd+oqmc35/4vC5OWJGk58xZBSdKyVFVbk6yit3p11Yzwi4CXJTm72d8PeBpwIvC+vvZbBxz6ZODyqtrZ1PsfTfkvAZ9MchjwWOC7LaYjSZoQTrAkScvZZ4E/BdYBT+krD/DbVfXN/spJAGrMMTOkzvuB91TVZ5OsA87fkwuWJE02bxGUJC1nfwG8s6q2zSi/GjgzzYwqybOb8i8BG5qyX6N3a+FMXwROTfKUpt6Tm/In8siDNE5vLQNJ0kRxgiVJWraq6gdV9WcDQv8nsC+wNcntzT7Ah4CVza2B/wX46oBj3kHv81nXJbkNeE8TOh/4VJL/DuxsNRFJ0sRI1bg7JSRJkiRJs+EKliRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRJkiS1xO/BGv99KJIkSZImU9o+oBMsRvdqGV/U+FK4BuPGjS9cfClcg/Hx8XEVFvv6jC9efClcg3Hj8x7jWuYtgpIkSZLUEidYkiRJktSSsROsJOcmuSPJ1iS3JnlOU35WksfP9YRJzkhy+GxiSS5JcvRczyFJkiRJi2HkBCvJCcApwLFVdQzwAuDuJnwWMKcJVpIVwBnAwAnWzFhVvaaqvj6Xc0iSJEnSYhm3gnUYsLOqHgCoqp1VtSPJG+lNhK5Nci1Akg8l2dKsdl0wfYAk25O8I8n1wGnAGmBTsxq2f1+9V86MJdmcZE0Tvz/JRUluTvKFJMc38buSvKypsyLJu5Pc1Ky4va61npIkSZKkMcZNsK4BjkhyZ5IPJjkJoKreB+wA1lfV+qbuuVW1BjgGOCnJMX3H+UlVPa+qPgZsATZU1eqq2jVdoaouHxZrHABsrqrjgPuAPwJeCLwCeGdT59XAj6tqLbAWeG2Sp89MKsnGZjK4ZWpqakwXSJIkSdLsjHxMe1Xdn+Q44PnAeuCTSc6pqksHVD81ycbmmIcBRwNbm9gnW7jWnwJ/02xvAx6oqgeTbANWNeUvAo5pVsMAnggcCXx3Rl5TwPTMqlzmkiRJktSGsd+DVVW7gc3A5mYyczpwaX+dZpXobGBtVf0oyaXAfn1V/q2Fa32wqqYfVf8wMH3b4sNJpvMIcGZVXd3C+SRJkiRpTsY95OKXkxzZV7Qa+F6zfR9wYLP9BHqTqB8nORR4yYjD9rebS2w2rgZen2RfgCRHJTlgHseTJEmSpFkbt4K1Enh/kicBDwHfBjY2sSng80nuqar1Sb4G3AHcBXx5xDEvBS5Osgs4YcZnrR4Vm2MuAJfQu13wliQBfgi8fA+OI0mSJElzlkfuuuusyqggvfsOjS9OfClcg3HjxhcuvhSuwfj4+LgKi319xhcvvhSuwbjxecbH/YjP2dgvGpYkSZIkzY4rWM3/nJMkSZLUOa2vYI19imAXLPFly07Hl8I1GDdufOHiS+EajBv3Fso9jy+FazBufN6/wy3zFkFJkiRJaokTLEmSJElqyR5NsJLsTnJr3+ucObbfnuTgAeVvm7H/lT25PkmSJElaDHv6GaxdVbW6zQtpvA34k+mdqnruApxDkiRJkhZEq7cINitTFyS5Jcm2JL/SlD8lyTVJvpbkwwz4rFmSC4H9mxWxTU3Z/c37uiTXJbksyZ1JLkyyIclXm/M8s6n31CRXJLmpef1mm/lJkiRJ0ih7OsGanghNv17VF9tZVccCHwLObsrOA66vqmcDnwWeNvOAVXUOzcpYVW0YcM5nAW8Cfh34PeCoqjoeuAQ4s6nzZ8B7q2ot8NtN7Ock2ZhkS5ItU1NTc0xdkiRJkgZbiFsEr2zebwZ+q9k+cXq7qv46yY/24Jw3VdU9AEm+A1zTlG8D1jfbLwCOTn62QPaEJAdW1X39B6qqKWB6ZlWv24OLkSRJkqSZFuJ7sB5o3nfPOP58HzP/QN/2w337D/ed5zHACVW1a57nkiRJkqQ521uPaf8SsAEgyUuAg4bUezDJvvM4zzXAG6Z3kqyex7EkSZIkaU7a+gzWhWPqXwCcmOQW4EXA94fUmwK2Tj/kYg+8EViTZGuSrwN/sIfHkSRJkqQ5S9V879xb9urnHmnYH2TAIw+N77X4UrgG48aNL1x8KVyDcePzjY+rsNjX5++wceMj4+N+xOdsb90iKEmSJEkTzxWs+T98Q5IkSdLy1PoK1kI8RXDZWeLLloseX8xbH9o4hnHjxpdufClcg3Hjxvc8vhSuwbjxef+t2zJvEZQkSZKkljjBkiRJkqSWOMGSJEmSpJbMa4KVZHfzPVh3JLktyR8maW3SluSMJIf37V+S5Oi2ji9JkiRJbZrvQy52VdVqgCSHAB8HngicN9sDJFlRVbuHhM8Abgd2AFTVa+Zzsfr/t3d/IXKdZRzHvz/7N7UFG2NqqoE0Yi9EaIzZaqC2NlippRSFooZeRBQjgmIE0ZSAiOBFWulVkRCpCBqF2sS0lkjU0lQUEpOGpEmpaauupiYaeyFarNjWx4vzLj0Zz5md7Z7dzJ7n94FhZ9/3vDPze5J5MifnzIyZmZmZmc2lzo42RcQZYCPwOVU+IeneqXlJD0t6f7n+gqSvSzoArJX0VUkHJR2XtL2svx1YA+woR8kWSdonaU25jfWSjpU1W2v384Kkb5QjavslXdFVRjMzMzMzs2E6fQ9WRPy+3ObSaTZ9PXA8It4TEb8C7o2IiYh4J7AIuDUiHgAOAXdExKqIeHFqcTltcCuwDlgFTEj6cO2290fENcAvgU8P3rmkjZIOSTq0ffv2WSQ2MzMzMzN71Vx8D9YoX9b1CrCz9vuNkr4MXAIsBp4EfjJk/QSwLyL+BiBpB3A9sBv4D/Bw2e5x4KbBxRGxHZjas4rPjPCAzczMzMzMptPpDpaklVQ7T2eAlzn7CNnFtev/nnrflaSLgW8BayLipKSvDWzbeFdD5l6KiKnvDHsFf5mymZmZmZnNky4/8e9NwDaq0/0CmARWSXqdpOXAtS1Lp3amnpd0KXB7be6fwGUNaw4AN0haIuk8YD3wWAcxzMzMzMzMXrPZHt1ZJOkIcAHVEavvAfeUuV8DfwCOUX0S4OGmG4iIv0v6dtluEjhYm/4usE3Si8Da2prTku4EHqU6mrUnIh6cZRYzMzMzM7NZ0atn06UVw843DIafj5hhfroN5vL+u7gNz3ve8+M7Pw6PwfOe9/xrnx+Hx+B5z89yfpTPj5iRTj9F0MzMzMzMLLP0R7AkbSyfKphS9vzgGji/82fOD66B8zt/5vzgGjh/9/l9BKv6cuTMsucH18D5c8ueH1wD588te35wDZy/Y97BMjMzMzMz64h3sMzMzMzMzDriHSxIe85pkT0/uAbOn1v2/OAaOH9u2fODa+D8HUv/IRdmZmZmZmZd8REsMzMzMzOzjngHy8zMzMzMrCO92sGSdLOkE5KelbS5jC2W9HNJz5Sfl4+6dibrx0VLDe6W9FtJT0j6saQ3jLq2jC+YGrRlKHNfkhSSlsxkbR/yS/p8GX9S0l0zXLug80taJWm/pCOSDkm6dtS1ZXwh5f+OpDOSjtfG0vTAlvxp+h8016A2l6EHNuZP1AObngOZeuBySY9Keqr8WX+hjKfog0Pyp+mDbTWozc9PH4yIXlyA84DfASuBC4GjwDuAu4DNZZvNwNZR15a5adePy2VIDT4InF+22drXGkyTYTmwF/gjsCRTfuBG4BfARWW7pcny/wz4UNnmFmBfH/OXx3c9sBo4XhvL1AOb8qfof8NqUMZ73wOH/B1I0QOH5M/UA5cBq8v1y4CnSfRacEj+NH2wrQbl93nrg+e8EB0WdC2wt/b7neVyAlhWK/qJUdeW69OuH5fLsBy1sY8AO/pYg2kyPABcA0y2PKl6mx+4H/jALGq30PPvBT5WxtYDP+hj/tpjX8HZL67S9MCm/ANzve1/09UgQw9sy5+lBw7Jn6oHDuR6ELgpWx8czD8wlqIPNtVgPvtgn04RfAtwsvb7c2Xsiog4DVB+LgWQdKWkPdOspW39mBqWY8ongZ9CL2vQmEHSbcCfI+JofeMs+YGrgfdJOiDpMUkTkCr/JuBuSSeBb1I1zD7mb5OpB06nz/2vVaIe2CZLD2yziYQ9UNIK4F3AARL2wYH8dWn6YL0G890Hz5/9wx8bahiLto0j4hTVofIZrx1jQ3NI2gK8DOyAXtagKcNFwBaqw+NnSZI/qJ7nlwPvBSaA+yWtTJT/s8AXI2KnpI8C91H9b3bf8s9ItvwJ+l8jSZeQpwe2ydID26TrgZIuBXYCmyLiH1JTvP4+Bwbz18bT9MF6Dagyz2sf7NMRrOeozq2c8lbgFPBXScsAys8zM1jLiOvHRWsOSRuAW4E7ohzfHHUtC6cGTRn+BFwFHJU0WcYOS3rzCGv7kP9UGd8Vld8A/wUG39zZ5/wbgF1l7EdA0xu8+5C/TaYe2ChJ/2vzNvL0wDZZemCbVD1Q0gVUL6x3RMRU7jR9sCV/qj7YUIN574N92sE6CLxd0lWSLgQ+DjxULhvKNhuozsUcdS0jrh8XjTkk3Qx8BbgtIv41k7VlbqHUoCnDrohYGhErImIF1ZNndUT8ZYS1fcj/ELAbWAcg6WqqN24+P+JaWPj5TwE3lG3WAc/MYC0snPxtMvXA/5Oo/zWKiGOJemCb3eTogW3S9EBVh6ruA56KiHtqUyn6YFv+TH2wqQbnpA/OxRvKztWF6hDf01SfALKljL0ReISqoTwCLC7jVwJ7hq0dtn5cLy01eJbqnNIj5bKtrzVoy1Cbn6S8sTFLfqoXE98HjgOHgXXJ8l8HPE71aUAHgHf3OP8PgdPAS1T/gHwqUw9syZ+m/7XVYGC+7z2w6e9Aph7YlD9TD7yO6pSuJ2rP+VvaMvStBkPyp+mDbTUY2GaSOe6DKovMzMzMzMxslvp0iqCZmZmZmdk55R0sMzMzMzOzjngHy8zMzMzMrCPewTIzMzMzM+uId7DMzMzMzMw64h0sMzMzMzOzjngHy8zMzMzMrCP/AyOAM2+sgA35AAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAKrCAYAAADs7iyrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAB7P0lEQVR4nOz9f5RldX3v+T9fNihIo6IIgQRvqxeSIQm20I3BKHQz6qjDdTQxGFZPLkzUNq4lilmsK4pLwEkyoBn9Rl2KFcxwR1uvCESNwUB0aLxoQBqEbtCIiq2YJsHONQaSFqF5f/84u+RQnh9VXbu6qs5+PtY66+z9eX8+e+/3p6s+1IfPPvukqpAkSZIkzd9jFvsCJEmSJGlSOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiQte0l2J7m173XOAp7rbQt1bEnS8he/B0uStNwlub+qVi7wOQIE+NeFPpckaflyBUuSNLGSXJjk60m2JvnTpuzQJH+Z5Lbm9dym/A+T3N68zmrKViX5RpIPArcAHwH2b1bJNi1WXpKkpcsVLEnSspdkN7Ctr+j/Av4W+DvgV6qqkjypqv4lySeBv6uq/1+SFcBK4D8ClwK/QW+V6kbgfwd+BNwFPLeqbmjOteCrZZKk5Wufxb4ASZJasKuqVvcXJNkH+AlwSZK/Bj7XhE4G/jNAVe0GfpzkecBfVtW/NW2vBJ4PfBb43vTkSpKkcbxFUJI0karqIeB44Arg5cDfjKieEbF/a/GyJEkTzgmWJGkiJVkJPLGqrgLOAlY3oS8Cr2/qrEjyBOBLwMuTPD7JAcArgP8+5NAPJtl3Ia9dkrR8eYugJGkS7J/k1r79vwH+DPhMkv3orVC9uYm9CZhK8mpgN/D6qvq7JJcCX23qXFJVX0uyasC5poCtSW6pqg3tpyJJWs58yIUkSZIktcRbBCVJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJT5FEHzKhyRJktRNo74HcY84wWJ0r5bxRY0vhWswbny+8fWbh8evXTc+vtjX7+/4+PgF5w+Pn3f+4l/fYsfH9c+4A0x6/y72GDCf808fY9L/jZZ7fLF/xpZ6vG3eIihJkiRJLXGCJUmSJEktGTvBSnJukjuSbE1ya5LnNOVnJXn8XE+Y5Iwkh88mluSSJEfP9RySJEmStBhGTrCSnACcAhxbVccALwDubsJnAXOaYCVZAZwBDJxgzYxV1Wuq6utzOYckSZIkLZZxK1iHATur6gGAqtpZVTuSvJHeROjaJNcCJPlQki3NatcF0wdIsj3JO5JcD5wGrAE2Nath+/fVe+XMWJLNSdY08fuTXJTk5iRfSHJ8E78rycuaOiuSvDvJTc2K2+ta6ylJkiRJGmPcBOsa4Igkdyb5YJKTAKrqfcAOYH1VrW/qnltVa4BjgJOSHNN3nJ9U1fOq6mPAFmBDVa2uql3TFarq8mGxxgHA5qo6DrgP+CPghcArgHc2dV4N/Liq1gJrgdcmefrMpJJsbCaDW6ampsZ0gSRJkiTNzsjHtFfV/UmOA54PrAc+meScqrp0QPVTk2xsjnkYcDSwtYl9soVr/SnwN832NuCBqnowyTZgVVP+IuCYZjUM4InAkcB3Z+Q1BUzPrMplLkmSJEltGPs9WFW1G9gMbG4mM6cDl/bXaVaJzgbWVtWPklwK7NdX5d9auNYHq2r6UfUPA9O3LT6cZDqPAGdW1dUtnE+SJEmS5mTcQy5+OcmRfUWrge812/cBBzbbT6A3ifpxkkOBl4w4bH+7ucRm42rg9Un2BUhyVJID5nE8SZIkSZq1cStYK4H3J3kS8BDwbWBjE5sCPp/knqpan+RrwB3AXcCXRxzzUuDiJLuAE2Z81upRsTnmAnAJvdsFb0kS4IfAy/fgOJIkSZI0Z+M+g3Uz8NwhsfcD7+/bP2NIvVUz9q8ArhhSd2ZsXV9sZd/2+TParWzeHwbe1rwkSZIkaa8a+0XDkiRJkqTZcYIlSZIkSS3JIw/m66zOd4AkSZLUUWn7gGMf094Fo3q1jC9qfClcg3HjCx3/1a8Pj99x9OJfn7/j4+Onfmp4/LLfWfzrW+z4uJ/xcfFxJ1js/Jb7GDCf808fw9+B+cUX+mdgsX/Glnq8bd4iKEmSJEktcYIlSZIkSS3ZowlWkt1Jbu17nTPH9tuTHDyg/G0z9r+yJ9cnSZIkSYthTz+DtauqVrd5IY23AX8yvVNVA7+DS5IkSZKWolZvEWxWpi5IckuSbUl+pSl/SpJrknwtyYcZ8FmzJBcC+zcrYpuasvub93VJrktyWZI7k1yYZEOSrzbneWZT76lJrkhyU/P6zTbzkyRJkqRR9nSCNT0Rmn69qi+2s6qOBT4EnN2UnQdcX1XPBj4LPG3mAavqHJqVsaraMOCczwLeBPw68HvAUVV1PHAJcGZT58+A91bVWuC3m9jPSbIxyZYkW6ampuaYuiRJkiQNthC3CF7ZvN8M/FazfeL0dlX9dZIf7cE5b6qqewCSfAe4pinfBqxvtl8AHJ38bIHsCUkOrKr7+g9UVVPA9MyqXrcHFyNJkiRJMy3E92A90LzvnnH8+T5m/oG+7Yf79h/uO89jgBOqatc8zyVJkiRJc7a3HtP+JWADQJKXAAcNqfdgkn3ncZ5rgDdM7yRZPY9jSZIkSdKctPUZrAvH1L8AODHJLcCLgO8PqTcFbJ1+yMUeeCOwJsnWJF8H/mAPjyNJkiRJc7ZHtwhW1Yoh5av6trcA65rtf6Y3sZr25iHt3wK8pW9/ZfO+GdjcV76ub/tnsaraCfQ/cEOSJEmS9pq9dYugJEmSJE28VM332RPLXuc7QJIkSeqon/t+3vlaiKcILj+jurXGho0vYHwpXINx48YXLr4UrqGAg/5lePxHT1r86zNufKnGl8I1GDc+33jbvEVQkiRJklriBEuSJEmSWjKvCVaS3c1j2u9IcluSP0zS2qQtyRlJDu/bvyTJ0W0dX5IkSZLaNN/PYO2qqtUASQ4BPg48EThvtgdIsqKqdg8JnwHcDuwAqKrXzOdiJUmSJGkhtbbaVFX3AhuBN6TnjCQfmI4n+VySdc32/UnemeRG4IQk70hyU5Lbk0w17V8JrAE2Natk+yfZnGRNc4zTkmxr2lzUd577k/xxs6J2Q5JD28pRkiRJkkZp9TNYVXVXc8xDxlQ9ALi9qp5TVdcDH6iqtVX1a8D+wClVdTmwBdhQVauratd04+a2wYuAk4HVwNokL+879g1V9SzgS8BrZ548ycYkW5JsmZqamkfGkiRJkvSIhXhM+2yeJb8buKJvf32S/wI8HngycAfwVyParwU2V9UPAZJsAk4EPg38FPhcU+9m4IUzG1fVFDA9sypeN4srliRJkqQxWp1gJXkGvcnTvcBDPHqFbL++7Z9Mf+4qyX7AB4E1VXV3kvNn1B14qhGxB+uRb0/ejd/1JUmSJGkvafOJf08FLqZ3u18B24HVSR6T5Ajg+CFNpydTO5OsBF7ZF7sPOHBAmxuBk5IcnGQFcBpwXQtpSJIkSdIem+/qzv5JbgX2pbdi9VHgPU3sy8B3gW30ngR4y6ADVNW/JPnzpt524Ka+8KXAxUl2ASf0tbknyVuBa+mtZl1VVZ+ZZy6SJEmSNC955G66zqqRNxzW6PsRC+MLGV8K12DcuPGFiy+FayjgoH8ZHv/Rkxb/+owbX6rxpXANxo3PMz6b50fMSatPEZQkSZKkLuv8ClaSjc1TBTup6/mDfWD+5t/l/ME+MH/z73L+YB+Yf/v5u4LV+3LkLut6/mAfmH+3dT1/sA/Mv9u6nj/YB+bfMidYkiRJktQSJ1iSJEmS1BInWNDZe04bXc8f7APz77au5w/2gfl3W9fzB/vA/FvW+YdcSJIkSVJbXMGSJEmSpJY4wZIkSZKklkzUBCvJi5N8M8m3k5zTlD05yd8m+VbzftBs286l/VIxpA/eneTvk2xN8pdJnjTbtk35sumDYTk0sbOTVJKD59J2EvJPcmZTfkeSd82x7bLOP8nqJDckuTXJliTHz7ZtU76c8v+LJPcmub2vrDNj4JD8OzP+weA+6It1YQwcmH+HxsBBvwNdGgOPSHJtkm80/9Zvaso7MQ6OyL8z4+CwPuiL751xsKom4gWsAL4DPAN4LHAbcDTwLuCcps45wEWzbdvExrZfKq8RffAiYJ+mzkWT2gdjcjgCuBr4HnBwl/IH1gNfAB7X1DukY/lfA7ykqfNSYPMk5t9c34nAscDtfWVdGgMH5d+J8W9UHzTlEz8GjvgZ6MQYOCL/Lo2BhwHHNtsHAnfSob8FR+TfmXFwWB80+3ttHFz0jmixQ08Aru7bf2vz+iZwWF+nf3O2bZvtse2XymtUHn1lrwA2TWIfjMnhcuBZwPYhv1QTmz9wGfCCefTdcs//auBVTdlpwMcnMf++a1/Fo/+46swYOCj/GbGJHf/G9UEXxsBh+XdlDByRf6fGwBl5fQZ4YdfGwZn5zyjrxDg4qA/25jg4SbcI/iJwd9/+D5qyQ6vqHoDm/RCAJIcnuWpMW4a1X6JG5THt94HPw0T2wcAckrwM+Iequq2/clfyB44Cnp/kxiTXJVkLncr/LODdSe4G/pTegDmJ+Q/TpTFwnEke/4bq0Bg4TFfGwGHOooNjYJJVwLOBG+ngODgj/36dGQf7+2Bvj4P7zP/yl4wMKKthlatqB72l8jm3XcJG5pHkXOAhYBNMZB8MyuFxwLn0lscfpSP5F73f84OA3wDWApcleUaH8n898OaquiLJqcBH6P3f7EnLf066ln8Hxr+Bkjye7oyBw3RlDBymc2NgkpXAFcBZVfWvyaD0Jvd3YGb+feWdGQf7+4Beznt1HJykFawf0Lu3ctovATuAf0pyGEDzfu8c2jLL9kvF0DySnA6cAmyoZn1ztm1ZPn0wKIfvA08HbkuyvSm7JckvzKLtJOS/oym/snq+CjwMzPxw5yTnfzpwZVP2KWDQB7wnIf9hujQGDtSR8W+YZ9KdMXCYroyBw3RqDEyyL70/rDdV1XTenRkHh+TfqXFwQB/s9XFwkiZYNwFHJnl6kscCvwt8tnmd3tQ5nd69mLNtyyzbLxUD80jyYuAtwMuq6t/n0raJLZc+GJTDlVV1SFWtqqpV9H55jq2qf5xF20nI/7PAp4GTAZIcRe+Dmztn2RaWf/47gJOaOicD35pDW1g++Q/TpTHw53Ro/BuoqrZ1aAwc5tN0YwwcpjNjYHpLVR8BvlFV7+kLdWIcHJZ/l8bBQX2wKOPgQnygbLFe9Jb47qT3BJBzm7KnAF+kN6B8EXhyU344cNWotqPaL9XXkD74Nr17Sm9tXhdPah8My6Evvp3mg41dyZ/eHxMfA24HbgFO7lj+zwNupvc0oBuB4yY4/08A9wAP0vsPyKu7NAYOyb8z49+wPpgRn/QxcNDPQJfGwEH5d2kMfB69W7q29v3Ov3RYDpPWByPy78w4OKwPZtTZzgKPg2kaSZIkSZLmaZJuEZQkSZKkReUES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSNDGSvDfJWX37Vye5pG///07yh7M81uYkaxbgMiVJE8wJliRpknwFeC5AkscABwO/2hd/LvDlcQdJsmJBrk6SNPGcYEmSJsmXaSZY9CZWtwP3JTkoyeOA/wl4UpKvJdmW5C+acpJsT/KOJNcDvzN9wCSPSfJfk/zRXs5FkrQMOcGSJE2MqtoBPJTkafQmWn8H3AicAKwB7gQuAV5VVb8O7AO8vu8QP6mq51XVf2v29wE2AXdW1dv3UhqSpGXMCZYkadJMr2JNT7D+rm//H4DvVtWdTd3/CpzY1/aTM471YeD2qvrjBb1iSdLEcIIlSZo005/D+nV6twjeQG8F67nALWPa/tuAY61Psl/bFylJmkxOsCRJk+bLwCnA/6iq3VX1P4An0Ztk/T/AqiT/san7e8B1I471EeAq4FNJ9lm4S5YkTQonWJKkSbON3tMDb5hR9uOq+gHwf9CbMG0DHgYuHnWwqnoPvZWvjzZPJpQkaahU1WJfgyRJkiRNBP9PnCRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRJkiS1xEfOgk/5kCRJkropbR/QCRYw9brhsY0fHt3rhfGFjC+FazC+/OPjKiz29d28Znj8uC2w5ubh8S3HLf71+zs+/t9osf8NF/v8xhc3vpA/n7O9BuOLG3/d1PD4hzcu/vUtdrxt3iIoSZIkSS1xgiVJkiRJLRk7wUpybpI7kmxNcmuS5zTlZyV5/FxPmOSMJIfPJpbkkiRHz/UckiRJkrQYRk6wkpwAnAIcW1XHAC8A7m7CZwFzmmAlWQGcAQycYM2MVdVrqurrczmHJEmSJC2WcStYhwE7q+oBgKraWVU7kryR3kTo2iTXAiT5UJItzWrXBdMHSLI9yTuSXA+cBqwBNjWrYfv31XvlzFiSzUnWNPH7k1yU5OYkX0hyfBO/K8nLmjorkrw7yU3NituIx1dIkiRJUrvGTbCuAY5IcmeSDyY5CaCq3gfsANZX1fqm7rlVtQY4BjgpyTF9x/lJVT2vqj4GbAE2VNXqqto1XaGqLh8WaxwAbK6q44D7gD8CXgi8AnhnU+fVwI+rai2wFnhtkqfPTCrJxmYyuGVqasRjVSRJkiRpDkY+pr2q7k9yHPB8YD3wySTnVNWlA6qfmmRjc8zDgKOBrU3sky1c60+Bv2m2twEPVNWDSbYBq5ryFwHHNKthAE8EjgS+OyOvKWB6ZlWjHtMuSZIkSbM19nuwqmo3sBnY3ExmTgcu7a/TrBKdDaytqh8luRTYr6/Kv7VwrQ9W1fSj6h8Gpm9bfDjJdB4Bzqyqq1s4nyRJkiTNybiHXPxykiP7ilYD32u27wMObLafQG8S9eMkhwIvGXHY/nZzic3G1cDrk+wLkOSoJAfM43iSJEmSNGvjVrBWAu9P8iTgIeDbwMYmNgV8Psk9VbU+ydeAO4C7gC+POOalwMVJdgEnzPis1aNic8wF4BJ6twvekiTAD4GX78FxJEmSJGnOxn0G62bguUNi7wfe37d/xpB6q2bsXwFcMaTuzNi6vtjKvu3zZ7Rb2bw/DLyteUmSJEnSXjX2i4YlSZIkSbPjBEuSJEmSWpJHHszXWZ3vAEmSJKmj0vYBxz6mvRNGdWuNDRtfwPhSuIZJiF9w/vD4eefD+s3D49euW/zrNz658aVwDcYXPz5uDFroMWqhz7/Q1z+uwnXrhodP2uzvsHH/DmibtwhKkiRJUkucYEmSJElSS/ZogpVkd5Jb+17nzLH99iQHDyh/24z9r+zJ9UmSJEnSYtjTz2DtqqrVbV5I423An0zvVNXA7+CSJEmSpKWo1VsEm5WpC5LckmRbkl9pyp+S5JokX0vyYQZ81izJhcD+zYrYpqbs/uZ9XZLrklyW5M4kFybZkOSrzXme2dR7apIrktzUvH6zzfwkSZIkaZQ9nWBNT4SmX6/qi+2sqmOBDwFnN2XnAddX1bOBzwJPm3nAqjqHZmWsqjYMOOezgDcBvw78HnBUVR0PXAKc2dT5M+C9VbUW+O0m9nOSbEyyJcmWqampOaYuSZIkSYMtxC2CVzbvNwO/1WyfOL1dVX+d5Ed7cM6bquoegCTfAa5pyrcB65vtFwBHJz9bIHtCkgOr6r7+A1XVFDA9sypetwdXI0mSJEkzLMT3YD3QvO+ecfz5Pmb+gb7th/v2H+47z2OAE6pq1zzPJUmSJElztrce0/4lYANAkpcABw2p92CSfedxnmuAN0zvJFk9j2NJkiRJ0py09RmsC8fUvwA4McktwIuA7w+pNwVsnX7IxR54I7AmydYkXwf+YA+PI0mSJElztke3CFbViiHlq/q2twDrmu1/pjexmvbmIe3fArylb39l874Z2NxXvq5v+2exqtoJ9D9wQ5IkSZL2mr11i6AkSZIkTbxUzffZE8te5ztAkiRJ6qif+37e+VqIpwguO6N6tToQ/9Spw+O/c9niXt/eOEcX+njc+ccdYLH779RPDY9f9jvj4wvdP+POP+74873+5RxfCtdg3LjxPY8vhWswbny+8bZ5i6AkSZIktcQJliRJkiS1ZF4TrCS7m8e035HktiR/mKS1SVuSM5Ic3rd/SZKj2zq+JEmSJLVpvp/B2lVVqwGSHAJ8HHgicN5sD5BkRVXtHhI+A7gd2AFQVa+Zz8VKkiRJ0kJqbbWpqu4FNgJvSM8ZST4wHU/yuSTrmu37k7wzyY3ACUnekeSmJLcnmWravxJYA2xqVsn2T7I5yZrmGKcl2da0uajvPPcn+eNmRe2GJIe2laMkSZIkjdLqZ7Cq6q7mmIeMqXoAcHtVPaeqrgc+UFVrq+rXgP2BU6rqcmALsKGqVlfVrunGzW2DFwEnA6uBtUle3nfsG6rqWcCXgNfOPHmSjUm2JNkyNTU1j4wlSZIk6REL8Zj22TxLfjdwRd/++iT/BXg88GTgDuCvRrRfC2yuqh8CJNkEnAh8Gvgp8Lmm3s3AC2c2rqopYHpmVa+bxQVLkiRJ0jitTrCSPIPe5Ole4CEevUK2X9/2T6Y/d5VkP+CDwJqqujvJ+TPqDjzViNiD9ci3J+/G7/qSJEmStJe0+cS/pwIX07vdr4DtwOokj0lyBHD8kKbTk6mdSVYCr+yL3QccOKDNjcBJSQ5OsgI4DbiuhTQkSZIkaY/Nd3Vn/yS3AvvSW7H6KPCeJvZl4LvANnpPArxl0AGq6l+S/HlTbztwU1/4UuDiJLuAE/ra3JPkrcC19Fazrqqqz8wzF0mSJEmal3lNsKpqxYhYARuGxFbO2H878PYB9a7g0Z/VWtcX+zi9x8IPPXbzoIzLhyYgSZIkSS1q9SmCkiRJktRlTrAkSZIkqSV55IF73ZRkY/PY9k7qev5gH5i/+Xc5f7APzN/8u5w/2Afm337+rmDBxsW+gEXW9fzBPjD/but6/mAfmH+3dT1/sA/Mv2VOsCRJkiSpJU6wJEmSJKklTrCgs/ecNrqeP9gH5t9tXc8f7APz77au5w/2gfm3rPMPuZAkSZKktriCJUmSJEktmagJVpIXJ/lmkm8nOacpe3KSv03yreb9oNm2nUv7pWJIH7w7yd8n2ZrkL5M8abZtm/Jl0wfDcmhiZyepJAfPpe0k5J/kzKb8jiTvmmPbZZ1/ktVJbkhya5ItSY6fbdumfDnl/xdJ7k1ye19ZZ8bAIfl3ZvyDwX3QF+vCGDgw/w6NgYN+B7o0Bh6R5Nok32j+rd/UlHdiHByRf2fGwWF90BffO+NgVU3EC1gBfAd4BvBY4DbgaOBdwDlNnXOAi2bbtomNbb9UXiP64EXAPk2diya1D8bkcARwNfA94OAu5Q+sB74APK6pd0jH8r8GeElT56XA5knMv7m+E4Fjgdv7yro0Bg7KvxPj36g+aMonfgwc8TPQiTFwRP5dGgMPA45ttg8E7qRDfwuOyL8z4+CwPmj299o4uOgd0WKHngBc3bf/1ub1TeCwvk7/5mzbNttj2y+V16g8+speAWyaxD4Yk8PlwLOA7UN+qSY2f+Ay4AXz6Lvlnv/VwKuastOAj09i/n3XvopH/3HVmTFwUP4zYhM7/o3rgy6MgcPy78oYOCL/To2BM/L6DPDCro2DM/OfUdaJcXBQH+zNcXCSbhH8ReDuvv0fNGWHVtU9AM37IQBJDk9y1Zi2DGu/RI3KY9rvA5+HieyDgTkkeRnwD1V1W3/lruQPHAU8P8mNSa5LshY6lf9ZwLuT3A38Kb0BcxLzH6ZLY+A4kzz+DdWhMXCYroyBw5xFB8fAJKuAZwM30sFxcEb+/TozDvb3wd4eB/eZ/+UvGRlQVsMqV9UOekvlc267hI3MI8m5wEPAJpjIPhiUw+OAc+ktjz9KR/Iver/nBwG/AawFLkvyjA7l/3rgzVV1RZJTgY/Q+7/Zk5b/nHQt/w6MfwMleTzdGQOH6coYOEznxsAkK4ErgLOq6l+TQelN7u/AzPz7yjszDvb3Ab2c9+o4OEkrWD+gd2/ltF8CdgD/lOQwgOb93jm0ZZbtl4qheSQ5HTgF2FDN+uZs27J8+mBQDt8Hng7clmR7U3ZLkl+YRdtJyH9HU35l9XwVeBiY+eHOSc7/dODKpuxTwKAPeE9C/sN0aQwcqCPj3zDPpDtj4DBdGQOH6dQYmGRfen9Yb6qq6bw7Mw4Oyb9T4+CAPtjr4+AkTbBuAo5M8vQkjwV+F/hs8zq9qXM6vXsxZ9uWWbZfKgbmkeTFwFuAl1XVv8+lbRNbLn0wKIcrq+qQqlpVVavo/fIcW1X/OIu2k5D/Z4FPAycDJDmK3gc3d86yLSz//HcAJzV1Tga+NYe2sHzyH6ZLY+DP6dD4N1BVbevQGDjMp+nGGDhMZ8bA9JaqPgJ8o6re0xfqxDg4LP8ujYOD+mBRxsGF+EDZYr3oLfHdSe8JIOc2ZU8BvkhvQPki8OSm/HDgqlFtR7Vfqq8hffBteveU3tq8Lp7UPhiWQ198O80HG7uSP70/Jj4G3A7cApzcsfyfB9xM72lANwLHTXD+nwDuAR6k9x+QV3dpDBySf2fGv2F9MCM+6WPgoJ+BLo2Bg/Lv0hj4PHq3dG3t+51/6bAcJq0PRuTfmXFwWB/MqLOdBR4H0zSSJEmSJM3TJN0iKEmSJEmLygmWJEmSJLXECZYkSZIktcQJliRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRJkiS1xAmWJEmSJLXECZYkSZIktcQJliRp4iQ5N8kdSbYmuTXJc5JsT3LwYl+bJGmy7bPYFyBJUpuSnACcAhxbVQ80k6rHLvJlSZI6whUsSdKkOQzYWVUPAFTVzqra0cTOTHJLkm1JfgUgyZOTfLpZ7bohyTFN+flJPprk/0vyrSSvXZx0JEnLiRMsSdKkuQY4IsmdST6Y5KS+2M6qOhb4EHB2U3YB8LWqOgZ4G/D/9tU/BvhfgROAdyQ5fOEvX5K0nDnBkiRNlKq6HzgO2Aj8EPhkkjOa8JXN+83Aqmb7ecBHm7b/H/CUJE9sYp+pql1VtRO4Fjh+wROQJC1rfgZLkjRxqmo3sBnYnGQbcHoTeqB5380j/w3MoEPMeJ9ZLknSQK5gSZImSpJfTnJkX9Fq4HsjmnwJ2NC0XUfvNsJ/bWL/W5L9kjwFWAfc1Pb1SpImiytYkqRJsxJ4f5InAQ8B36Z3u+ApQ+qfD/w/SbYC/84jq10AXwX+Gnga8H/2PSxDkqSBUuXdDpIkzZTkfOD+qvrTxb4WSdLy4S2CkiRJktQSV7AkSZIkqSWuYEmSJElSS5xgSZIkSVJLfIqg32kiSZIkddWg70KcFydYjO7VMr6o8aVwDcaNG1+4+FK4hjbi6zcPj1+7bvGv74Lzh8fPO3/h2y92fFyFpf7vt5TjS+EajBuf9xjRMm8RlCRJkqSWOMGSJEmSpJY4wZIkSZKkloydYCU5N8kdSbYmuTXJc5rys5I8fq4nTHJGksNnE0tySZKj53oOSZIkSVoMIydYSU4ATgGOrapjgBcAdzfhs4A5TbCSrADOAAZOsGbGquo1VfX1uZxDkiRJkhbLuBWsw4CdVfUAQFXtrKodSd5IbyJ0bZJrAZJ8KMmWZrXrgukDJNme5B1JrgdOA9YAm5rVsP376r1yZizJ5iRrmvj9SS5KcnOSLyQ5vonfleRlTZ0VSd6d5KZmxe11rfWUJEmSJI0xboJ1DXBEkjuTfDDJSQBV9T5gB7C+qtY3dc+tqjXAMcBJSY7pO85Pqup5VfUxYAuwoapWV9Wu6QpVdfmwWOMAYHNVHQfcB/wR8ELgFcA7mzqvBn5cVWuBtcBrkzx9ZlJJNjaTwS1TU1NjukCSJEmSZmfk92BV1f1JjgOeD6wHPpnknKq6dED1U5NsbI55GHA0sLWJfbKFa/0p8DfN9jbggap6MMk2YFVT/iLgmGY1DOCJwJHAd2fkNQVMz6zKZS5JkiRJbRj7RcNVtRvYDGxuJjOnA5f212lWic4G1lbVj5JcCuzXV+XfWrjWB6tq+rvAHgamb1t8OMl0HgHOrKqrWzifJEmSJM3JuIdc/HKSI/uKVgPfa7bvAw5stp9AbxL14ySHAi8Zcdj+dnOJzcbVwOuT7AuQ5KgkB8zjeJIkSZI0a+NWsFYC70/yJOAh4NvAxiY2BXw+yT1VtT7J14A7gLuAL4845qXAxUl2ASfM+KzVo2JzzAXgEnq3C96SJMAPgZfvwXEkSZIkac7GfQbrZuC5Q2LvB97ft3/GkHqrZuxfAVwxpO7M2Lq+2Mq+7fNntFvZvD8MvK15SZIkSdJeNfaLhiVJkiRJs5NHnhvRWZ3vAEmSJKmj0vYBxz5FsAtG9WoZX9T4UrgG48aNL1x8KVyD8fEVFvr8nzp1ePx3Llv485/6qeHxy35nfHyp96+/w8aNj463zVsEJUmSJKklTrAkSZIkqSV7NMFKsjvJrX2vc+bYfnuSgweUv23G/lf25PokSZIkaTHs6WewdlXV6jYvpPE24E+md6pq4CPiJUmSJGkpavUWwWZl6oIktyTZluRXmvKnJLkmydeSfJgBnzVLciGwf7Mitqkpu795X5fkuiSXJbkzyYVJNiT5anOeZzb1nprkiiQ3Na/fbDM/SZIkSRplTydY0xOh6der+mI7q+pY4EPA2U3ZecD1VfVs4LPA02YesKrOoVkZq6oNA875LOBNwK8DvwccVVXHA5cAZzZ1/gx4b1WtBX67if2cJBuTbEmyZWpqao6pS5IkSdJgC3GL4JXN+83AbzXbJ05vV9VfJ/nRHpzzpqq6ByDJd4BrmvJtwPpm+wXA0cnPFsiekOTAqrqv/0BVNQVMz6zqdXtwMZIkSZI000J8D9YDzfvuGcef72PmH+jbfrhv/+G+8zwGOKGqds3zXJIkSZI0Z3vrMe1fAjYAJHkJcNCQeg8m2Xce57kGeMP0TpLV8ziWJEmSJM1JW5/BunBM/QuAE5PcArwI+P6QelPA1umHXOyBNwJrkmxN8nXgD/bwOJIkSZI0Z3t0i2BVrRhSvqpvewuwrtn+Z3oTq2lvHtL+LcBb+vZXNu+bgc195ev6tn8Wq6qdQP8DNyRJkiRpr9lbtwhKkiRJ0sRL1XyfPbHsdb4DJEmSpI76ue/nna+FeIrgsnPqp4bHLvsd+NSpw+O/cxmj/1lqbHje7cdd/7j2Szm+FK7BuHHjCxdfCtdg3LjxPY8vhWswbny+8bZ5i6AkSZIktcQJliRJkiS1ZF4TrCS7m8e035HktiR/mKS1SVuSM5Ic3rd/SZKj2zq+JEmSJLVpvp/B2lVVqwGSHAJ8HHgicN5sD5BkRVXtHhI+A7gd2AFQVa+Zz8VKkiRJ0kJqbbWpqu4FNgJvSM8ZST4wHU/yuSTrmu37k7wzyY3ACUnekeSmJLcnmWravxJYA2xqVsn2T7I5yZrmGKcl2da0uajvPPcn+eNmRe2GJIe2laMkSZIkjdLqZ7Cq6q7mmIeMqXoAcHtVPaeqrgc+UFVrq+rXgP2BU6rqcmALsKGqVlfVrunGzW2DFwEnA6uBtUle3nfsG6rqWcCXgNfOPHmSjUm2JNkyNTU1j4wlSZIk6REL8ZCL2TxLfjdwRd/++iQ3JtlGb9L0q2ParwU2V9UPq+ohYBNwYhP7KfC5ZvtmYNXMxlU1VVVrqmrNxo0bZ3G5kiRJkjReq9+DleQZ9CZP9wIP8egJ3H592z+Z/txVkv2ADwJrquruJOfPqDvwVCNiD9Yj3568G7/rS5IkSdJe0uYT/54KXEzvdr8CtgOrkzwmyRHA8UOaTk+mdiZZCbyyL3YfcOCANjcCJyU5OMkK4DTguhbSkCRJkqQ9Nt/Vnf2T3ArsS2/F6qPAe5rYl4HvAtvoPQnwlkEHqKp/SfLnTb3twE194UuBi5PsAk7oa3NPkrcC19Jbzbqqqj4zz1wkSZIkaV7mNcGqqhUjYgVsGBJbOWP/7cDbB9S7gkd/VmtdX+zj9B4LP/TYzYMyLh+agCRJkiS1aCEeciFJkiRJneQES5IkSZJakkceuNdNSTZWVWe/DKvr+YN9YP7m3+X8wT4wf/Pvcv5gH5h/+/m7ggVd/yKsrucP9oH5d1vX8wf7wPy7rev5g31g/i1zgiVJkiRJLXGCJUmSJEktcYIFnb3ntNH1/ME+MP9u63r+YB+Yf7d1PX+wD8y/ZZ1/yIUkSZIktcUVLEmSJElqiRMsSZIkSWrJRE2wkrw4yTeTfDvJOU3Zk5P8bZJvNe8HzbbtXNovFUP64N1J/j7J1iR/meRJs23blC+bPhiWQxM7O0klOXgubSch/yRnNuV3JHnXHNsu6/yTrE5yQ5Jbk2xJcvxs2zblyyn/v0hyb5Lb+8o6MwYOyb8z4x8M7oO+WBfGwIH5d2gMHPQ70KUx8Igk1yb5RvNv/aamvBPj4Ij8OzMODuuDvvjeGQeraiJewArgO8AzgMcCtwFHA+8CzmnqnANcNNu2TWxs+6XyGtEHLwL2aepcNKl9MCaHI4Crge8BB3cpf2A98AXgcU29QzqW/zXAS5o6LwU2T2L+zfWdCBwL3N5X1qUxcFD+nRj/RvVBUz7xY+CIn4FOjIEj8u/SGHgYcGyzfSBwJx36W3BE/p0ZB4f1QbO/18bBRe+IFjv0BODqvv23Nq9vAof1dfo3Z9u22R7bfqm8RuXRV/YKYNMk9sGYHC4HngVsH/JLNbH5A5cBL5hH3y33/K8GXtWUnQZ8fBLz77v2VTz6j6vOjIGD8p8Rm9jxb1wfdGEMHJZ/V8bAEfl3agyckddngBd2bRycmf+Msk6Mg4P6YG+Og5N0i+AvAnf37f+gKTu0qu4BaN4PAUhyeJKrxrRlWPslalQe034f+DxMZB8MzCHJy4B/qKrb+it3JX/gKOD5SW5Mcl2StdCp/M8C3p3kbuBP6Q2Yk5j/MF0aA8eZ5PFvqA6NgcN0ZQwc5iw6OAYmWQU8G7iRDo6DM/Lv15lxsL8P9vY4uM/8L3/JyICyGla5qnbQWyqfc9slbGQeSc4FHgI2wUT2waAcHgecS295/FE6kn/R+z0/CPgNYC1wWZJndCj/1wNvrqorkpwKfITe/82etPznpGv5d2D8GyjJ4+nOGDhMV8bAYTo3BiZZCVwBnFVV/5oMSm9yfwdm5t9X3plxsL8P6OW8V8fBSVrB+gG9eyun/RKwA/inJIcBNO/3zqEts2y/VAzNI8npwCnAhmrWN2fbluXTB4Ny+D7wdOC2JNubsluS/MIs2k5C/jua8iur56vAw8DMD3dOcv6nA1c2ZZ8CBn3AexLyH6ZLY+BAHRn/hnkm3RkDh+nKGDhMp8bAJPvS+8N6U1VN592ZcXBI/p0aBwf0wV4fBydpgnUTcGSSpyd5LPC7wGeb1+lNndPp3Ys527bMsv1SMTCPJC8G3gK8rKr+fS5tm9hy6YNBOVxZVYdU1aqqWkXvl+fYqvrHWbSdhPw/C3waOBkgyVH0Pri5c5ZtYfnnvwM4qalzMvCtObSF5ZP/MF0aA39Oh8a/gapqW4fGwGE+TTfGwGE6Mwamt1T1EeAbVfWevlAnxsFh+XdpHBzUB4syDi7EB8oW60Vvie9Oek8AObcpewrwRXoDyheBJzflhwNXjWo7qv1SfQ3pg2/Tu6f01uZ18aT2wbAc+uLbaT7Y2JX86f0x8THgduAW4OSO5f884GZ6TwO6EThugvP/BHAP8CC9/4C8uktj4JD8OzP+DeuDGfFJHwMH/Qx0aQwclH+XxsDn0bula2vf7/xLh+UwaX0wIv/OjIPD+mBGne0s8DiYppEkSZIkaZ4m6RZBSZIkSVpUTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJy06SSvLRvv19kvwwyefmeJzNSdY021cledIeXMsZST4w13aSpMm0z2JfgCRJe+DfgF9Lsn9V7QJeCPzDfA5YVS9t5cokSZ3mCpYkabn6PPC/NtunAZ+YDiQ5IMlfJLkpydeS/G9N+f5J/luSrUk+Cezf12Z7koOb7f/c1LlteqUsyX9KcmNzvC8kOXRvJSpJWj6cYEmSlqv/Bvxukv2AY4Ab+2LnAv9fVa0F1gPvTnIA8Hrg36vqGOCPgeNmHjTJrzbtT66qZwFvakLXA79RVc9uzv1fFiYtSdJy5i2CkqRlqaq2JllFb/XqqhnhFwEvS3J2s78f8DTgROB9fe23Djj0ycDlVbWzqfc/mvJfAj6Z5DDgscB3W0xHkjQhnGBJkpazzwJ/CqwDntJXHuC3q+qb/ZWTANSYY2ZInfcD76mqzyZZB5y/JxcsSZps3iIoSVrO/gJ4Z1Vtm1F+NXBmmhlVkmc35V8CNjRlv0bv1sKZvgicmuQpTb0nN+VP5JEHaZzeWgaSpIniBEuStGxV1Q+q6s8GhP5PYF9ga5Lbm32ADwErm1sD/wvw1QHHvIPe57OuS3Ib8J4mdD7wqST/HdjZaiKSpImRqnF3SkiSJEmSZsMVLEmSJElqiRMsSZIkSWqJEyxJkiRJaokTLEmSJElqid+DNf77UCRJkiRNprR9QCdYjO7VMr6o8aVwDcaNG1+4+FK4BuPj4+MqLPb1GV+8+FK4BuPG5z3GtcxbBCVJkiSpJU6wJEmSJKklTrAkSZIkqSVjJ1hJzk1yR5KtSW5N8pym/Kwkj5/rCZOckeTw2cSSXJLk6LmeQ5IkSZIWw8gJVpITgFOAY6vqGOAFwN1N+CxgThOsJCuAM4CBE6yZsap6TVV9fS7nkCRJkqTFMm4F6zBgZ1U9AFBVO6tqR5I30psIXZvkWoAkH0qypVntumD6AEm2J3lHkuuB04A1wKZmNWz/vnqvnBlLsjnJmiZ+f5KLktyc5AtJjm/idyV5WVNnRZJ3J7mpWXF7XWs9JUmSJEljjJtgXQMckeTOJB9MchJAVb0P2AGsr6r1Td1zq2oNcAxwUpJj+o7zk6p6XlV9DNgCbKiq1VW1a7pCVV0+LNY4ANhcVccB9wF/BLwQeAXwzqbOq4EfV9VaYC3w2iRPn5lUko3NZHDL1NTUmC6QJEmSpNkZ+T1YVXV/kuOA5wPrgU8mOaeqLh1Q/dQkG5tjHgYcDWxtYp9s4Vp/CvxNs70NeKCqHkyyDVjVlL8IOKZZDQN4InAk8N0ZeU0B0zOrcplLkiRJUhvGftFwVe0GNgObm8nM6cCl/XWaVaKzgbVV9aMklwL79VX5txau9cGqmv4usIeB6dsWH04ynUeAM6vq6hbOJ0mSJElzMu4hF7+c5Mi+otXA95rt+4ADm+0n0JtE/TjJocBLRhy2v91cYrNxNfD6JPsCJDkqyQHzOJ4kSZIkzdq4FayVwPuTPAl4CPg2sLGJTQGfT3JPVa1P8jXgDuAu4MsjjnkpcHGSXcAJMz5r9ajYHHMBuITe7YK3JAnwQ+Dle3AcSZIkSZqzPHLXXWdVRgXp3XdofHHiS+EajBs3vnDxpXANxsfHx1VY7OszvnjxpXANxo3PMz7uR3zOxn7RsCRJkiRpdlzBav7nnCRJkqTOaX0Fa+xTBLtgiS9bdjq+FK7BuHHjCxdfCtdg3Li3UO55fClcg3Hj8/4dbpm3CEqSJElSS5xgSZIkSVJL9miClWR3klv7XufMsf32JAcPKH/bjP2v7Mn1SZIkSdJi2NPPYO2qqtVtXkjjbcCfTO9U1XMX4BySJEmStCBavUWwWZm6IMktSbYl+ZWm/ClJrknytSQfZsBnzZJcCOzfrIhtasrub97XJbkuyWVJ7kxyYZINSb7anOeZTb2nJrkiyU3N6zfbzE+SJEmSRtnTCdb0RGj69aq+2M6qOhb4EHB2U3YecH1VPRv4LPC0mQesqnNoVsaqasOAcz4LeBPw68DvAUdV1fHAJcCZTZ0/A95bVWuB325iPyfJxiRbkmyZmpqaY+qSJEmSNNhC3CJ4ZfN+M/BbzfaJ09tV9ddJfrQH57ypqu4BSPId4JqmfBuwvtl+AXB08rMFsickObCq7us/UFVNAdMzq3rdHlyMJEmSJM20EN+D9UDzvnvG8ef7mPkH+rYf7tt/uO88jwFOqKpd8zyXJEmSJM3Z3npM+5eADQBJXgIcNKTeg0n2ncd5rgHeML2TZPU8jiVJkiRJc9LWZ7AuHFP/AuDEJLcALwK+P6TeFLB1+iEXe+CNwJokW5N8HfiDPTyOJEmSJM1ZquZ7596yVz/3SMP+IAMeeWh8r8WXwjUYN2584eJL4RqMG59vfFyFxb4+f4eNGx8ZH/cjPmd76xZBSZIkSZp4rmDN/+EbkiRJkpan1lewFuIpgsvOEl+2XPT4Yt760MYxjBs3vnTjS+EajBs3vufxpXANxo3P+2/dlnmLoCRJkiS1xAmWJEmSJLVkXhOsJLubx7TfkeS2JH+YpLVJW5Izkhzet39JkqPbOr4kSZIktWm+n8HaVVWrAZIcAnwceCJw3mwPkGRFVe0eEj4DuB3YAVBVr5nPxUqSJEnSQmpttamq7gU2Am9IzxlJPjAdT/K5JOua7fuTvDPJjcAJSd6R5KYktyeZatq/ElgDbGpWyfZPsjnJmuYYpyXZ1rS5qO889yf542ZF7YYkh7aVoyRJkiSN0upnsKrqruaYh4ypegBwe1U9p6quBz5QVWur6teA/YFTqupyYAuwoapWV9Wu6cbNbYMXAScDq4G1SV7ed+wbqupZwJeA1848eZKNSbYk2TI1NTWPjCVJkiTpEQvxmPbZPEt+N3BF3/76JP8FeDzwZOAO4K9GtF8LbK6qHwIk2QScCHwa+CnwuabezcALZzauqilgemZVr5vFBUuSJEnSOK1OsJI8g97k6V7gIR69QrZf3/ZPpj93lWQ/4IPAmqq6O8n5M+oOPNWI2IP1yLcn78bv+pIkSZK0l7T5xL+nAhfTu92vgO3A6iSPSXIEcPyQptOTqZ1JVgKv7IvdBxw4oM2NwElJDk6yAjgNuK6FNCRJkiRpj813dWf/JLcC+9Jbsfoo8J4m9mXgu8A2ek8CvGXQAarqX5L8eVNvO3BTX/hS4OIku4AT+trck+StwLX0VrOuqqrPzDMXSZIkSZqXPHI3XWfVqPsNi9H3I3YhPq7CQp6/jWMYN2586caXwjUYN258z+NL4RqMG59nfDbPj5iTVp8iKEmSJEld5gRLkiRJklrS+VsEk2xsHtveSV3PH+wD8zf/LucP9oH5m3+X8wf7wPzbz98VLNi42BewyLqeP9gH5t9tXc8f7APz77au5w/2gfm3zAmWJEmSJLXECZYkSZIktcQJFnT2ntNG1/MH+8D8u63r+YN9YP7d1vX8wT4w/5Z1/iEXkiRJktQWV7AkSZIkqSVOsCRJkiSpJRM1wUry4iTfTPLtJOc0ZU9O8rdJvtW8HzTbtnNpv1QM6YN3J/n7JFuT/GWSJ822bVO+bPpgWA5N7OwkleTgubSdhPyTnNmU35HkXXNsu6zzT7I6yQ1Jbk2yJcnxs23blC+n/P8iyb1Jbu8r68wYOCT/zox/MLgP+mJdGAMH5t+hMXDQ70CXxsAjklyb5BvNv/WbmvJOjIMj8u/MODisD/rie2ccrKqJeAErgO8AzwAeC9wGHA28CzinqXMOcNFs2zaxse2XymtEH7wI2Kepc9Gk9sGYHI4Arga+BxzcpfyB9cAXgMc19Q7pWP7XAC9p6rwU2DyJ+TfXdyJwLHB7X1mXxsBB+Xdi/BvVB035xI+BI34GOjEGjsi/S2PgYcCxzfaBwJ106G/BEfl3Zhwc1gfN/l4bBxe9I1rs0BOAq/v239q8vgkc1tfp35xt22Z7bPul8hqVR1/ZK4BNk9gHY3K4HHgWsH3IL9XE5g9cBrxgHn233PO/GnhVU3Ya8PFJzL/v2lfx6D+uOjMGDsp/Rmxix79xfdCFMXBY/l0ZA0fk36kxcEZenwFe2LVxcGb+M8o6MQ4O6oO9OQ5O0i2Cvwjc3bf/g6bs0Kq6B6B5PwQgyeFJrhrTlmHtl6hReUz7feDzMJF9MDCHJC8D/qGqbuuv3JX8gaOA5ye5Mcl1SdZCp/I/C3h3kruBP6U3YE5i/sN0aQwcZ5LHv6E6NAYO05UxcJiz6OAYmGQV8GzgRjo4Ds7Iv19nxsH+Ptjb4+A+87/8JSMDympY5araQW+pfM5tl7CReSQ5F3gI2AQT2QeDcngccC695fFH6Uj+Re/3/CDgN4C1wGVJntGh/F8PvLmqrkhyKvARev83e9Lyn5Ou5d+B8W+gJI+nO2PgMF0ZA4fp3BiYZCVwBXBWVf1rMii9yf0dmJl/X3lnxsH+PqCX814dBydpBesH9O6tnPZLwA7gn5IcBtC83zuHtsyy/VIxNI8kpwOnABuqWd+cbVuWTx8MyuH7wNOB25Jsb8puSfILs2g7CfnvaMqvrJ6vAg8DMz/cOcn5nw5c2ZR9Chj0Ae9JyH+YLo2BA3Vk/BvmmXRnDBymK2PgMJ0aA5PsS+8P601VNZ13Z8bBIfl3ahwc0Ad7fRycpAnWTcCRSZ6e5LHA7wKfbV6nN3VOp3cv5mzbMsv2S8XAPJK8GHgL8LKq+ve5tG1iy6UPBuVwZVUdUlWrqmoVvV+eY6vqH2fRdhLy/yzwaeBkgCRH0fvg5s5ZtoXln/8O4KSmzsnAt+bQFpZP/sN0aQz8OR0a/waqqm0dGgOH+TTdGAOH6cwYmN5S1UeAb1TVe/pCnRgHh+XfpXFwUB8syji4EB8oW6wXvSW+O+k9AeTcpuwpwBfpDShfBJ7clB8OXDWq7aj2S/U1pA++Te+e0lub18WT2gfDcuiLb6f5YGNX8qf3x8THgNuBW4CTO5b/84Cb6T0N6EbguAnO/xPAPcCD9P4D8uoujYFD8u/M+DesD2bEJ30MHPQz0KUxcFD+XRoDn0fvlq6tfb/zLx2Ww6T1wYj8OzMODuuDGXW2s8DjYJpGkiRJkqR5mqRbBCVJkiRpUTnBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJE2MJL+U5DNJvpXkO0n+LMljk6xO8tK+eucnOXsxr1WSNJmcYEmSJkKSAFcCn66qI4GjgJXAHwOrgZcObz3nc61o61iSpMniBEuSNClOBn5SVf8PQFXtBt4MvAZ4F/CqJLcmeVVT/+gkm5PcleSN0wdJ8r8n+WpT98PTk6kk9yd5Z5IbgRP2amaSpGXDCZYkaVL8KnBzf0FV/SuwHfgj4JNVtbqqPtmEfwX4X4DjgfOS7JvkfwJeBfxmVa0GdgMbmvoHALdX1XOq6vqFTkaStDzts9gXIElSSwLUHMr/uqoeAB5Ici9wKPA/A8cBN/XuOGR/4N6m/m7girYvWpI0WZxgSZImxR3Ab/cXJHkCcAS9ydFMD/Rt76b338QA/7Wq3jqg/k+a2w4lSRrKWwQlSZPii8Djk/xn+NmDKP5v4FLgn4ADZ3mMVyY5pDnGk5P8h4W5XEnSJHKCJUmaCFVVwCuA30nyLeBO4CfA24Br6T3Uov8hF4OO8XXg7cA1SbYCfwsctuAXL0maGOn990iSJEmSNF+uYEmSJElSS5xgSZIkSVJLnGBJkiRJUkucYEmSJElSS/werMFfPilJkiRp8qXtAzrBYnSvlvFFjS+FazBu3PjCxZfCNcwmPq7CUj/+BecPj593/vj4Yve/8aUbXwrXsDfi6zcPj1+7bukf3/joeNu8RVCSJEmSWuIES5IkSZJa4gRLkiRJkloydoKV5NwkdyTZmuTWJM9pys9K8vi5njDJGUkOn00sySVJjp7rOSRJkiRpMYycYCU5ATgFOLaqjgFeANzdhM8C5jTBSrICOAMYOMGaGauq11TV1+dyDkmSJElaLONWsA4DdlbVAwBVtbOqdiR5I72J0LVJrgVI8qEkW5rVrgumD5Bke5J3JLkeOA1YA2xqVsP276v3ypmxJJuTrGni9ye5KMnNSb6Q5PgmfleSlzV1ViR5d5KbmhW317XWU5IkSZI0xrgJ1jXAEUnuTPLBJCcBVNX7gB3A+qpa39Q9t6rWAMcAJyU5pu84P6mq51XVx4AtwIaqWl1Vu6YrVNXlw2KNA4DNVXUccB/wR8ALgVcA72zqvBr4cVWtBdYCr03y9JlJJdnYTAa3TE1NjekCSZIkSZqdkd+DVVX3JzkOeD6wHvhkknOq6tIB1U9NsrE55mHA0cDWJvbJFq71p8DfNNvbgAeq6sEk24BVTfmLgGOa1TCAJwJHAt+dkdcUMD2zKpe5JEmSJLVh7BcNV9VuYDOwuZnMnA5c2l+nWSU6G1hbVT9KcimwX1+Vf2vhWh+squnvAnsYmL5t8eEk03kEOLOqrm7hfJIkSZI0J+MecvHLSY7sK1oNfK/Zvg84sNl+Ar1J1I+THAq8ZMRh+9vNJTYbVwOvT7IvQJKjkhwwj+NJkiRJ0qyNW8FaCbw/yZOAh4BvAxub2BTw+ST3VNX6JF8D7gDuAr484piXAhcn2QWcMOOzVo+KzTEXgEvo3S54S5IAPwRevgfHkSRJkqQ5G/cZrJuB5w6JvR94f9/+GUPqrZqxfwVwxZC6M2Pr+mIr+7bPn9FuZfP+MPC25iVJkiRJe9XYLxqWJEmSJM1OHnluRGd1vgMkSZKkjkrbBxz7FMEuWL95eOzadaN7vTC+kPGlcA3GjRtfuPhSuIa9ER9XYbGv74Lzh8fPO398fNL7x/hoi30NkxD3b9HFjbfNWwQlSZIkqSVOsCRJkiSpJXs0wUqyO8mtfa9z5th+e5KDB5S/bcb+V/bk+iRJkiRpMezpZ7B2VdXqNi+k8TbgT6Z3qmrgI+IlSZIkaSlq9RbBZmXqgiS3JNmW5Fea8qckuSbJ15J8mAGfNUtyIbB/syK2qSm7v3lfl+S6JJcluTPJhUk2JPlqc55nNvWemuSKJDc1r99sMz9JkiRJGmVPJ1jTE6Hp16v6Yjur6ljgQ8DZTdl5wPVV9Wzgs8DTZh6wqs6hWRmrqg0Dzvks4E3ArwO/BxxVVccDlwBnNnX+DHhvVa0FfruJ/ZwkG5NsSbJlampqjqlLkiRJ0mALcYvglc37zcBvNdsnTm9X1V8n+dEenPOmqroHIMl3gGua8m3A+mb7BcDRyc8WyJ6Q5MCquq//QFU1BUzPrOoTm/fgaiRJkiRphoX4HqwHmvfdM44/38fMP9C3/XDf/sN953kMcEJV7ZrnuSRJkiRpzvbWY9q/BGwASPIS4KAh9R5Msu88znMN8IbpnSSr53EsSZIkSZqTtj6DdeGY+hcAJya5BXgR8P0h9aaArdMPudgDbwTWJNma5OvAH+zhcSRJkiRpzvboFsGqWjGkfFXf9hZgXbP9z/QmVtPePKT9W4C39O2vbN43A5v7ytf1bf8sVlU7gf4HbkiSJEnSXrO3bhGUJEmSpImXqvk+e2LZ63wHSJIkSR31c9/PO18L8RTBZeeC84fHzjt/fHzkP0vB+s3Dw9euG9t8wePjKsz3+PPJf7bnMG7c+PKML4VrMG7c+J7Hl8I1GDc+77+FW+YtgpIkSZLUEidYkiRJktSSeU2wkuxuHtN+R5LbkvxhktYmbUnOSHJ43/4lSY5u6/iSJEmS1Kb5fgZrV1WtBkhyCPBx4InAebM9QJIVVbV7SPgM4HZgB0BVvWY+FytJkiRJC6m11aaquhfYCLwhPWck+cB0PMnnkqxrtu9P8s4kNwInJHlHkpuS3J5kqmn/SmANsKlZJds/yeYka5pjnJZkW9Pmor7z3J/kj5sVtRuSHNpWjpIkSZI0Squfwaqqu5pjHjKm6gHA7VX1nKq6HvhAVa2tql8D9gdOqarLgS3AhqpaXVW7phs3tw1eBJwMrAbWJnl537FvqKpnAV8CXjvz5Ek2JtmSZMvU1NQ8MpYkSZKkRyzEQy5m8yz53cAVffvrk9yYZBu9SdOvjmm/FthcVT+sqoeATcCJTeynwOea7ZuBVTMbV9VUVa2pqjUbN26cxeVKkiRJ0nitfg9WkmfQmzzdCzzEoydw+/Vt/2T6c1dJ9gM+CKypqruTnD+j7sBTjYg9WI98e/Ju/K4vSZIkSXtJm0/8eypwMb3b/QrYDqxO8pgkRwDHD2k6PZnamWQl8Mq+2H3AgQPa3AiclOTgJCuA04DrWkhDkiRJkvbYfFd39k9yK7AvvRWrjwLvaWJfBr4LbKP3JMBbBh2gqv4lyZ839bYDN/WFLwUuTrILOKGvzT1J3gpcS28166qq+sw8c5EkSZKkeZnXBKuqVoyIFbBhSGzljP23A28fUO8KHv1ZrXV9sY/Teyz80GM3D8q4fGgCkiRJktSihXjIhSRJkiR1khMsSZIkSWpJHnngXjcl2VhVnf0yrK7nD/aB+Zt/l/MH+8D8zb/L+YN9YP7t5+8KFnT9i7C6nj/YB+bfbV3PH+wD8++2rucP9oH5t8wJliRJkiS1xAmWJEmSJLXECRZ09p7TRtfzB/vA/Lut6/mDfWD+3db1/ME+MP+Wdf4hF5IkSZLUFlewJEmSJKklTrAkSZIkqSUTNcFK8uIk30zy7STnNGVPTvK3Sb7VvB8027Zzab9UDOmDdyf5+yRbk/xlkifNtm1Tvmz6YFgOTezsJJXk4Lm0nYT8k5zZlN+R5F1zbLus80+yOskNSW5NsiXJ8bNt25Qvp/z/Ism9SW7vK+vMGDgk/86MfzC4D/piXRgDB+bfoTFw0O9Al8bAI5Jcm+Qbzb/1m5ryToyDI/LvzDg4rA/64ntnHKyqiXgBK4DvAM8AHgvcBhwNvAs4p6lzDnDRbNs2sbHtl8prRB+8CNinqXPRpPbBmByOAK4Gvgcc3KX8gfXAF4DHNfUO6Vj+1wAvaeq8FNg8ifk313cicCxwe19Zl8bAQfl3Yvwb1QdN+cSPgSN+BjoxBo7Iv0tj4GHAsc32gcCddOhvwRH5d2YcHNYHzf5eGwcXvSNa7NATgKv79t/avL4JHNbX6d+cbdtme2z7pfIalUdf2SuATZPYB2NyuBx4FrB9yC/VxOYPXAa8YB59t9zzvxp4VVN2GvDxScy/79pX8eg/rjozBg7Kf0ZsYse/cX3QhTFwWP5dGQNH5N+pMXBGXp8BXti1cXBm/jPKOjEODuqDvTkOTtItgr8I3N23/4Om7NCqugegeT8EIMnhSa4a05Zh7ZeoUXlM+33g8zCRfTAwhyQvA/6hqm7rr9yV/IGjgOcnuTHJdUnWQqfyPwt4d5K7gT+lN2BOYv7DdGkMHGeSx7+hOjQGDtOVMXCYs+jgGJhkFfBs4EY6OA7OyL9fZ8bB/j7Y2+PgPvO//CUjA8pqWOWq2kFvqXzObZewkXkkORd4CNgEE9kHg3J4HHAuveXxR+lI/kXv9/wg4DeAtcBlSZ7RofxfD7y5qq5IcirwEXr/N3vS8p+TruXfgfFvoCSPpztj4DBdGQOH6dwYmGQlcAVwVlX9azIovcn9HZiZf195Z8bB/j6gl/NeHQcnaQXrB/TurZz2S8AO4J+SHAbQvN87h7bMsv1SMTSPJKcDpwAbqlnfnG1blk8fDMrh+8DTgduSbG/KbknyC7NoOwn572jKr6yerwIPAzM/3DnJ+Z8OXNmUfQoY9AHvSch/mC6NgQN1ZPwb5pl0Zwwcpitj4DCdGgOT7EvvD+tNVTWdd2fGwSH5d2ocHNAHe30cnKQJ1k3AkUmenuSxwO8Cn21epzd1Tqd3L+Zs2zLL9kvFwDySvBh4C/Cyqvr3ubRtYsulDwblcGVVHVJVq6pqFb1fnmOr6h9n0XYS8v8s8GngZIAkR9H74ObOWbaF5Z//DuCkps7JwLfm0BaWT/7DdGkM/DkdGv8GqqptHRoDh/k03RgDh+nMGJjeUtVHgG9U1Xv6Qp0YB4fl36VxcFAfLMo4uBAfKFusF70lvjvpPQHk3KbsKcAX6Q0oXwSe3JQfDlw1qu2o9kv1NaQPvk3vntJbm9fFk9oHw3Loi2+n+WBjV/Kn98fEx4DbgVuAkzuW//OAm+k9DehG4LgJzv8TwD3Ag/T+A/LqLo2BQ/LvzPg3rA9mxCd9DBz0M9ClMXBQ/l0aA59H75aurX2/8y8dlsOk9cGI/DszDg7rgxl1trPA42CaRpIkSZKkeZqkWwQlSZIkaVE5wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRNnCSbk/wvM8rOSnJXknNGtFuT5H3N9rokz13oa5UkTZZ9FvsCJElaAJ8Afhe4uq/sd4HTq+q/D2tUVVuALc3uOuB+4CsLdI2SpAnkCpYkaRJdDpyS5HEASVYBhwP/MckHmrLfSXJ7ktuSfKkpW5fkc039PwDenOTWJM9flCwkScuOK1iSpIlTVf+c5KvAi4HP0Fu9+iRQfdXeAfwvVfUPSZ40o/32JBcD91fVn+6ly5YkTQBXsCRJk2r6NkGa90/MiH8ZuDTJa4EVe/PCJEmTywmWJGlSfRr4n5McC+xfVbf0B6vqD4C3A0cAtyZ5yt6/REnSpPEWQUnSRKqq+5NsBv6Cn1+9Iskzq+pG4MYk/4neRKvffcATFvxCJUkTxRUsSdIk+wTwLOC/DYi9O8m2JLcDXwJumxH/K+AVPuRCkjQXqarxtSRJkiRJY7mCJUmSJEktcYIlSZIkSS1xgiVJkiRJLXGCJUmSJEkt8THt4FM+JEmSpG5K2wd0gsXoXi3jixpfCtdg3HjX4+s3D49fu27v/I6Pq7DYfXTB+cPj550/Pj7uBOPaL/X8F/v6lnp8oX++l8LvsHHjSzneNm8RlCRJkqSWOMGSJEmSpJY4wZIkSZKkloydYCU5N8kdSbYmuTXJc5rys5I8fq4nTHJGksNnE0tySZKj53oOSZIkSVoMIydYSU4ATgGOrapjgBcAdzfhs4A5TbCSrADOAAZOsGbGquo1VfX1uZxDkiRJkhbLuBWsw4CdVfUAQFXtrKodSd5IbyJ0bZJrAZJ8KMmWZrXrgukDJNme5B1JrgdOA9YAm5rVsP376r1yZizJ5iRrmvj9SS5KcnOSLyQ5vonfleRlTZ0VSd6d5KZmxe11rfWUJEmSJI0xboJ1DXBEkjuTfDDJSQBV9T5gB7C+qtY3dc+tqjXAMcBJSY7pO85Pqup5VfUxYAuwoapWV9Wu6QpVdfmwWOMAYHNVHQfcB/wR8ELgFcA7mzqvBn5cVWuBtcBrkzx9ZlJJNjaTwS1TU1NjukCSJEmSZmfk92BV1f1JjgOeD6wHPpnknKq6dED1U5NsbI55GHA0sLWJfbKFa/0p8DfN9jbggap6MMk2YFVT/iLgmGY1DOCJwJHAd2fkNQVMz6zKZS5JkiRJbRj7RcNVtRvYDGxuJjOnA5f212lWic4G1lbVj5JcCuzXV+XfWrjWB6tq+rvAHgamb1t8OMl0HgHOrKqrWzifJEmSJM3JuIdc/HKSI/uKVgPfa7bvAw5stp9AbxL14ySHAi8Zcdj+dnOJzcbVwOuT7AuQ5KgkB8zjeJIkSZI0a+NWsFYC70/yJOAh4NvAxiY2BXw+yT1VtT7J14A7gLuAL4845qXAxUl2ASfM+KzVo2JzzAXgEnq3C96SJMAPgZfvwXEkSZIkac7GfQbrZuC5Q2LvB97ft3/GkHqrZuxfAVwxpO7M2Lq+2Mq+7fNntFvZvD8MvK15SZIkSdJeNfaLhiVJkiRJs5NHnhvRWZ3vAEmSJKmj0vYBxz5FsAtG9WoZX9T4UrgG48aNL1y8rXOsuXl4fMtx49vfvGZ4/LgtC99HrxvxlYwf3rjw7Rc6Pu7fZ2rE96Vs/PDiX/+kx+fT/9PHGHeSxc6x6/H5jpGTHm+btwhKkiRJUkucYEmSJElSS/ZogpVkd5Jb+17nzLH99iQHDyh/24z9r+zJ9UmSJEnSYtjTz2DtqqrVbV5I423An0zvVNXAR8RLkiRJ0lLU6i2CzcrUBUluSbItya805U9Jck2SryX5MAM+a5bkQmD/ZkVsU1N2f/O+Lsl1SS5LcmeSC5NsSPLV5jzPbOo9NckVSW5qXr/ZZn6SJEmSNMqeTrCmJ0LTr1f1xXZW1bHAh4Czm7LzgOur6tnAZ4GnzTxgVZ1DszJWVRsGnPNZwJuAXwd+Dziqqo4HLgHObOr8GfDeqloL/HYT+zlJNibZkmTL1NSIRy9JkiRJ0hwsxC2CVzbvNwO/1WyfOL1dVX+d5Ed7cM6bquoegCTfAa5pyrcB65vtFwBHJz9bIHtCkgOr6r7+A1XVFDA9s6oRTyeVJEmSpFlbiO/BeqB53z3j+PN9zPwDfdsP9+0/3HeexwAnVNWueZ5LkiRJkuZsbz2m/UvABoAkLwEOGlLvwST7zuM81wBvmN5Jsnoex5IkSZKkOWnrM1gXjql/AXBikluAFwHfH1JvCtg6/ZCLPfBGYE2SrUm+DvzBHh5HkiRJkuZsj24RrKoVQ8pX9W1vAdY12/9Mb2I17c1D2r8FeEvf/srmfTOwua98Xd/2z2JVtRPof+CGJEmSJO01e+sWQUmSJEmaeKma77Mnlr3Od4AkSZLUUT/3/bzztRBPEVx2Xvr54bGrXjI+PvKfpeCN7x8eft+ZY5tz5LeHx7/1H8e3n298XP4Lef42jrE34ov9b/T+Nw6Pn/m+xe8f48ZHWexrMG7c+J7Hl8I1GDc+33jbvEVQkiRJklriBEuSJEmSWjKvCVaS3c1j2u9IcluSP0zS2qQtyRlJDu/bvyTJ0W0dX5IkSZLaNN/PYO2qqtUASQ4BPg48EThvtgdIsqKqdg8JnwHcDuwAqKrXzOdiJUmSJGkhtbbaVFX3AhuBN6TnjCQfmI4n+VySdc32/UnemeRG4IQk70hyU5Lbk0w17V8JrAE2Natk+yfZnGRNc4zTkmxr2lzUd577k/xxs6J2Q5JD28pRkiRJkkZp9TNYVXVXc8xDxlQ9ALi9qp5TVdcDH6iqtVX1a8D+wClVdTmwBdhQVauratd04+a2wYuAk4HVwNokL+879g1V9SzgS8BrZ548ycYkW5JsmZqamkfGkiRJkvSIhXjIxWyeJb8buKJvf32SG5Nsozdp+tUx7dcCm6vqh1X1ELAJOLGJ/RT4XLN9M7BqZuOqmqqqNVW1ZuPGjbO4XEmSJEkar9XvwUryDHqTp3uBh3j0BG6/vu2fTH/uKsl+wAeBNVV1d5LzZ9QdeKoRsQfrkW9P3o3f9SVJkiRpL2nziX9PBS6md7tfAduB1Ukek+QI4PghTacnUzuTrARe2Re7DzhwQJsbgZOSHJxkBXAacF0LaUiSJEnSHpvv6s7+SW4F9qW3YvVR4D1N7MvAd4Ft9J4EeMugA1TVvyT586beduCmvvClwMVJdgEn9LW5J8lbgWvprWZdVVWfmWcukiRJkjQv85pgVdWKEbECNgyJrZyx/3bg7QPqXcGjP6u1ri/2cXqPhR967OZBGZcPTUCSJEmSWrQQD7mQJEmSpE5ygiVJkiRJLckjD9zrpiQbq6qzX4bV9fzBPjB/8+9y/mAfmL/5dzl/sA/Mv/38XcGCrn8RVtfzB/vA/Lut6/mDfWD+3db1/ME+MP+WOcGSJEmSpJY4wZIkSZKkljjBgs7ec9roev5gH5h/t3U9f7APzL/bup4/2Afm37LOP+RCkiRJktriCpYkSZIktcQJliRJkiS1ZKImWElenOSbSb6d5Jym7MlJ/jbJt5r3g2bbdi7tl4ohffDuJH+fZGuSv0zypNm2bcqXTR8My6GJnZ2kkhw8l7aTkH+SM5vyO5K8a45tl3X+SVYnuSHJrUm2JDl+tm2b8uWU/18kuTfJ7X1lnRkDh+TfmfEPBvdBX6wLY+DA/Ds0Bg76HejSGHhEkmuTfKP5t35TU96JcXBE/p0ZB4f1QV9874yDVTURL2AF8B3gGcBjgduAo4F3Aec0dc4BLppt2yY2tv1SeY3ogxcB+zR1LprUPhiTwxHA1cD3gIO7lD+wHvgC8Lim3iEdy/8a4CVNnZcCmycx/+b6TgSOBW7vK+vSGDgo/06Mf6P6oCmf+DFwxM9AJ8bAEfl3aQw8DDi22T4QuJMO/S04Iv/OjIPD+qDZ32vj4KJ3RIsdegJwdd/+W5vXN4HD+jr9m7Nt22yPbb9UXqPy6Ct7BbBpEvtgTA6XA88Ctg/5pZrY/IHLgBfMo++We/5XA69qyk4DPj6J+fdd+yoe/cdVZ8bAQfnPiE3s+DeuD7owBg7Lvytj4Ij8OzUGzsjrM8ALuzYOzsx/RlknxsFBfbA3x8FJukXwF4G7+/Z/0JQdWlX3ADTvhwAkOTzJVWPaMqz9EjUqj2m/D3weJrIPBuaQ5GXAP1TVbf2Vu5I/cBTw/CQ3JrkuyVroVP5nAe9Ocjfwp/QGzEnMf5gujYHjTPL4N1SHxsBhujIGDnMWHRwDk6wCng3cSAfHwRn59+vMONjfB3t7HNxn/pe/ZGRAWQ2rXFU76C2Vz7ntEjYyjyTnAg8Bm2Ai+2BQDo8DzqW3PP4oHcm/6P2eHwT8BrAWuCzJMzqU/+uBN1fVFUlOBT5C7/9mT1r+c9K1/Dsw/g2U5PF0Zwwcpitj4DCdGwOTrASuAM6qqn9NBqU3ub8DM/PvK+/MONjfB/Ry3qvj4CStYP2A3r2V034J2AH8U5LDAJr3e+fQllm2XyqG5pHkdOAUYEM165uzbcvy6YNBOXwfeDpwW5LtTdktSX5hFm0nIf8dTfmV1fNV4GFg5oc7Jzn/04Erm7JPAYM+4D0J+Q/TpTFwoI6Mf8M8k+6MgcN0ZQwcplNjYJJ96f1hvamqpvPuzDg4JP9OjYMD+mCvj4OTNMG6CTgyydOTPBb4XeCzzev0ps7p9O7FnG1bZtl+qRiYR5IXA28BXlZV/z6Xtk1sufTBoByurKpDqmpVVa2i98tzbFX94yzaTkL+nwU+DZwMkOQoeh/c3DnLtrD8898BnNTUORn41hzawvLJf5gujYE/p0Pj30BVta1DY+Awn6YbY+AwnRkD01uq+gjwjap6T1+oE+PgsPy7NA4O6oNFGQcX4gNli/Wit8R3J70ngJzblD0F+CK9AeWLwJOb8sOBq0a1HdV+qb6G9MG36d1TemvzunhS+2BYDn3x7TQfbOxK/vT+mPgYcDtwC3Byx/J/HnAzvacB3QgcN8H5fwK4B3iQ3n9AXt2lMXBI/p0Z/4b1wYz4pI+Bg34GujQGDsq/S2Pg8+jd0rW173f+pcNymLQ+GJF/Z8bBYX0wo852FngcTNNIkiRJkjRPk3SLoCRJkiQtKidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSJEmS1BInWJIkSZLUEidYkiRJktQSJ1iSpImQ5P4Z+2ck+cBiXY8kqZucYEmSJElSS5xgSZImXpL/kOSLSbY2709ryi9N8qEk1ya5K8lJSf4iyTeSXNrX/kVJ/i7JLUk+lWTloiUjSVrSnGBJkibF/klunX4B7+yLfQD4f6vqGGAT8L6+2EHAycCbgb8C3gv8KvDrSVYnORh4O/CCqjoW2AL84YJnI0lalvZZ7AuQJKklu6pq9fROkjOANc3uCcBvNdsfBd7V1+6vqqqSbAP+qaq2Ne3vAFYBvwQcDXw5CcBjgb9bsCwkScuaEyxJUhdV3/YDzfvDfdvT+/sAu4G/rarT9tK1SZKWMW8RlCR1wVeA3222NwDXz6HtDcBvJvmPAEken+Solq9PkjQhnGBJkrrgjcD/kWQr8HvAm2bbsKp+CJwBfKJpfwPwKwtxkZKk5S9VNb6WJEmSJGksV7AkSZIkqSVOsCRJkiSpJU6wJEmSJKklTrAkSZIkqSVOsCRJkiSpJX7R8KO/bFKSJElSd6TtAzrBgtHdWmPDxhcwvhSuYRLiT/zX4fEfPwH2e2B4/CePW/zr73p8kv999tY1jOvDpd7HS/365nv948ao3/zK8PiXnwtrbh4e33Lcwl/fQh9/vv/+8z3/0+4ecQLg+0eMrvP9I+DX7hgev/1XF/9ndKnH5/sz4N8Bo+Nt8xZBSZIkSWqJEyxJkiRJasnYCVaSc5PckWRrkluTPKcpPyvJ4+d6wiRnJDl8NrEklyQ5eq7nkCRJkqTFMHKCleQE4BTg2Ko6BngBMH2X7VnAnCZYSVYAZwADJ1gzY1X1mqr6+lzOIUmSJEmLZdwK1mHAzqp6AKCqdlbVjiRvpDcRujbJtQBJPpRkS7PadcH0AZJsT/KOJNcDpwFrgE3Natj+ffVeOTOWZHOSNU38/iQXJbk5yReSHN/E70rysqbOiiTvTnJTs+L2utZ6SpIkSZLGGDfBugY4IsmdST6Y5CSAqnofsANYX1Xrm7rnVtUa4BjgpCTH9B3nJ1X1vKr6GLAF2FBVq6tq13SFqrp8WKxxALC5qo4D7gP+CHgh8ArgnU2dVwM/rqq1wFrgtUmePjOpJBubyeCWqampMV0gSZIkSbMz8jHtVXV/kuOA5wPrgU8mOaeqLh1Q/dQkG5tjHgYcDWxtYp9s4Vp/CvxNs70NeKCqHkyyDVjVlL8IOKZZDQN4InAk8N0ZeU0B0zOrwnUuSZIkSS0Y+z1YVbUb2AxsbiYzpwOX9tdpVonOBtZW1Y+SXArs11fl31q41geravpR9Q8D07ctPpxkOo8AZ1bV1S2cT5IkSZLmZNxDLn45yZF9RauB7zXb9wEHNttPoDeJ+nGSQ4GXjDhsf7u5xGbjauD1SfYFSHJUkgPmcTxJkiRJmrVxK1grgfcneRLwEPBtYGMTmwI+n+Seqlqf5GvAHcBdwJdHHPNS4OIku4ATZnzW6lGxOeYCcAm92wVvSRLgh8DL9+A4kiRJkjRn4z6DdTPw3CGx9wPv79s/Y0i9VTP2rwCuGFJ3ZmxdX2xl3/b5M9qtbN4fBt7WvCRJkiRprxr7RcOSJEmSpNnJI8+N6KzOd4AkSZLUUWn7gGOfItgJo7q1xoaNL2B8KVyD8cWPH/Wt4fE7j1z65/8P3x8e/97Txrff74Hh8Z88bum3b+N3fL59ON8cx53/ST8eHv+XJy789Y87/7j85vtvPO78C/07uti/Y0u9f+b78zGq/fQxFvu/EwsdX+ifkYW+vsX+GVzq8bZ5i6AkSZIktcQJliRJkiS1ZI8mWEl2J7m173XOHNtvT3LwgPK3zdj/yp5cnyRJkiQthj39DNauqlrd5oU03gb8yfROVQ18RLwkSZIkLUWt3iLYrExdkOSWJNuS/EpT/pQk1yT5WpIPM+CzZkkuBPZvVsQ2NWX3N+/rklyX5LIkdya5MMmGJF9tzvPMpt5Tk1yR5Kbm9Ztt5idJkiRJo+zpBGt6IjT9elVfbGdVHQt8CDi7KTsPuL6qng18FnjazANW1Tk0K2NVtWHAOZ8FvAn4deD3gKOq6njgEuDMps6fAe+tqrXAbzexn5NkY5ItSbZMTU3NMXVJkiRJGmwhbhG8snm/GfitZvvE6e2q+uskP9qDc95UVfcAJPkOcE1Tvg1Y32y/ADg6+dkC2ROSHFhV9/UfqKqmgOmZVfG6PbgaSZIkSZphIb4Ha/pJ/LtnHH++j5nvf8L/w337D/ed5zHACVW1a57nkiRJkqQ521uPaf8SsAEgyUuAg4bUezDJvvM4zzXAG6Z3kqyex7EkSZIkaU7a+gzWhWPqXwCcmOQW4EXAsO9cnwK2Tj/kYg+8EViTZGuSrwN/sIfHkSRJkqQ526NbBKtqxZDyVX3bW4B1zfY/05tYTXvzkPZvAd7St7+yed8MbO4rX9e3/bNYVe0E+h+4IUmSJEl7zd66RVCSJEmSJl6q5vvsiWWv8x0gSZIkddTPfT/vfC3EUwSXnT987/DYe948uteL+ceP+MHw+N2/NL79qZ8aHr/sd8bHT7hhePzvfmP89S1kfLrOQv8bLPS/0bj4p04dHv+dy8b/jI6Lj/s3Hnd9820/35+R9/7h8Pib37Pw/z7jKsz332+x+38x28/2GPPtw3E5jOvj+Y6j49rP92d0ocfxxR6Dl/sYP8nxpXANxo3P+7/zLfMWQUmSJElqiRMsSZIkSWqJEyxJkiRJasm8JlhJdjffg3VHktuS/GGS1iZtSc5Icnjf/iVJjm7r+JIkSZLUpvk+5GJXVa0GSHII8HHgicB5sz1AkhVVtXtI+AzgdmAHQFW9Zj4XK0mSJEkLqbXVpqq6F9gIvCE9ZyT5wHQ8yeeSrGu270/yziQ3AickeUeSm5LcnmSqaf9KYA2wqVkl2z/J5iRrmmOclmRb0+aivvPcn+SPmxW1G5Ic2laOkiRJkjRKq5/Bqqq7mmMeMqbqAcDtVfWcqroe+EBVra2qXwP2B06pqsuBLcCGqlpdVbumGze3DV4EnAysBtYmeXnfsW+oqmcBXwJeO/PkSTYm2ZJky9TU1DwyliRJkqRHLMRDLmbzZV27gSv69tcnuTHJNnqTpl8d034tsLmqflhVDwGbgBOb2E+BzzXbNwOrZjauqqmqWlNVazZu3DiLy5UkSZKk8Vr9ouEkz6A3eboXeIhHT+D269v+yfTnrpLsB3wQWFNVdyc5f0bdgacaEXuwqqa/M2w3fpmyJEmSpL2kzSf+PRW4mN7tfgVsB1YneUySI4DjhzSdnkztTLISeGVf7D7gwAFtbgROSnJwkhXAacB1LaQhSZIkSXtsvqs7+ye5FdiX3orVR4H3NLEvA98FttF7EuAtgw5QVf+S5M+betuBm/rClwIXJ9kFnNDX5p4kbwWupbeadVVVfWaeuUiSJEnSvMxrglVVK0bECtgwJLZyxv7bgbcPqHcFj/6s1rq+2MfpPRZ+6LGbB2VcPjQBSZIkSWrRQjzkQpIkSZI6KY88D6Kbkmysqs4+q73r+YN9YP7m3+X8wT4wf/Pvcv5gH5h/+/m7gtX7cuQu63r+YB+Yf7d1PX+wD8y/27qeP9gH5t8yJ1iSJEmS1BInWJIkSZLUEidY0Nl7Thtdzx/sA/Pvtq7nD/aB+Xdb1/MH+8D8W9b5h1xIkiRJUltcwZIkSZKkljjBkiRJkqSWTNQEK8mLk3wzybeTnNOUPTnJ3yb5VvN+0GzbzqX9UjGkD96d5O+TbE3yl0meNNu2Tfmy6YNhOTSxs5NUkoPn0nYS8k9yZlN+R5J3zbHtss4/yeokNyS5NcmWJMfPtm1Tvpzy/4sk9ya5va+sM2PgkPw7M/7B4D7oi3VhDByYf4fGwEG/A10aA49Icm2SbzT/1m9qyjsxDo7IvzPj4LA+6IvvnXGwqibiBawAvgM8A3gscBtwNPAu4JymzjnARbNt28TGtl8qrxF98CJgn6bORZPaB2NyOAK4GvgecHCX8gfWA18AHtfUO6Rj+V8DvKSp81Jg8yTm31zficCxwO19ZV0aAwfl34nxb1QfNOUTPwaO+BnoxBg4Iv8ujYGHAcc22wcCd9KhvwVH5N+ZcXBYHzT7e20cXPSOaLFDTwCu7tt/a/P6JnBYX6d/c7Ztm+2x7ZfKa1QefWWvADZNYh+MyeFy4FnA9iG/VBObP3AZ8IJ59N1yz/9q4FVN2WnAxycx/75rX8Wj/7jqzBg4KP8ZsYkd/8b1QRfGwGH5d2UMHJF/p8bAGXl9Bnhh18bBmfnPKOvEODioD/bmODhJtwj+InB33/4PmrJDq+oegOb9EIAkhye5akxbhrVfokblMe33gc/DRPbBwBySvAz4h6q6rb9yV/IHjgKen+TGJNclWQudyv8s4N1J7gb+lN6AOYn5D9OlMXCcSR7/hurQGDhMV8bAYc6ig2NgklXAs4Eb6eA4OCP/fp0ZB/v7YG+Pg/vM//KXjAwoq2GVq2oHvaXyObddwkbmkeRc4CFgE0xkHwzK4XHAufSWxx+lI/kXvd/zg4DfANYClyV5Rofyfz3w5qq6IsmpwEfo/d/sSct/TrqWfwfGv4GSPJ7ujIHDdGUMHKZzY2CSlcAVwFlV9a/JoPQm93dgZv595Z0ZB/v7gF7Oe3UcnKQVrB/Qu7dy2i8BO4B/SnIYQPN+7xzaMsv2S8XQPJKcDpwCbKhmfXO2bVk+fTAoh+8DTwduS7K9KbslyS/Mou0k5L+jKb+yer4KPAzM/HDnJOd/OnBlU/YpYNAHvCch/2G6NAYO1JHxb5hn0p0xcJiujIHDdGoMTLIvvT+sN1XVdN6dGQeH5N+pcXBAH+z1cXCSJlg3AUcmeXqSxwK/C3y2eZ3e1Dmd3r2Ys23LLNsvFQPzSPJi4C3Ay6rq3+fStoktlz4YlMOVVXVIVa2qqlX0fnmOrap/nEXbScj/s8CngZMBkhxF74ObO2fZFpZ//juAk5o6JwPfmkNbWD75D9OlMfDndGj8G6iqtnVoDBzm03RjDBymM2NgektVHwG+UVXv6Qt1Yhwcln+XxsFBfbAo4+BCfKBssV70lvjupPcEkHObsqcAX6Q3oHwReHJTfjhw1ai2o9ov1deQPvg2vXtKb21eF09qHwzLoS++neaDjV3Jn94fEx8DbgduAU7uWP7PA26m9zSgG4HjJjj/TwD3AA/S+w/Iq7s0Bg7JvzPj37A+mBGf9DFw0M9Al8bAQfl3aQx8Hr1burb2/c6/dFgOk9YHI/LvzDg4rA9m1NnOAo+DaRpJkiRJkuZpkm4RlCRJkqRF5QRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5IkSZJa4gRLkiRJklriBEuSJEmSWuIES5K0pCXZneTWvtc5A+qsS/K5ls+7Lslz+/b/IMl/bvMckqTJs89iX4AkSWPsqqrVi3DedcD9wFcAquriRbgGSdIy4wqWJGlZSvLiJH+f5Hrgt/rKz09ydt/+7UlWNdv/OcnWJLcl+WhT9p+S3Jjka0m+kOTQpv4fAG9uVs2e33/cJKuT3NAc6y+THNSUb05yUZKvJrkzyfP3WodIkpYEJ1iSpKVu/xm3CL4qyX7AnwP/CXg+8AvjDpLkV4FzgZOr6lnAm5rQ9cBvVNWzgf8G/Jeq2g5cDLy3qlZX1X+fcbj/F3hLVR0DbAPO64vtU1XHA2fNKJckdYC3CEqSlrqfu0UwyWrgu1X1rWb/Y8DGMcc5Gbi8qnYCVNX/aMp/CfhkksOAxwLfHXWQJE8EnlRV1zVF/xX4VF+VK5v3m4FVY65JkjRhXMGSJC1XNaT8IR7937f9mvcMafN+4ANV9evA6/rq76kHmvfd+D8yJalznGBJkpajvweenuSZzf5pfbHtwLEASY4Fnt6UfxE4NclTmtiTm/InAv/QbJ/ed5z7gANnnriqfgz8qO/zVb8HXDezniSpm5xgSZKWupmfwbqwqn5C75bAv24ecvG9vvpXAE9OcivweuBOgKq6A/hj4LoktwHvaeqfD3wqyX8HdvYd56+AV0w/5GLGNZ0OvDvJVmA18M720pUkLWepGnaHhSRJkiRpLlzBkiRJkqSWOMGSJEmSpJY4wZIkSZKkljjBkiRJkqSW+P0cw79HRZIkSdJkS9sHdIIFo7u1xoaNL2B8KVyDcePzjc/3AIt9/f6OGzdufJTFvgbjxuf93+mWeYugJEmSJLXECZYkSZIktWTsBCvJuUnuSLK1+Tb75zTlZyV5/FxPmOSMJIfPJpbkkiRHz/UckiRJkrQYRk6wkpwAnAIcW1XHAC8A7m7CZwFzmmAlWQGcAQycYM2MVdVrqurrczmHJEmSJC2WcStYhwE7q+oBgKraWVU7kryR3kTo2iTXAiT5UJItzWrXBdMHSLI9yTuSXA+cBqwBNjWrYfv31XvlzFiSzUnWNPH7k1yU5OYkX0hyfBO/K8nLmjorkrw7yU3NitvrWuspSZIkSRpj3ATrGuCIJHcm+WCSkwCq6n3ADmB9Va1v6p5bVWuAY4CTkhzTd5yfVNXzqupjwBZgQ1Wtrqpd0xWq6vJhscYBwOaqOg64D/gj4IXAK4B3NnVeDfy4qtYCa4HXJnn6zKSSbGwmg1umpqbGdIEkSZIkzc7Ix7RX1f1JjgOeD6wHPpnknKq6dED1U5NsbI55GHA0sLWJfbKFa/0p8DfN9jbggap6MMk2YFVT/iLgmGY1DOCJwJHAd2fkNQVMz6wK17kkSZIktWDs92BV1W5gM7C5mcycDlzaX6dZJTobWFtVP0pyKbBfX5V/a+FaH6yq6UfVPwxM37b4cJLpPAKcWVVXt3A+SZIkSZqTcQ+5+OUkR/YVrQa+12zfBxzYbD+B3iTqx0kOBV4y4rD97eYSm42rgdcn2RcgyVFJDpjH8SRJkiRp1satYK0E3p/kScBDwLeBjU1sCvh8knuqan2SrwF3AHcBXx5xzEuBi5PsAk6Y8VmrR8XmmAvAJfRuF7wlSYAfAi/fg+NIkiRJ0pzlkbvuOqvIyOi4sPEFjC+FazBufL7x+R5gsa/f33Hjxo2PstjXYNz4Av5ndo+M/aJhSZIkSdLsuILV/A9mSZIkSZ3T+grW2KcIdsESX7bsdHwpXINx48YXLr4UrsH40o93+TbapR5fCtdg3Pi8x5iWeYugJEmSJLXECZYkSZIktWSPJlhJdie5te91zhzbb09y8IDyt83Y/8qeXJ8kSZIkLYY9/QzWrqpa3eaFNN4G/Mn0TlU9dwHOIUmSJEkLotVbBJuVqQuS3JJkW5JfacqfkuSaJF9L8mEGfNYsyYXA/s2K2Kam7P7mfV2S65JcluTOJBcm2ZDkq815ntnUe2qSK5Lc1Lx+s838JEmSJGmUPZ1gTU+Epl+v6ovtrKpjgQ8BZzdl5wHXV9Wzgc8CT5t5wKo6h2ZlrKo2DDjns4A3Ab8O/B5wVFUdD1wCnNnU+TPgvVW1FvjtJvZzkmxMsiXJlqmpqTmmLkmSJEmDLcQtglc27zcDv9Vsnzi9XVV/neRHe3DOm6rqHoAk3wGuacq3Aeub7RcARyc/WyB7QpIDq+q+/gNV1RQwPbOq1+3BxUiSJEnSTAvxPVgPNO+7Zxx/vo+Zf6Bv++G+/Yf7zvMY4ISq2jXPc0mSJEnSnO2tx7R/CdgAkOQlwEFD6j2YZN95nOca4A3TO0lWz+NYkiRJkjQnbX0G68Ix9S8ATkxyC/Ai4PtD6k0BW6cfcrEH3gisSbI1ydeBP9jD40iSJEnSnKVqvnfuLXv1c4807A8y4JGHxvdafClcg3HjxhcuvhSuwfjSj4+rsNjX1+X4UrgG48bnGR/3Iz5ne+sWQUmSJEmaeK5gzf/hG5IkSZKWp9ZXsBbiKYLLzhJftux0fClcg/HxFRb7+owv3/hSuAbjSz9+wfnD4+edv/jX1+X4UrgG48bn/XdOy7xFUJIkSZJa4gRLkiRJklriBEuSJEmSWjKvCVaS3c33YN2R5LYkf5iktUlbkjOSHN63f0mSo9s6viRJkiS1ab4PudhVVasBkhwCfBx4InDebA+QZEVV7R4SPgO4HdgBUFWvmc/FSpIkSf//9u4vRK6zjOP492f/prZgY0xNNZBG7IUIjTGpBmprg5VaSlEoauhFRDEiKEYQTQloFLxIK70qEiIVQaNQm5jWEolamopCYtKQNCk1bdXV1ERjL0SLFdv6eHHepSfjObOz7snu7Hl+Hxh2533PO3t+TzJP9uScmTE7lzo72xQRZ4ANwGdU+ZikeyfnJT0s6b3l+xckfU3SAWCNpC9LOijpuKTtZf3twCpgRzlLtkDSPkmrymOsk3SsrNla+zkvSPp6OaO2X9IVXWU0MzMzMzMbptPXYEXE78pjLp5i09cCxyPiXRHxS+DeiFgdEW8HFgC3RsQDwCHgjohYEREvTi4ulw1uBdYCK4DVkj5Ye+z9EXEN8Avgk4M/XNIGSYckHdq+ffsMEpuZmZmZmb3qXHwO1igf1vUKsLN2/0ZJXwQuARYCTwI/HrJ+NbAvIv4KIGkHcD2wG/g38HDZ7nHgpsHFEbEdmDyyik+NsMNmZmZmZmZT6fQAS9JyqoOnM8DLnH2G7OLa9/+afN2VpIuBbwKrIuKkpC0D2zb+qCFzL0XE5GeGvYI/TNnMzMzMzGZJl+/49wZgG9XlfgFMACskvUbSUuDalqWTB1PPS7oUuL029w/gsoY1B4AbJC2SdB6wDnisgxhmZmZmZmb/t5me3Vkg6QhwAdUZq+8C95S5XwG/B45RvRPg4aYHiIi/SfpW2W4COFib/g6wTdKLwJramtOS7gQepTqbtSciHpxhFjMzMzMzsxnRq1fTpRXDrjcMhl+P6PlzOz8O++D5qTeY6/3z/PydH4d98Pz4z391S/v8V7bM/f5lnh+HffC852c4P8r7R0xLp+8iaGZmZmZmlln6M1iSNpR3FUwpe35wDZzf+TPnB9fA+Z0/c35wDZy/+/w+g1V9OHJm2fODa+D8uWXPD66B8+eWPT+4Bs7fMR9gmZmZmZmZdcQHWGZmZmZmZh3xARakvea0yJ4fXAPnzy17fnANnD+37PnBNXD+jqV/kwszMzMzM7Ou+AyWmZmZmZlZR3yAZWZmZmZm1pFeHWBJulnSCUnPStpUxhZK+pmkZ8rXy0ddO53146KlBndL+o2kJyT9SNLrRl1bxudNDdoylLkvSApJi6aztg/5JX22jD8p6a5prp3X+SWtkLRf0hFJhyRdO+raMj6f8n9b0hlJx2tjaXpgS/40/Q+aa1Cby9ADG/Mn6oFNz4FMPXCppEclPVX+rD9XxlP0wSH50/TBthrU5menD0ZEL27AecBvgeXAhcBR4G3AXcCmss0mYOuoa8vclOvH5TakBu8Hzi/bbO1rDabIsBTYC/wBWJQpP3Aj8HPgorLd4mT5fwp8oGxzC7Cvj/nL/l0PrASO18Yy9cCm/Cn637AalPHe98AhfwdS9MAh+TP1wCXAyvL9ZcDTJPpdcEj+NH2wrQbl/qz1wTkvRIcFXQPsrd2/s9xOAEtqRT8x6try/ZTrx+U2LEdt7EPAjj7WYIoMDwDXABMtT6re5gfuB943g9rN9/x7gY+UsXXA9/uYv7bvyzj7l6s0PbAp/8Bcb/vfVDXI0APb8mfpgUPyp+qBA7keBG7K1gcH8w+MpeiDTTWYzT7Yp0sE3wScrN1/roxdERGnAcrXxQCSrpS0Z4q1tK0fU8NyTPo48BPoZQ0aM0i6DfhTRBytb5wlP3A18B5JByQ9Jmk1pMq/Ebhb0kngG1QNs4/522TqgVPpc/9rlagHtsnSA9tsJGEPlLQMeAdwgIR9cCB/XZo+WK/BbPfB82e++2NDDWPRtnFEnKI6VT7ttWNsaA5Jm4GXgR3Qyxo0ZbgI2Ex1evwsSfIH1fP8cuDdwGrgfknLE+X/NPD5iNgp6cPAfVT/m923/NOSLX+C/tdI0iXk6YFtsvTANul6oKRLgZ3Axoj4u9QUr7/PgcH8tfE0fbBeA6rMs9oH+3QG6zmqaysnvRk4BfxF0hKA8vXMNNYy4vpx0ZpD0nrgVuCOKOc3R13L/KlBU4Y/AlcBRyVNlLHDkt44wto+5D9VxndF5dfAf4DBF3f2Of96YFcZ+yHQ9ALvPuRvk6kHNkrS/9q8hTw9sE2WHtgmVQ+UdAHVL9Y7ImIyd5o+2JI/VR9sqMGs98E+HWAdBN4q6SpJFwIfBR4qt/Vlm/VU12KOupYR14+LxhySbga+BNwWEf+cztoyN19q0JRhV0QsjohlEbGM6smzMiL+PMLaPuR/CNgNrAWQdDXVCzefH3EtzP/8p4AbyjZrgWemsRbmT/42mXrg/0jU/xpFxLFEPbDNbnL0wDZpeqCqU1X3AU9FxD21qRR9sC1/pj7YVIM56YPn4gVlc3WjOsX3NNU7gGwuY68HHqFqKI8AC8v4lcCeYWuHrR/XW0sNnqW6pvRIuW3raw3aMtTmJygvbMySn+qXie8Bx4HDwNpk+a8DHqd6N6ADwDt7nP8HwGngJap/QD6RqQe25E/T/9pqMDDf9x7Y9HcgUw9syp+pB15HdUnXE7Xn/C1tGfpWgyH50/TBthoMbDPBOe6DKovMzMzMzMxshvp0iaCZmZmZmdmc8gGWmZmZmZlZR3yAZWZmZmZm1hEfYJmZmZmZmXXEB1hmZmZmZmYd8QGWmZmZmZlZR3yAZWZmZmZm1pH/AvbyM28ml/kJAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 864x691.2 with 8 Axes>"
       ]
@@ -4132,17 +3406,17 @@
      "start_time": "2020-11-23T12:10:20.483760Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.009190Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.009086Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.276895Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.276627Z"
+     "iopub.execute_input": "2023-07-04T15:30:20.624283Z",
+     "iopub.status.busy": "2023-07-04T15:30:20.624149Z",
+     "iopub.status.idle": "2023-07-04T15:30:20.906944Z",
+     "shell.execute_reply": "2023-07-04T15:30:20.906669Z"
     },
     "scrolled": false
    },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAD8CAYAAABq+gXNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtIUlEQVR4nO3df5BlVX33+/dHQEDBiCIIhtxBryQXFUaYwWAMMJRyxeLxakJpKEqZJ+oYb/kDU+QRpUrASlIiPqYSLYUWEyo65mqEqDEoqJfBK4ZxhmFgBo2oOIoZFMljDCQjwvC9f5zdcmjPj+4+p6e7z36/qk71Pvu71z7ru+jznV6sffZJVSFJkiRJGt1jFrsDkiRJkjQpnGBJkiRJ0pg4wZIkSZKkMXGCJUmSJElj4gRLkiRJksbECZYkSZIkjYkTLEnSREnyF0nO7Xp+bZIrup7/zyR/3KftlUnObLZ3JDl4wTssSZooTrAkSZPma8DzAZI8BjgYeFZX/PnAjYvQL0lSCzjBkiRNmhtpJlh0JlbbgfuSHJRkX+D/AP7PJJuSbE8ylST9TpZk/yRfSPK6he+6JGm5c4IlSZooVbUTeCjJb9CZaP0zsBE4EVgF3AZ8oKpWV9Wzgf2BM/qc7gDgH4GPV9WHF7zzkqRlzwmWJGkSTa9iTU+w/rnr+deANUk2JtkGnMqjLyHs9hngb6rqbxe+y5KkSeAES5I0iaY/h/UcOpcI3kRnBWv681cfBM6squcAHwb263OeG4HTB11CKElSNydYkqRJdCOdy/7+V1Xtrqr/BTyRziTrn5tj7k1yAHDmgPO8E/g3OhMySZKGcoIlSZpE2+jcPfCmGft+VlX30lm12gZ8Gtg05FznAvslec/4uylJmjSpqsXugyRJkiRNBFewJEmSJGlMnGBJkiRJ0pg4wZIkSZKkMXGCJUmSJElj4gRLkiRJksZk78XuwBLgbRQlSZKkdhr7F8k7wWLwqJbxRY0vhT4YNz5qfNgBF1/UP3zhRYvff9/jxo0bH2Sx+2Dc+Mj/To+ZlwhKkiRJ0pgMnWAluSDJ7UluS7I1yfOa/ecmedxcXzDJ2iSHzyaW5IokR8/1NSRJkiRpMQycYCU5ETgDOK6qjgFeCNzVhM8F5jTBSrIXsBboOcGaGauq11bVN+byGpIkSZK0WIatYB0G3FtVDwBU1b1VtTPJm+lMhK5Pcj1Akg8l2dysdl08fYIkO5K8M8lXgbOAVcD6ZjVs/67jzpwZS7Ihyaomfn+SS5LcnORLSU5o4ncmeWlzzF5JLk2yqVlxe/3YRkqSJEmShhg2wboOOCLJHUk+mORkgKr6K2AnsKaq1jTHXlBVq4BjgJOTHNN1np9X1Quq6mPAZuDsqlpZVbumD6iqT/WLNR4PbKiq44H7gD8FXgS8HHhXc8xrgJ9V1WpgNfC6JEfOYTwkSZIkad4GTrCq6n7geGAd8BPgE0nW9jn8FUm2ALcAzwK6Pzv1idG7yi+ALzTb24AbqurBZntFs/804NVJtgIbgScDz5x5oiTrmtW2zVNTU2PomiRJkiTN4jbtVbUb2ABsSLINOAe4svuYZpXoPGB1Vf00yZXAfl2H/OcY+vpgVU3fSfFhYPqyxYeTTOcR4E1Vde2gE1XVFDA9syqvI5QkSZI0DsNucvGbSbpXgFYC32+27wMObLafQGcS9bMkhwKnDzhtd7u5xGbjWuANSfYBSHJUksePcD5JkiRJmrVhK1gHAO9P8kTgIeA7dC4XhM4K0OeT3F1Va5LcAtwO3AncOOCcVwKXJdkFnDjjs1aPis0xF4Ar6FwuuCVJ6FzW+LJ5nEeSJEmS5iyPXHXXWrXY3x5tfLDF7oNx4yN/Q/yQAy6+qH/4wosWv/++x40bNz7IYvfBuPER48N+xeds6BcNS5IkSZJmxwmWJEmSJI2Jlwg2V/BIkiRJap2xXyI49DbtbbDErwttdXwp9MG4cT+jtXDxpdAH48aNzz++FPpg3PjI/w6PmZcISpIkSdKYzGuClWR3kq1dj/Pn2H5HkoN77H/HjOdfm0//JEmSJGkxzPcSwV1VtXKcHWm8A/jz6SdV9fwFeA1JkiRJWhBjvUSwWZm6OMmWJNuS/Faz/8lJrktyS5LL6XEpZJJ3A/s3K2Lrm333Nz9PSXJDkk8muSPJu5OcneTrzes8oznuKUmuSrKpefzOOPOTJEmSpEHmO8GanghNP17ZFbu3qo4DPgSc1+y7EPhqVT0X+CzwGzNPWFXn06yMVdXZPV7zWOAtwHOAVwFHVdUJwBXAm5pj/hL4i6paDfx+E5MkSZKkPWIhLhG8uvl5M/B7zfZJ09tV9U9JfjqP19xUVXcDJPkucF2zfxuwptl+IXB08ssFsickObCq7us+UZJ1wDqAyy+/HNatm0d3JEmSJOnRFuI27Q80P3fPOP+od0F8oGv74a7nD3e9zmOAE6tq16ATVdUUMDX99PUjdkySJEmSYM/dpv0rwNkASU4HDupz3INJ9hnhda4D3jj9JMnKEc4lSZIkSXMyrs9gvXvI8RcDJyXZApwG/KDPcVPAbdM3uZiHNwOrktyW5BvAH83zPJIkSZI0Z6laiO8vXlZqsb892vhgi90H48YX/Bvkhxxw8UX9wxdetPj99z1u3Hh740uhD8aNjxgf9is+Z3vqEkFJkiRJmnhOsCRJkiRpTLxEcPS7G0qSJElansZ+ieBC3KZ92Rn2+YZRLtxcAteVLuv4UuiDcePGFy6+FPpg3Ljx+ceXQh+MGx81Pm4jXSKYZHdzF8Hbk9ya5I+TjO2ywyRrkxze9fyKJEeP6/ySJEmSNE6jrmDtqqqVAEkOAT4O/Bpw4WxPkGSvqtrdJ7wW2A7sBKiq147SWUmSJElaSGNbbaqqe4B1wBvTsTbJB6bjST6X5JRm+/4k70qyETgxyTuTbEqyPclU0/5MYBWwvlkl2z/JhiSrmnOclWRb0+aSrte5P8mfNStqNyU5dFw5SpIkSdIgY72LYFXd2ZzzkCGHPh7YXlXPq6qvAh+oqtVV9Wxgf+CMqvoUsBk4u6pWVtWu6cbNZYOXAKcCK4HVSV7Wde6bqupY4CvA68aWoCRJkiQNsBC3aZ/NnTh2A1d1PV+TZGOSbXQmTc8a0n41sKGqflJVDwHrgZOa2C+AzzXbNwMrfqWDybokm5NsnpqamkV3JUmSJGm4sd5FMMnT6Uye7gEe4tETuP26tn8+/bmrJPsBHwRWVdVdSS6acWzPlxoQe7Aeuff8bnrkWFVTwPTMqgbdRVCSJEmSZmucd/x7CnAZncv9CtgBrEzymCRHACf0aTo9mbo3yQHAmV2x+4ADe7TZCJyc5OAkewFnATeMIQ1JkiRJmrdRV7D2T7IV2IfOitVHgfc1sRuB7wHb6NwJcEuvE1TVvyf5cHPcDmBTV/hK4LIku4ATu9rcneTtwPV0VrOuqarPjJiLJEmSJI0kj1xN11oDLxH0i4b9AkPjxo0vXHwp9MG4cePzjy+FPhg3PmJ8NvePmJOFuMmFJEmSJLWSEyxJkiRJGpPWXyKYZF1zV8FWanv+4BiYv/m3OX9wDMzf/NucPzgG5j/+/F3BgnWL3YFF1vb8wTEw/3Zre/7gGJh/u7U9f3AMzH/MnGBJkiRJ0pg4wZIkSZKkMXGCBa295rTR9vzBMTD/dmt7/uAYmH+7tT1/cAzMf8xaf5MLSZIkSRoXV7AkSZIkaUwmaoKV5MVJvpXkO0nOb/Y9KckXk3y7+XnQbNvOpf1S0WcMLk3yL0luS/IPSZ4427bN/mUzBv1yaGLnJakkB8+l7STkn+RNzf7bk7xnjm2Xdf5JVia5KcnWJJuTnDDbts3+5ZT/Xye5J8n2rn2tqYF98m9N/YPeY9AVa0MN7Jl/i2pgr/dAm2rgEUmuT/LN5r/1W5r9raiDA/JvTR3sNwZd8T1TB6tqIh7AXsB3gacDjwVuBY4G3gOc3xxzPnDJbNs2saHtl8pjwBicBuzdHHPJpI7BkByOAK4Fvg8c3Kb8gTXAl4B9m+MOaVn+1wGnN8e8BNgwifk3/TsJOA7Y3rWvTTWwV/6tqH+DxqDZP/E1cMDvQCtq4ID821QDDwOOa7YPBO6gRX8LDsi/NXWw3xg0z/dYHVz0gRjjgJ4IXNv1/O3N41vAYV2D/q3Ztm22h7ZfKo9BeXTtezmwfhLHYEgOnwKOBXb0eVNNbP7AJ4EXjjB2yz3/a4FXNvvOAj4+ifl39X0Fj/7jqjU1sFf+M2ITW/+GjUEbamC//NtSAwfk36oaOCOvzwAvalsdnJn/jH2tqIO9xmBP1sFJukTwacBdXc9/2Ow7tKruBmh+HgKQ5PAk1wxpS7/2S9SgPKb9IfB5mMgx6JlDkpcC/1pVt3Yf3Jb8gaOA302yMckNSVZDq/I/F7g0yV3Ae+kUzEnMv5821cBhJrn+9dWiGthPW2pgP+fSwhqYZAXwXGAjLayDM/Lv1po62D0Ge7oO7j1695eM9NhX/Q6uqp10lsrn3HYJG5hHkguAh4D1MJFj0CuHfYEL6CyPP0pL8i867/ODgN8GVgOfTPL0FuX/BuCtVXVVklcAH6Hzf7MnLf85aVv+Lah/PSV5HO2pgf20pQb207oamOQA4Crg3Kr6j6RXepP7HpiZf9f+1tTB7jGgk/MerYOTtIL1QzrXVk77dWAn8OMkhwE0P++ZQ1tm2X6p6JtHknOAM4Czq1nfnG1bls8Y9MrhB8CRwK1JdjT7tiR56izaTkL+O5v9V1fH14GHgZkf7pzk/M8Brm72/T3Q6wPek5B/P22qgT21pP718wzaUwP7aUsN7KdVNTDJPnT+sF5fVdN5t6YO9sm/VXWwxxjs8To4SROsTcAzkxyZ5LHAHwCfbR7nNMecQ+dazNm2ZZbtl4qeeSR5MfA24KVV9V9zadvElssY9Mrh6qo6pKpWVNUKOm+e46rqR7NoOwn5fxb4NHAqQJKj6Hxw895ZtoXln/9O4OTmmFOBb8+hLSyf/PtpUw38FS2qfz1V1bYW1cB+Pk07amA/ramB6SxVfQT4ZlW9ryvUijrYL/821cFeY7AodXAhPlC2WA86S3x30LkDyAXNvicDX6ZTUL4MPKnZfzhwzaC2g9ov1UefMfgOnWtKtzaPyyZ1DPrl0BXfQfPBxrbkT+ePiY8B24EtwKkty/8FwM107ga0ETh+gvP/O+Bu4EE6/4C8pk01sE/+ral//cZgRnzSa2Cv34E21cBe+bepBr6AziVdt3W951/SL4dJG4MB+bemDvYbgxnH7GCB62CaRpIkSZKkEU3SJYKSJEmStKicYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxsQJliRJkiSNiRMsSZIkSRoTJ1iSJEmSNCZOsCRJkiRpTJxgSZIkSdKYOMGSJEmSpDFxgiVJkiRJY+IES5LUKkl2J9maZHuSv0/yuCRPTPJ/L3bfJEnLnxMsSVLb7KqqlVX1bOAXwB8BTwScYEmSRuYES5LUZv8f8L8D7wae0axsXbrIfZIkLWN7L3YHJElaDEn2Bk4HvgB8Hnh2Va1c1E5JkpY9V7AkSW2zf5KtwGbgB8BHFrc7kqRJ4gqWJKltds1cqUqySF2RJE0aV7AkSYL7gAMXuxOSpOXPCZYkqfWq6t+AG5tbt3uTC0nSvKWqFrsPkiRJkjQRXMGSJEmSpDFxgiVJkiRJY+IES5IkSZLGxAmWJEmSJI2JEyxJkiRJGhO/aBi8jaIkSZLUTmP/pnknWAwe1TK+qPGl0AfjxocdsNCvv+rm/vHNxy98+za8x5fyGJm/8WHx10/1j1++DqZe3z++7vLJeA8bNz5KfNy8RFCSJEmSxmToBCvJBUluT3Jbkq1JntfsPzfJ4+b6gknWJjl8NrEkVyQ5eq6vIUmSJEmLYeAEK8mJwBnAcVV1DPBC4K4mfC4wpwlWkr2AtUDPCdbMWFW9tqq+MZfXkCRJkqTFMmwF6zDg3qp6AKCq7q2qnUneTGcidH2S6wGSfCjJ5ma16+LpEyTZkeSdSb4KnAWsAtY3q2H7dx135sxYkg1JVjXx+5NckuTmJF9KckITvzPJS5tj9kpyaZJNzYrbgKuOJUmSJGm8hk2wrgOOSHJHkg8mORmgqv4K2Amsqao1zbEXVNUq4Bjg5CTHdJ3n51X1gqr6GLAZOLuqVlbVrukDqupT/WKNxwMbqup44D7gT4EXAS8H3tUc8xrgZ1W1GlgNvC7JkXMYD0mSJEmat4ETrKq6HzgeWAf8BPhEkrV9Dn9Fki3ALcCzgO7PTn1i9K7yC+ALzfY24IaqerDZXtHsPw14dZKtwEbgycAzZ54oybpmtW3z1NSAW+9IkiRJ0hwMvU17Ve0GNgAbkmwDzgGu7D6mWSU6D1hdVT9NciWwX9ch/zmGvj5YVdN3UnwYmL5s8eEk03kEeFNVXTvoRFU1BUzPrMrrCCVJkiSNw7CbXPxmku4VoJXA95vt+4ADm+0n0JlE/SzJocDpA07b3W4usdm4FnhDkn0AkhyV5PEjnE+SJEmSZm3YCtYBwPuTPBF4CPgOncsFobMC9Pkkd1fVmiS3ALcDdwI3DjjnlcBlSXYBJ874rNWjYnPMBeAKOpcLbkkSOpc1vmwe55EkSZKkORs4waqqm4Hn94m9H3h/1/O1fY5bMeP5VcBVfY6dGTulK3ZA1/ZFM9od0Px8GHhH85AkSZKkPWroFw1LkiRJkmbHCZYkSZIkjUkeuTFfa7V+ACRJkqSWyrhPOPQ27W0waFTL+KLGl0IfjBtf6PiwA9Zs6B++/pTF7/8kvMdHHeOF/m+03H8Hlnv/Jz0+7L/PoPj0MRdf1D9+4UX+Dhhf2vFxm9clgkl2J9na9Th/ju13JDm4x/53zHj+tfn0T5IkSZIWw3xXsHZV1cpxdqTxDuDPp59UVc87GEqSJEnSUjTWm1w0K1MXJ9mSZFuS32r2PznJdUluSXI5PVbqkrwb2L9ZEVvf7Lu/+XlKkhuSfDLJHUneneTsJF9vXucZzXFPSXJVkk3N43fGmZ8kSZIkDTLfCdb0RGj68cqu2L1VdRzwIeC8Zt+FwFer6rnAZ4HfmHnCqjqfZmWsqs7u8ZrHAm8BngO8Cjiqqk6g8+XCb2qO+UvgL6pqNfD7TUySJEmS9oiFuETw6ubnzcDvNdsnTW9X1T8l+ek8XnNTVd0NkOS7wHXN/m3Ammb7hcDRyS8XyJ6Q5MCqum8erydJkiRJc7IQ34P1QPNzN4+ewI16k44HurYf7nr+cNfrPAY4sVkFW1lVT+s1uUqyLsnmJJunpqZG7JYkSZIkdeypLxr+CnA2QJLTgYP6HPdgkn1GeJ3rgDdOP0mystdBVTVVVauqatW6detGeDlJkiRJesS4PoP17iHHXwyclGQLcBrwgz7HTQG3Td/kYh7eDKxKcluSbwB/NM/zSJIkSdKczeszWFW1V5/9K7q2NwOnNNv/RmdiNe2tfdq/DXhb1/MDmp8bgA1d+0/p2v5lrKruBbpvuCFJkiRJe8yeukRQkiRJkiaeEyxJkiRJGpNUjXpzv2Wv9QMgSZIktVSGHzI38/0erIkyaFRrFvH/fmX/+N+sHX6CI3f0D39vxej9W+z4KPntiddYCmNk3Hhb40uhD8aNG59/fCn0wbjxUePj5iWCkiRJkjQmI02wkuxubtN+e5Jbk/xxkrFN2pKsTXJ41/Mrkhw9rvNLkiRJ0jiNeongrqpaCZDkEODjwK8BF872BEn2qqrdfcJrge3AToCqeu0onZUkSZKkhTS21aaqugdYB7wxHWuTfGA6nuRzSU5ptu9P8q4kG4ETk7wzyaYk25NMNe3PBFYB65tVsv2TbEiyqjnHWUm2NW0u6Xqd+5P8WbOidlOSQ8eVoyRJkiQNMtbPYFXVnc05Dxly6OOB7VX1vKr6KvCBqlpdVc8G9gfOqKpPAZuBs6tqZVXtmm7cXDZ4CXAqsBJYneRlXee+qaqOBb4CvG5sCUqSJEnSAAtxk4vZ3OpwN3BV1/M1STYm2UZn0vSsIe1XAxuq6idV9RCwHjipif0C+FyzfTOw4lc6mKxLsjnJ5qmpqVl0V5IkSZKGG+tt2pM8nc7k6R7gIR49gduva/vn05+7SrIf8EFgVVXdleSiGcf2fKkBsQfrkS/32k2PHKtqCpieWdXrh7yYJEmSJM3GOO/49xTgMjqX+xWwA1iZ5DFJjgBO6NN0ejJ1b5IDgDO7YvcBB/ZosxE4OcnBSfYCzgJuGEMakiRJkjRvo65g7Z9kK7APnRWrjwLva2I3At8DttG5E+CWXieoqn9P8uHmuB3Apq7wlcBlSXYBJ3a1uTvJ24Hr6axmXVNVnxkxF0mSJEkaSR65mq61atRvf/7vV/aP/83a4Sc4ckf/8PdWLP63W48aHyW/PfEaS2GMjBtva3wp9MG4cePzjy+FPhg3PmJ8NvePmJOFuMmFJEmSJLWSEyxJkiRJGpPWXyKYZF1zV8FWanv+4BiYv/m3OX9wDMzf/NucPzgG5j/+/F3BgnWL3YFF1vb8wTEw/3Zre/7gGJh/u7U9f3AMzH/MnGBJkiRJ0pg4wZIkSZKkMXGCBa295rTR9vzBMTD/dmt7/uAYmH+7tT1/cAzMf8xaf5MLSZIkSRoXV7AkSZIkaUwmaoKV5MVJvpXkO0nOb/Y9KckXk3y7+XnQbNvOpf1S0WcMLk3yL0luS/IPSZ4427bN/mUzBv1yaGLnJakkB8+l7STkn+RNzf7bk7xnjm2Xdf5JVia5KcnWJJuTnDDbts3+5ZT/Xye5J8n2rn2tqYF98m9N/YPeY9AVa0MN7Jl/i2pgr/dAm2rgEUmuT/LN5r/1W5r9raiDA/JvTR3sNwZd8T1TB6tqIh7AXsB3gacDjwVuBY4G3gOc3xxzPnDJbNs2saHtl8pjwBicBuzdHHPJpI7BkByOAK4Fvg8c3Kb8gTXAl4B9m+MOaVn+1wGnN8e8BNgwifk3/TsJOA7Y3rWvTTWwV/6tqH+DxqDZP/E1cMDvQCtq4ID821QDDwOOa7YPBO6gRX8LDsi/NXWw3xg0z/dYHVz0gRjjgJ4IXNv1/O3N41vAYV2D/q3Ztm22h7ZfKo9BeXTtezmwfhLHYEgOnwKOBXb0eVNNbP7AJ4EXjjB2yz3/a4FXNvvOAj4+ifl39X0Fj/7jqjU1sFf+M2ITW/+GjUEbamC//NtSAwfk36oaOCOvzwAvalsdnJn/jH2tqIO9xmBP1sFJukTwacBdXc9/2Ow7tKruBmh+HgKQ5PAk1wxpS7/2S9SgPKb9IfB5mMgx6JlDkpcC/1pVt3Yf3Jb8gaOA302yMckNSVZDq/I/F7g0yV3Ae+kUzEnMv5821cBhJrn+9dWiGthPW2pgP+fSwhqYZAXwXGAjLayDM/Lv1po62D0Ge7oO7j1695eM9NhX/Q6uqp10lsrn3HYJG5hHkguAh4D1MJFj0CuHfYEL6CyPP0pL8i867/ODgN8GVgOfTPL0FuX/BuCtVXVVklcAH6Hzf7MnLf85aVv+Lah/PSV5HO2pgf20pQb207oamOQA4Crg3Kr6j6RXepP7HpiZf9f+1tTB7jGgk/MerYOTtIL1QzrXVk77dWAn8OMkhwE0P++ZQ1tm2X6p6JtHknOAM4Czq1nfnG1bls8Y9MrhB8CRwK1JdjT7tiR56izaTkL+O5v9V1fH14GHgZkf7pzk/M8Brm72/T3Q6wPek5B/P22qgT21pP718wzaUwP7aUsN7KdVNTDJPnT+sF5fVdN5t6YO9sm/VXWwxxjs8To4SROsTcAzkxyZ5LHAHwCfbR7nNMecQ+dazNm2ZZbtl4qeeSR5MfA24KVV9V9zadvElssY9Mrh6qo6pKpWVNUKOm+e46rqR7NoOwn5fxb4NHAqQJKj6Hxw895ZtoXln/9O4OTmmFOBb8+hLSyf/PtpUw38FS2qfz1V1bYW1cB+Pk07amA/ramB6SxVfQT4ZlW9ryvUijrYL/821cFeY7AodXAhPlC2WA86S3x30LkDyAXNvicDX6ZTUL4MPKnZfzhwzaC2g9ov1UefMfgOnWtKtzaPyyZ1DPrl0BXfQfPBxrbkT+ePiY8B24EtwKkty/8FwM107ga0ETh+gvP/O+Bu4EE6/4C8pk01sE/+ral//cZgRnzSa2Cv34E21cBe+bepBr6AziVdt3W951/SL4dJG4MB+bemDvYbgxnH7GCB62CaRpIkSZKkEU3SJYKSJEmStKicYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxsQJliRJkiSNiRMsSZIkSRoTJ1iSJEmSNCZOsCRJkiRpTJxgSZIkSdKYOMGSJEmSpDFxgiVJkiRJY+IES5I08ZI8Ncn/k+S7Sb6R5JokRy12vyRJk8cJliRpoiUJ8A/Ahqp6RlUdDbwDOHQ2bZP4b6Ukadb8R0OSNOnWAA9W1WXTO6pqK3BLki8n2ZJkW5L/CyDJiiTfTPJBYAtwxKL0WpK0LKWqFrsPkiQtmCRvBo6sqrfO2L838Liq+o8kBwM3Ac8E/jfgTuD5VXXTHu+wJGlZ23uxOyBJ0iIJ8OdJTgIeBp7GI5cNft/JlSRpPrxEUJI06W4Hju+x/2zgKcDxVbUS+DGwXxP7zz3TNUnSpHGCJUmadP8vsG+S103vSLKazqWA91TVg0nWNM8lSRqJEyxJ0kSrzoeNXw68qLlN++3ARcA1wKokm+msZv3L4vVSkjQpvMmFJEmSJI2JK1iSJEmSNCZOsCRJkiRpTJxgSZIkSdKYOMGSJEmSpDFxgiVJkiRJY7L3YndgCfA2ipIkSVI7ZdwndILF4FEt44saXwp9mIT4sbf1j996DDz1x/3jPzp08fv/J+/tH7/0vMXv36jjv9j9GxZfyN+P2fbh1R/tH//bV43ex2HnHzX+xdP6x1903ei/I6OOz7D32LD+jRofluCPn9o/fOiPhuc/bPxO+2L/+HUvGr2GvvdP+sfPu3T0399Rx3+U//7T5/joq/vHX/W3i1/HlnIdHMe/E8P6t9A1dLnHx81LBCVJkiRpTIZOsJJckOT2JLcl2Zrkec3+c5M8bq4vmGRtksNnE0tyRZKj5/oakiRJkrQYBk6wkpwInAEcV1XHAC8E7mrC5wJzmmAl2QtYC/ScYM2MVdVrq+obc3kNSZIkSVosw1awDgPuraoHAKrq3qrameTNdCZC1ye5HiDJh5Jsbla7Lp4+QZIdSd6Z5KvAWcAqYH2zGrZ/13Fnzowl2ZBkVRO/P8klSW5O8qUkJzTxO5O8tDlmrySXJtnUrLi9fmwjJUmSJElDDJtgXQcckeSOJB9McjJAVf0VsBNYU1VrmmMvqKpVwDHAyUmO6TrPz6vqBVX1MWAzcHZVrayqXdMHVNWn+sUajwc2VNXxwH3AnwIvAl4OvKs55jXAz6pqNbAaeF2SI+cwHpIkSZI0bwMnWFV1P3A8sA74CfCJJGv7HP6KJFuAW4BnAd2fnfrE6F3lF8AXmu1twA1V9WCzvaLZfxrw6iRbgY3Ak4FnzjxRknXNatvmqampMXRNkiRJkmZxm/aq2g1sADYk2QacA1zZfUyzSnQesLqqfprkSmC/rkP+cwx9fbCqpu+k+DAwfdniw0mm8wjwpqq6dtCJqmoKmJ5ZldcRSpIkSRqHYTe5+M0k3StAK4HvN9v3AQc220+gM4n6WZJDgdMHnLa73Vxis3Et8IYk+wAkOSrJ40c4nyRJkiTN2rAVrAOA9yd5IvAQ8B06lwtCZwXo80nurqo1SW4BbgfuBG4ccM4rgcuS7AJOnPFZq0fF5pgLwBV0LhfckiR0Lmt82TzOI0mSJElzNnCCVVU3A8/vE3s/8P6u52v7HLdixvOrgKv6HDszdkpX7ICu7YtmtDug+fkw8I7mIUmSJEl71NAvGpYkSZIkzU4euW9Ea7V+ACRJkqSWyrhPOPQugm0waFTL+KLGl0IfJiG+6ub+8c3Hw+F394/vPGzx+z9q/OKL+scvvGjxx3+xx2dYfCF/P2bbh9cP+EaNy9ctfA7DXn/Y79h/+1z/+D+eATev6h8/fvPov0PD+jfs/MP6P6z9sPjUgNv5rrucoQl+7r/1D5/xj8P/+43a/1F//4b1f9Tf32H//UaJTx8z6ntksevcYtbB2Zx/1NcfNv6T/nfAsPi4eYmgJEmSJI3JvCZYSXYn2dr1OH+O7XckObjH/nfMeP61+fRPkiRJkhbDfC8R3FVVK8fZkcY7gD+fflJVPe9gKEmSJElL0VgvEWxWpi5OsiXJtiS/1ex/cpLrktySpOfV1EneDezfrIitb/bd3/w8JckNST6Z5I4k705ydpKvN6/zjOa4pyS5Ksmm5vE748xPkiRJkgaZ7wRreiI0/XhlV+zeqjoO+BBwXrPvQuCrVfVc4LPAb8w8YVWdT7MyVlVn93jNY4G3AM8BXgUcVVUn0Ply4Tc1x/wl8BdVtRr4/SYmSZIkSXvEQlwieHXz82bg95rtk6a3q+qfkvx0Hq+5qaruBkjyXeC6Zv82YE2z/ULg6OSXC2RPSHJgVd3XfaIk64B1AJdffjmsWzeP7kiSJEnSoy3EbdofaH7unnH+Ue+C+EDX9sNdzx/uep3HACdW1a5BJ6qqKWD6hqI14O6wkiRJkjRre+o27V8BzgZIcjpwUJ/jHkyyzwivcx3wxuknSVaOcC5JkiRJmpNxfQbr3UOOvxg4KckW4DTgB32OmwJum77JxTy8GViV5LYk3wD+aJ7nkSRJkqQ5m9clglW1V5/9K7q2NwOnNNv/RmdiNe2tfdq/DXhb1/MDmp8bgA1d+0/p2v5lrKruBbpvuCFJkiRJe8yeukRQkiRJkiaeEyxJkiRJGpNUjXpzv2Wv9QMgSZIktVSGHzI3C3Gb9uVn0LAWXPo/+of/5D2w7y/6xx947NDTGx8QXwp9MG7c+MLFl0IfjBs3Pv/4UuiDceOjxsfNSwQlSZIkaUxGmmAl2d3cpv32JLcm+eMkY5u0JVmb5PCu51ckOXpc55ckSZKkcRr1EsFdVbUSIMkhwMeBXwMunO0JkuxVVbv7hNcC24GdAFX12lE6K0mSJEkLaWyrTVV1D7AOeGM61ib5wHQ8yeeSnNJs35/kXUk2AicmeWeSTUm2J5lq2p8JrALWN6tk+yfZkGRVc46zkmxr2lzS9Tr3J/mzZkXtpiSHjitHSZIkSRpkrJ/Bqqo7m3MeMuTQxwPbq+p5VfVV4ANVtbqqng3sD5xRVZ8CNgNnV9XKqto13bi5bPAS4FRgJbA6ycu6zn1TVR0LfAV43dgSlCRJkqQBFuImF7O51eFu4Kqu52uSbEyyjc6k6VlD2q8GNlTVT6rqIWA9cFIT+wXwuWb7ZmDFr3QwWZdkc5LNU1NTs+iuJEmSJA031tu0J3k6ncnTPcBDPHoCt1/X9s+nP3eVZD/gg8CqqroryUUzju35UgNiD9YjX+61mx45VtUUMD2zKl4/5NUkSZIkaRbGece/pwCX0bncr4AdwMokj0lyBHBCn6bTk6l7kxwAnNkVuw84sEebjcDJSQ5OshdwFnDDGNKQJEmSpHkbdQVr/yRbgX3orFh9FHhfE7sR+B6wjc6dALf0OkFV/XuSDzfH7QA2dYWvBC5Lsgs4savN3UneDlxPZzXrmqr6zIi5SJIkSdJI8sjVdK1Vw77e+dL/0T/8J++BfX/RP/7AYxf/26mXc3wp9MG4ceMLF18KfTBu3Pj840uhD8aNjxifzf0j5mQhbnIhSZIkSa3kBEuSJEmSxqT1lwgmWdfcVbCV2p4/OAbmb/5tzh8cA/M3/zbnD46B+Y8/f1ewYN1id2CRtT1/cAzMv93anj84Bubfbm3PHxwD8x8zJ1iSJEmSNCZOsCRJkiRpTJxgQWuvOW20PX9wDMy/3dqePzgG5t9ubc8fHAPzH7PW3+RCkiRJksbFFSxJkiRJGpOJmmAleXGSbyX5TpLzm31PSvLFJN9ufh4027Zzab9U9BmDS5P8S5LbkvxDkifOtm2zf9mMQb8cmth5SSrJwXNpOwn5J3lTs//2JO+ZY9tlnX+SlUluSrI1yeYkJ8y2bbN/OeX/10nuSbK9a19ramCf/FtT/6D3GHTF2lADe+bfohrY6z3Qphp4RJLrk3yz+W/9lmZ/K+rggPxbUwf7jUFXfM/UwaqaiAewF/Bd4OnAY4FbgaOB9wDnN8ecD1wy27ZNbGj7pfIYMAanAXs3x1wyqWMwJIcjgGuB7wMHtyl/YA3wJWDf5rhDWpb/dcDpzTEvATZMYv5N/04CjgO2d+1rUw3slX8r6t+gMWj2T3wNHPA70IoaOCD/NtXAw4Djmu0DgTto0d+CA/JvTR3sNwbN8z1WBxd9IMY4oCcC13Y9f3vz+BZwWNegf2u2bZvtoe2XymNQHl37Xg6sn8QxGJLDp4BjgR193lQTmz/wSeCFI4zdcs//WuCVzb6zgI9PYv5dfV/Bo/+4ak0N7JX/jNjE1r9hY9CGGtgv/7bUwAH5t6oGzsjrM8CL2lYHZ+Y/Y18r6mCvMdiTdXCSLhF8GnBX1/MfNvsOraq7AZqfhwAkOTzJNUPa0q/9EjUoj2l/CHweJnIMeuaQ5KXAv1bVrd0HtyV/4Cjgd5NsTHJDktXQqvzPBS5NchfwXjoFcxLz76dNNXCYSa5/fbWoBvbTlhrYz7m0sAYmWQE8F9hIC+vgjPy7taYOdo/Bnq6De4/e/SUjPfZVv4OraiedpfI5t13CBuaR5ALgIWA9TOQY9MphX+ACOsvjj9KS/IvO+/wg4LeB1cAnkzy9Rfm/AXhrVV2V5BXAR+j83+xJy39O2pZ/C+pfT0keR3tqYD9tqYH9tK4GJjkAuAo4t6r+I+mV3uS+B2bm37W/NXWwewzo5LxH6+AkrWD9kM61ldN+HdgJ/DjJYQDNz3vm0JZZtl8q+uaR5BzgDODsatY3Z9uW5TMGvXL4AXAkcGuSHc2+LUmeOou2k5D/zmb/1dXxdeBhYOaHOyc5/3OAq5t9fw/0+oD3JOTfT5tqYE8tqX/9PIP21MB+2lID+2lVDUyyD50/rNdX1XTeramDffJvVR3sMQZ7vA5O0gRrE/DMJEcmeSzwB8Bnm8c5zTHn0LkWc7ZtmWX7paJnHkleDLwNeGlV/ddc2jax5TIGvXK4uqoOqaoVVbWCzpvnuKr60SzaTkL+nwU+DZwKkOQoOh/cvHeWbWH5578TOLk55lTg23NoC8sn/37aVAN/RYvqX09Vta1FNbCfT9OOGthPa2pgOktVHwG+WVXv6wq1og72y79NdbDXGCxKHVyID5Qt1oPOEt8ddO4AckGz78nAl+kUlC8DT2r2Hw5cM6jtoPZL9dFnDL5D55rSrc3jskkdg345dMV30HywsS350/lj4mPAdmALcGrL8n8BcDOduwFtBI6f4Pz/DrgbeJDOPyCvaVMN7JN/a+pfvzGYEZ/0Gtjrd6BNNbBX/m2qgS+gc0nXbV3v+Zf0y2HSxmBA/q2pg/3GYMYxO1jgOpimkSRJkiRpRJN0iaAkSZIkLSonWJIkSZI0Jk6wJEmSJGlMnGBJkiRJ0pg4wZIkSZKkMXGCJUmSJElj4gRLkiRJksbECZYkSZIkjcn/D2oiQisLB6HDAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAD8CAYAAABq+gXNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtFklEQVR4nO3df5BlVX33+/dHQEHBiCIIhtxBryQXFUaYwWAMMJRyxeLx0YTSUJQyT9Qx3vIHpsgVpUrASlIgXlOJlkKLCRUd82iEqDEoqJfBK4ZxhmFgBo2oOIoZFMljDCQjwvC9f5zdcmjPj+4+p6e7z36/qk71Pvu71z7ru+jznV6sffZJVSFJkiRJGt1jFrsDkiRJkjQpnGBJkiRJ0pg4wZIkSZKkMXGCJUmSJElj4gRLkiRJksbECZYkSZIkjYkTLEnSxEvytCT/M8l3k3wjyTVJjlzsfkmSJo8TLEnSREsS4B+ADVX1zKo6CngncMhs2ibx30pJ0qz5j4YkadKtAR6sqsumd1TVVuCWJF9OsiXJtiT/HSDJiiTfTPJBYAtw+KL0WpK0LKWqFrsPkiQtmCRvAY6oqrfN2L838Piq+o8kBwE3Ac8C/jfgTuAFVXXTHu+wJGlZ23uxOyBJ0iIJ8OdJTgQeBp7OI5cNft/JlSRpPrxEUJI06W4Hjuux/yzgqcBxVbUS+DGwbxP7zz3TNUnSpHGCJUmadP8v8Lgkr5/ekWQ1nUsB76mqB5OsaZ5LkjQSJ1iSpIlWnQ8bvwJ4cXOb9tuBC4FrgFVJNtNZzfqXxeulJGlSeJMLSZIkSRoTV7AkSZIkaUycYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxmTvxe7AEuBtFCVJkqR2yrhP6ASLwaNaxhc1vhT6MAnxY27rH7/1aHjaj/vHf3TI4vf/T97bP37puYvfv1HHf7H7Nyy+kL8fs+3Daz7aP/63rx69j8POP2r8i6f2j7/4utF/R0Ydn2HvsWH9GzU+LMEfP61/+JAfDc9/2Pid+sX+8etePHoNfe+f9I+fe+nov7+jjv8o//2nz/HR1/SPv/pvF7+OLeU6OI5/J4b1b6Fr6HKPj5uXCEqSJEnSmAydYCU5P8ntSW5LsjXJ85v95yR5/FxfMMnaJIfNJpbkiiRHzfU1JEmSJGkxDJxgJTkBOB04tqqOBl4E3NWEzwHmNMFKshewFug5wZoZq6rXVdU35vIakiRJkrRYhq1gHQrcW1UPAFTVvVW1M8lb6EyErk9yPUCSDyXZ3Kx2XTR9giQ7krwryVeBM4FVwPpmNWy/ruPOmBlLsiHJqiZ+f5JLktyc5EtJjm/idyZ5WXPMXkkuTbKpWXF7w9hGSpIkSZKGGDbBug44PMkdST6Y5CSAqvorYCewpqrWNMeeX1WrgKOBk5Ic3XWen1fVC6vqY8Bm4KyqWllVu6YPqKpP9Ys1ngBsqKrjgPuAPwVeDLwCeHdzzGuBn1XVamA18PokR8xhPCRJkiRp3gZOsKrqfuA4YB3wE+ATSdb2OfyVSbYAtwDPBro/O/WJ0bvKL4AvNNvbgBuq6sFme0Wz/1TgNUm2AhuBpwDPmnmiJOua1bbNU1NTY+iaJEmSJM3iNu1VtRvYAGxIsg04G7iy+5hmlehcYHVV/TTJlcC+XYf85xj6+mBVTd9J8WFg+rLFh5NM5xHgzVV17aATVdUUMD2zKq8jlCRJkjQOw25y8ZtJuleAVgLfb7bvAw5otp9IZxL1sySHAKcNOG13u7nEZuNa4I1J9gFIcmSSJ4xwPkmSJEmatWErWPsD70/yJOAh4Dt0LheEzgrQ55PcXVVrktwC3A7cCdw44JxXApcl2QWcMOOzVo+KzTEXgCvoXC64JUnoXNb48nmcR5IkSZLmbOAEq6puBl7QJ/Z+4P1dz9f2OW7FjOdXAVf1OXZm7OSu2P5d2xfOaLd/8/Nh4J3NQ5IkSZL2qKFfNCxJkiRJmh0nWJIkSZI0Jnnkxnyt1foBkCRJkloq4z7h0Nu0t8GgUS3jixpfCn2YhPiqm/vHNx8Hh93dP77z0MXv/6jxiy7sH7/gwsUf/8Uen2Hxhfz9mG0f3jDgKwsvX7fwOQx7/WG/Y//tc/3j/3g63Lyqf/y4zaP/Dg3r37DzD+v/sPbD4lMDvi9l3eUMTfBz/61/+PR/HP7fb9T+j/r7N6z/o/7+DvvvN0p8+phR3yOLXecWsw7O5vyjvv6w8Z/0vwOGxcfNSwQlSZIkaUzmNcFKsjvJ1q7HeXNsvyPJQT32v3PG86/Np3+SJEmStBjme4ngrqpaOc6ONN4J/Pn0k6rqeYt4SZIkSVqKxnqJYLMydVGSLUm2JfmtZv9TklyX5JYkPa+mTnIxsF+zIra+2Xd/8/PkJDck+WSSO5JcnOSsJF9vXueZzXFPTXJVkk3N43fGmZ8kSZIkDTLfCdb0RGj68aqu2L1VdSzwIeDcZt8FwFer6nnAZ4HfmHnCqjqPZmWsqs7q8ZrHAG8Fngu8Gjiyqo4HrgDe3Bzzl8BfVNVq4PebmCRJkiTtEQtxieDVzc+bgd9rtk+c3q6qf0ry03m85qaquhsgyXeB65r924A1zfaLgKOSXy6QPTHJAVV1X/eJkqwD1gFcfvnlsG7dPLojSZIkSY+2ELdpf6D5uXvG+Ue9C+IDXdsPdz1/uOt1HgOcUFW7Bp2oqqaA6RuK1oC7w0qSJEnSrO2p27R/BTgLIMlpwIF9jnswyT4jvM51wJumnyRZOcK5JEmSJGlOxvUZrIuHHH8RcGKSLcCpwA/6HDcF3DZ9k4t5eAuwKsltSb4B/NE8zyNJkiRJczavSwSraq8++1d0bW8GTm62/43OxGra2/q0fzvw9q7n+zc/NwAbuvaf3LX9y1hV3Qt033BDkiRJkvaYPXWJoCRJkiRNPCdYkiRJkjQmqRr15n7LXusHQJIkSWqpDD9kbhbiNu3Lz6BhLbj0/+4f/pP3wON+0T/+wGOHnt74gPhS6INx48YXLr4U+mDcuPH5x5dCH4wbHzU+biNdIphkd3MXwduT3Jrkj5OM7bLDJGuTHNb1/IokR43r/JIkSZI0TqOuYO2qqpUASQ4GPg78GnDBbE+QZK+q2t0nvBbYDuwEqKrXjdJZSZIkSVpIY1ttqqp7gHXAm9KxNskHpuNJPpfk5Gb7/iTvTrIROCHJu5JsSrI9yVTT/gxgFbC+WSXbL8mGJKuac5yZZFvT5pKu17k/yZ81K2o3JTlkXDlKkiRJ0iBjvYtgVd3ZnPPgIYc+AdheVc+vqq8CH6iq1VX1HGA/4PSq+hSwGTirqlZW1a7pxs1lg5cApwArgdVJXt517puq6hjgK8Drx5agJEmSJA2wELdpn82dOHYDV3U9X5NkY5JtdCZNzx7SfjWwoap+UlUPAeuBE5vYL4DPNds3Ayt+pYPJuiSbk2yempqaRXclSZIkabix3kUwyTPoTJ7uAR7i0RO4fbu2fz79uask+wIfBFZV1V1JLpxxbM+XGhB7sB659/xueuRYVVPA9MyqeMOQV5MkSZKkWRjnHf+eClxG53K/AnYAK5M8JsnhwPF9mk5Ppu5Nsj9wRlfsPuCAHm02AiclOSjJXsCZwA1jSEOSJEmS5m3UFaz9kmwF9qGzYvVR4H1N7Ebge8A2OncC3NLrBFX170k+3By3A9jUFb4SuCzJLuCErjZ3J3kHcD2d1axrquozI+YiSZIkSSPJI1fTtVb5RcNLN74U+mDcuPGFiy+FPhg3bnz+8aXQB+PGR4zP5v4Rc7IQN7mQJEmSpFZygiVJkiRJY9L6SwSTrGvuKthKbc8fHAPzN/825w+Ogfmbf5vzB8fA/MefvytYsG6xO7DI2p4/OAbm325tzx8cA/Nvt7bnD46B+Y+ZEyxJkiRJGhMnWJIkSZI0Jk6woLXXnDbanj84Bubfbm3PHxwD82+3tucPjoH5j1nrb3IhSZIkSePiCpYkSZIkjclETbCSvCTJt5J8J8l5zb4nJ/likm83Pw+cbdu5tF8q+ozBpUn+JcltSf4hyZNm27bZv2zGoF8OTezcJJXkoLm0nYT8k7y52X97kvfMse2yzj/JyiQ3JdmaZHOS42fbttm/nPL/6yT3JNneta81NbBP/q2pf9B7DLpibaiBPfNvUQ3s9R5oUw08PMn1Sb7Z/Ld+a7O/FXVwQP6tqYP9xqArvmfqYFVNxAPYC/gu8AzgscCtwFHAe4DzmmPOAy6ZbdsmNrT9UnkMGINTgb2bYy6Z1DEYksPhwLXA94GD2pQ/sAb4EvC45riDW5b/dcBpzTEvBTZMYv5N/04EjgW2d+1rUw3slX8r6t+gMWj2T3wNHPA70IoaOCD/NtXAQ4Fjm+0DgDto0d+CA/JvTR3sNwbN8z1WBxd9IMY4oCcA13Y9f0fz+BZwaNegf2u2bZvtoe2XymNQHl37XgGsn8QxGJLDp4BjgB193lQTmz/wSeBFI4zdcs//WuBVzb4zgY9PYv5dfV/Bo/+4ak0N7JX/jNjE1r9hY9CGGtgv/7bUwAH5t6oGzsjrM8CL21YHZ+Y/Y18r6mCvMdiTdXCSLhF8OnBX1/MfNvsOqaq7AZqfBwMkOSzJNUPa0q/9EjUoj2l/CHweJnIMeuaQ5GXAv1bVrd0HtyV/4Ejgd5NsTHJDktXQqvzPAS5NchfwXjoFcxLz76dNNXCYSa5/fbWoBvbTlhrYzzm0sAYmWQE8D9hIC+vgjPy7taYOdo/Bnq6De4/e/SUjPfZVv4OraiedpfI5t13CBuaR5HzgIWA9TOQY9MrhccD5dJbHH6Ul+Red9/mBwG8Dq4FPJnlGi/J/I/C2qroqySuBj9D5v9mTlv+ctC3/FtS/npI8nvbUwH7aUgP7aV0NTLI/cBVwTlX9R9Irvcl9D8zMv2t/a+pg9xjQyXmP1sFJWsH6IZ1rK6f9OrAT+HGSQwGan/fMoS2zbL9U9M0jydnA6cBZ1axvzrYty2cMeuXwA+AI4NYkO5p9W5I8bRZtJyH/nc3+q6vj68DDwMwPd05y/mcDVzf7/h7o9QHvSci/nzbVwJ5aUv/6eSbtqYH9tKUG9tOqGphkHzp/WK+vqum8W1MH++TfqjrYYwz2eB2cpAnWJuBZSY5I8ljgD4DPNo+zm2POpnMt5mzbMsv2S0XPPJK8BHg78LKq+q+5tG1iy2UMeuVwdVUdXFUrqmoFnTfPsVX1o1m0nYT8Pwt8GjgFIMmRdD64ee8s28Lyz38ncFJzzCnAt+fQFpZP/v20qQb+ihbVv56qaluLamA/n6YdNbCf1tTAdJaqPgJ8s6re1xVqRR3sl3+b6mCvMViUOrgQHyhbrAedJb476NwB5Pxm31OAL9MpKF8GntzsPwy4ZlDbQe2X6qPPGHyHzjWlW5vHZZM6Bv1y6IrvoPlgY1vyp/PHxMeA7cAW4JSW5f9C4GY6dwPaCBw3wfn/HXA38CCdf0Be26Ya2Cf/1tS/fmMwIz7pNbDX70CbamCv/NtUA19I55Ku27re8y/tl8OkjcGA/FtTB/uNwYxjdrDAdTBNI0mSJEnSiCbpEkFJkiRJWlROsCRJkiRpTJxgSZIkSdKYOMGSJEmSpDFxgiVJkiRJY+IES5IkSZLGxAmWJEmSJI2JEyxJkiRJGhMnWJIkSZI0Jk6wJEmSJGlMnGBJkiRJ0pg4wZIkSZKkMXGCJUlqlSS7k2xNsj3J3yd5fJInJfm/FrtvkqTlzwmWJKltdlXVyqp6DvAL4I+AJwFOsCRJI3OCJUlqs/8P+N+Bi4FnNitbly5ynyRJy9jei90BSZIWQ5K9gdOALwCfB55TVSsXtVOSpGXPFSxJUtvsl2QrsBn4AfCRxe2OJGmSuIIlSWqbXTNXqpIsUlckSZPGFSxJkuA+4IDF7oQkaflzgiVJar2q+jfgxubW7d7kQpI0b6mqxe6DJEmSJE0EV7AkSZIkaUycYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxsQvGgZvoyhJkiS109i/ad4JFoNHtYwvanwp9MG48WEHLPTrr7q5f3zzcQvfvg3v8aU8RuZvfFj8DVP945evg6k39I+vu3wy3sPGjY8SHzcvEZQkSZKkMRk6wUpyfpLbk9yWZGuS5zf7z0ny+Lm+YJK1SQ6bTSzJFUmOmutrSJIkSdJiGDjBSnICcDpwbFUdDbwIuKsJnwPMaYKVZC9gLdBzgjUzVlWvq6pvzOU1JEmSJGmxDFvBOhS4t6oeAKiqe6tqZ5K30JkIXZ/keoAkH0qyuVntumj6BEl2JHlXkq8CZwKrgPXNath+XcedMTOWZEOSVU38/iSXJLk5yZeSHN/E70zysuaYvZJcmmRTs+I24KpjSZIkSRqvYROs64DDk9yR5INJTgKoqr8CdgJrqmpNc+z5VbUKOBo4KcnRXef5eVW9sKo+BmwGzqqqlVW1a/qAqvpUv1jjCcCGqjoOuA/4U+DFwCuAdzfHvBb4WVWtBlYDr09yxBzGQ5IkSZLmbeAEq6ruB44D1gE/AT6RZG2fw1+ZZAtwC/BsoPuzU58Yvav8AvhCs70NuKGqHmy2VzT7TwVek2QrsBF4CvCsmSdKsq5Zbds8NTXg1juSJEmSNAdDb9NeVbuBDcCGJNuAs4Eru49pVonOBVZX1U+TXAns23XIf46hrw9W1fSdFB8Gpi9bfDjJdB4B3lxV1w46UVVNAdMzq/I6QkmSJEnjMOwmF7+ZpHsFaCXw/Wb7PuCAZvuJdCZRP0tyCHDagNN2t5tLbDauBd6YZB+AJEcmecII55MkSZKkWRu2grU/8P4kTwIeAr5D53JB6KwAfT7J3VW1JsktwO3AncCNA855JXBZkl3ACTM+a/Wo2BxzAbiCzuWCW5KEzmWNL5/HeSRJkiRpzgZOsKrqZuAFfWLvB97f9Xxtn+NWzHh+FXBVn2Nnxk7uiu3ftX3hjHb7Nz8fBt7ZPCRJkiRpjxr6RcOSJEmSpNlxgiVJkiRJY5JHbszXWq0fAEmSJKmlMu4TDr1NexsMGtUyvqjxpdAH48YXOj7sgDUb+oevP3nx+z8J7/FRx3ih/xst99+B5d7/SY8P++8zKD59zEUX9o9fcKG/A8aXdnzc5nWJYJLdSbZ2Pc6bY/sdSQ7qsf+dM55/bT79kyRJkqTFMN8VrF1VtXKcHWm8E/jz6SdV1fMOhpIkSZK0FI31JhfNytRFSbYk2Zbkt5r9T0lyXZJbklxOj5W6JBcD+zUrYuubffc3P09OckOSTya5I8nFSc5K8vXmdZ7ZHPfUJFcl2dQ8fmec+UmSJEnSIPOdYE1PhKYfr+qK3VtVxwIfAs5t9l0AfLWqngd8FviNmSesqvNoVsaq6qwer3kM8FbgucCrgSOr6ng6Xy785uaYvwT+oqpWA7/fxCRJkiRpj1iISwSvbn7eDPxes33i9HZV/VOSn87jNTdV1d0ASb4LXNfs3wasabZfBByV/HKB7IlJDqiq++bxepIkSZI0JwvxPVgPND938+gJ3Kg36Xiga/vhrucPd73OY4ATmlWwlVX19F6TqyTrkmxOsnlqamrEbkmSJElSx576ouGvAGcBJDkNOLDPcQ8m2WeE17kOeNP0kyQrex1UVVNVtaqqVq1bt26El5MkSZKkR4zrM1gXDzn+IuDEJFuAU4Ef9DluCrht+iYX8/AWYFWS25J8A/ijeZ5HkiRJkuZsXp/Bqqq9+uxf0bW9GTi52f43OhOraW/r0/7twNu7nu/f/NwAbOjaf3LX9i9jVXUv0H3DDUmSJEnaY/bUJYKSJEmSNPGcYEmSJEnSmKRq1Jv7LXutHwBJkiSppTL8kLmZ7/dgTZRBo1qziP+PK/vH/2bt8BMcsaN/+HsrRu/fYsdHyW9PvMZSGCPjxtsaXwp9MG7c+PzjS6EPxo2PGh83LxGUJEmSpDEZaYKVZHdzm/bbk9ya5I+TjG3SlmRtksO6nl+R5KhxnV+SJEmSxmnUSwR3VdVKgCQHAx8Hfg24YLYnSLJXVe3uE14LbAd2AlTV60bprCRJkiQtpLGtNlXVPcA64E3pWJvkA9PxJJ9LcnKzfX+SdyfZCJyQ5F1JNiXZnmSqaX8GsApY36yS7ZdkQ5JVzTnOTLKtaXNJ1+vcn+TPmhW1m5IcMq4cJUmSJGmQsX4Gq6rubM558JBDnwBsr6rnV9VXgQ9U1eqqeg6wH3B6VX0K2AycVVUrq2rXdOPmssFLgFOAlcDqJC/vOvdNVXUM8BXg9WNLUJIkSZIGWIibXMzmVoe7gau6nq9JsjHJNjqTpmcPab8a2FBVP6mqh4D1wIlN7BfA55rtm4EVv9LBZF2SzUk2T01NzaK7kiRJkjTcWG/TnuQZdCZP9wAP8egJ3L5d2z+f/txVkn2BDwKrququJBfOOLbnSw2IPViPfLnXbnrkWFVTwPTMqt4w5MUkSZIkaTbGece/pwKX0bncr4AdwMokj0lyOHB8n6bTk6l7k+wPnNEVuw84oEebjcBJSQ5KshdwJnDDGNKQJEmSpHkbdQVrvyRbgX3orFh9FHhfE7sR+B6wjc6dALf0OkFV/XuSDzfH7QA2dYWvBC5Lsgs4oavN3UneAVxPZzXrmqr6zIi5SJIkSdJI8sjVdK1Vo3778/+4sn/8b9YOP8ERO/qHv7di8b/detT4KPntiddYCmNk3Hhb40uhD8aNG59/fCn0wbjxEeOzuX/EnCzETS4kSZIkqZWcYEmSJEnSmLT+EsEk65q7CrZS2/MHx8D8zb/N+YNjYP7m3+b8wTEw//Hn7woWrFvsDiyytucPjoH5t1vb8wfHwPzbre35g2Ng/mPmBEuSJEmSxsQJliRJkiSNiRMsaO01p4225w+Ogfm3W9vzB8fA/Nut7fmDY2D+Y9b6m1xIkiRJ0ri4giVJkiRJYzJRE6wkL0nyrSTfSXJes+/JSb6Y5NvNzwNn23Yu7ZeKPmNwaZJ/SXJbkn9I8qTZtm32L5sx6JdDEzs3SSU5aC5tJyH/JG9u9t+e5D1zbLus80+yMslNSbYm2Zzk+Nm2bfYvp/z/Osk9SbZ37WtNDeyTf2vqH/Qeg65YG2pgz/xbVAN7vQfaVAMPT3J9km82/63f2uxvRR0ckH9r6mC/MeiK75k6WFUT8QD2Ar4LPAN4LHArcBTwHuC85pjzgEtm27aJDW2/VB4DxuBUYO/mmEsmdQyG5HA4cC3wfeCgNuUPrAG+BDyuOe7gluV/HXBac8xLgQ2TmH/TvxOBY4HtXfvaVAN75d+K+jdoDJr9E18DB/wOtKIGDsi/TTXwUODYZvsA4A5a9LfggPxbUwf7jUHzfI/VwUUfiDEO6AnAtV3P39E8vgUc2jXo35pt22Z7aPul8hiUR9e+VwDrJ3EMhuTwKeAYYEefN9XE5g98EnjRCGO33PO/FnhVs+9M4OOTmH9X31fw6D+uWlMDe+U/Izax9W/YGLShBvbLvy01cED+raqBM/L6DPDittXBmfnP2NeKOthrDPZkHZykSwSfDtzV9fyHzb5DqupugObnwQBJDktyzZC29Gu/RA3KY9ofAp+HiRyDnjkkeRnwr1V1a/fBbckfOBL43SQbk9yQZDW0Kv9zgEuT3AW8l07BnMT8+2lTDRxmkutfXy2qgf20pQb2cw4trIFJVgDPAzbSwjo4I/9uramD3WOwp+vg3qN3f8lIj33V7+Cq2klnqXzObZewgXkkOR94CFgPEzkGvXJ4HHA+neXxR2lJ/kXnfX4g8NvAauCTSZ7RovzfCLytqq5K8krgI3T+b/ak5T8nbcu/BfWvpySPpz01sJ+21MB+WlcDk+wPXAWcU1X/kfRKb3LfAzPz79rfmjrYPQZ0ct6jdXCSVrB+SOfaymm/DuwEfpzkUIDm5z1zaMss2y8VffNIcjZwOnBWNeubs23L8hmDXjn8ADgCuDXJjmbfliRPm0XbSch/Z7P/6ur4OvAwMPPDnZOc/9nA1c2+vwd6fcB7EvLvp001sKeW1L9+nkl7amA/bamB/bSqBibZh84f1uurajrv1tTBPvm3qg72GIM9XgcnaYK1CXhWkiOSPBb4A+CzzePs5piz6VyLOdu2zLL9UtEzjyQvAd4OvKyq/msubZvYchmDXjlcXVUHV9WKqlpB581zbFX9aBZtJyH/zwKfBk4BSHIknQ9u3jvLtrD8898JnNQccwrw7Tm0heWTfz9tqoG/okX1r6eq2taiGtjPp2lHDeynNTUwnaWqjwDfrKr3dYVaUQf75d+mOthrDBalDi7EB8oW60Fnie8OOncAOb/Z9xTgy3QKypeBJzf7DwOuGdR2UPul+ugzBt+hc03p1uZx2aSOQb8cuuI7aD7Y2Jb86fwx8TFgO7AFOKVl+b8QuJnO3YA2AsdNcP5/B9wNPEjnH5DXtqkG9sm/NfWv3xjMiE96Dez1O9CmGtgr/zbVwBfSuaTrtq73/Ev75TBpYzAg/9bUwX5jMOOYHSxwHUzTSJIkSZI0okm6RFCSJEmSFpUTLEmSJEkaEydYkiRJkjQmTrAkSZIkaUycYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxsQJliRJkiSNiRMsSZIkSRoTJ1iSJEmSNCZOsCRJkiRpTJxgSZImSpK/SHJO1/Nrk1zR9fz/SfLHfdpemeSMZntHkoMWvMOSpIniBEuSNGm+BrwAIMljgIOAZ3fFXwDcuAj9kiS1gBMsSdKkuZFmgkVnYrUduC/JgUkeB/wfwP+ZZFOS7UmmkqTfyZLsl+QLSV6/8F2XJC13TrAkSROlqnYCDyX5DToTrX8GNgInAKuA24APVNXqqnoOsB9wep/T7Q/8I/DxqvrwgndekrTsOcGSJE2i6VWs6QnWP3c9/xqwJsnGJNuAU3j0JYTdPgP8TVX97cJ3WZI0CZxgSZIm0fTnsJ5L5xLBm+isYE1//uqDwBlV9Vzgw8C+fc5zI3DaoEsIJUnq5gRLkjSJbqRz2d//qqrdVfW/gCfRmWT9c3PMvUn2B84YcJ53Af9GZ0ImSdJQTrAkSZNoG527B940Y9/PqupeOqtW24BPA5uGnOscYN8k7xl/NyVJkyZVtdh9kCRJkqSJ4AqWJEmSJI2JEyxJkiRJGhMnWJIkSZI0Jk6wJEmSJGlMnGBJkiRJ0pjsvdgdWAK8jaIkSZLUTmP/InknWAwe1TK+qPGl0AfjxkeNDzvgogv7hy+4cPH773vcuHHjgyx2H4wbH/nf6THzEkFJkiRJGpOhE6wk5ye5PcltSbYmeX6z/5wkj5/rCyZZm+Sw2cSSXJHkqLm+hiRJkiQthoETrCQnAKcDx1bV0cCLgLua8DnAnCZYSfYC1gI9J1gzY1X1uqr6xlxeQ5IkSZIWy7AVrEOBe6vqAYCqureqdiZ5C52J0PVJrgdI8qEkm5vVroumT5BkR5J3JfkqcCawCljfrIbt13XcGTNjSTYkWdXE709ySZKbk3wpyfFN/M4kL2uO2SvJpUk2NStubxjbSEmSJEnSEMMmWNcBhye5I8kHk5wEUFV/BewE1lTVmubY86tqFXA0cFKSo7vO8/OqemFVfQzYDJxVVSuratf0AVX1qX6xxhOADVV1HHAf8KfAi4FXAO9ujnkt8LOqWg2sBl6f5Ig5jIckSZIkzdvACVZV3Q8cB6wDfgJ8IsnaPoe/MskW4Bbg2UD3Z6c+MXpX+QXwhWZ7G3BDVT3YbK9o9p8KvCbJVmAj8BTgWTNPlGRds9q2eWpqagxdkyRJkqRZ3Ka9qnYDG4ANSbYBZwNXdh/TrBKdC6yuqp8muRLYt+uQ/xxDXx+squk7KT4MTF+2+HCS6TwCvLmqrh10oqqaAqZnVuV1hJIkSZLGYdhNLn4zSfcK0Erg+832fcABzfYT6UyifpbkEOC0AaftbjeX2GxcC7wxyT4ASY5M8oQRzidJkiRJszZsBWt/4P1JngQ8BHyHzuWC0FkB+nySu6tqTZJbgNuBO4EbB5zzSuCyJLuAE2Z81upRsTnmAnAFncsFtyQJncsaXz6P80iSJEnSnOWRq+5aqxb726OND7bYfTBufORviB9ywEUX9g9fcOHi99/3uHHjxgdZ7D4YNz5ifNiv+JwN/aJhSZIkSdLsuILV/A9mSZIkSa0z9hWsoXcRbIMlvmzZ6vhS6INx415CuHDxpdAH48aNzz++FPpg3PjI/w6PmZcISpIkSdKYzGuClWR3kq1dj/Pm2H5HkoN67H/njOdfm0//JEmSJGkxzPcSwV1VtXKcHWm8E/jz6SdV9YIFeA1JkiRJWhBjvUSwWZm6KMmWJNuS/Faz/ylJrktyS5LL6XEpZJKLgf2aFbH1zb77m58nJ7khySeT3JHk4iRnJfl68zrPbI57apKrkmxqHr8zzvwkSZIkaZD5TrCmJ0LTj1d1xe6tqmOBDwHnNvsuAL5aVc8DPgv8xswTVtV5NCtjVXVWj9c8Bngr8Fzg1cCRVXU8nS8XfnNzzF8Cf1FVq4Hfb2KSJEmStEcsxCWCVzc/bwZ+r9k+cXq7qv4pyU/n8ZqbqupugCTfBa5r9m8D1jTbLwKOSn65QPbEJAdU1X3dJ0qyDlgHcPnll8O6dfPojiRJkiQ92kLcpv2B5ufuGecf9S6ID3RtP9z1/OGu13kMcEJV7Rp0oqqaAqamn75hxI5JkiRJEuy527R/BTgLIMlpwIF9jnswyT4jvM51wJumnyRZOcK5JEmSJGlOxvUZrIuHHH8RcGKSLcCpwA/6HDcF3DZ9k4t5eAuwKsltSb4B/NE8zyNJkiRJc5aqhfj+4mWlFvvbo40Ptth9MG58wb9BfsgBF13YP3zBhYvff9/jxo23N74U+mDc+IjxYb/ic7anLhGUJEmSpInnBEuSJEmSxsRLBEe/u6EkSZKk5WnslwguxG3al51hn28Y5cLNJXBd6bKOL4U+GDdufOHiS6EPxo0bn398KfTBuPFR4+PmJYKSJEmSNCYjTbCS7G5u0357kluT/HGSsU3akqxNcljX8yuSHDWu80uSJEnSOI16ieCuqloJkORg4OPArwEXzPYESfaqqt19wmuB7cBOgKp63SidlSRJkqSFNLbVpqq6B1gHvCkda5N8YDqe5HNJTm6270/y7iQbgROSvCvJpiTbk0w17c8AVgHrm1Wy/ZJsSLKqOceZSbY1bS7pep37k/xZs6J2U5JDxpWjJEmSJA0y1s9gVdWdzTkPHnLoE4DtVfX8qvoq8IGqWl1VzwH2A06vqk8Bm4GzqmplVe2abtxcNngJcAqwElid5OVd576pqo4BvgK8fmwJSpIkSdIAC3GTi9nc6nA3cFXX8zVJNibZRmfS9Owh7VcDG6rqJ1X1ELAeOLGJ/QL4XLN9M7DiVzqYrEuyOcnmqampWXRXkiRJkoYb623akzyDzuTpHuAhHj2B27dr++fTn7tKsi/wQWBVVd2V5MIZx/Z8qQGxB+uRL/faTY8cq2oKmJ5Z1aDbtEuSJEnSbI3zjn9PBS6jc7lfATuAlUkek+Rw4Pg+TacnU/cm2R84oyt2H3BAjzYbgZOSHJRkL+BM4IYxpCFJkiRJ8zbqCtZ+SbYC+9BZsfoo8L4mdiPwPWAbnTsBbul1gqr69yQfbo7bAWzqCl8JXJZkF3BCV5u7k7wDuJ7OatY1VfWZEXORJEmSpJHkkavpWmvgJYIXXMjQr39e7G+fnuT4UuiDcePGFy6+FPpg3Ljx+ceXQh+MGx8xPpv7R8zJQtzkQpIkSZJayQmWJEmSJI1J6y8RTLKuuatgK7U9f3AMzN/825w/OAbmb/5tzh8cA/Mff/6uYMG6xe7AImt7/uAYmH+7tT1/cAzMv93anj84BuY/Zk6wJEmSJGlMnGBJkiRJ0pg4wYLWXnPaaHv+4BiYf7u1PX9wDMy/3dqePzgG5j9mrb/JhSRJkiSNiytYkiRJkjQmEzXBSvKSJN9K8p0k5zX7npzki0m+3fw8cLZt59J+qegzBpcm+ZcktyX5hyRPmm3bZv+yGYN+OTSxc5NUkoPm0nYS8k/y5mb/7UneM8e2yzr/JCuT3JRka5LNSY6fbdtm/3LK/6+T3JNke9e+1tTAPvm3pv5B7zHoirWhBvbMv0U1sNd7oE018PAk1yf5ZvPf+q3N/lbUwQH5t6YO9huDrvieqYNVNREPYC/gu8AzgMcCtwJHAe8BzmuOOQ+4ZLZtm9jQ9kvlMWAMTgX2bo65ZFLHYEgOhwPXAt8HDmpT/sAa4EvA45rjDm5Z/tcBpzXHvBTYMIn5N/07ETgW2N61r001sFf+rah/g8ag2T/xNXDA70ArauCA/NtUAw8Fjm22DwDuoEV/Cw7IvzV1sN8YNM/3WB1c9IEY44CeAFzb9fwdzeNbwKFdg/6t2bZttoe2XyqPQXl07XsFsH4Sx2BIDp8CjgF29HlTTWz+wCeBF40wdss9/2uBVzX7zgQ+Pon5d/V9BY/+46o1NbBX/jNiE1v/ho1BG2pgv/zbUgMH5N+qGjgjr88AL25bHZyZ/4x9raiDvcZgT9bBSbpE8OnAXV3Pf9jsO6Sq7gZofh4MkOSwJNcMaUu/9kvUoDym/SHweZjIMeiZQ5KXAf9aVbd2H9yW/IEjgd9NsjHJDUlWQ6vyPwe4NMldwHvpFMxJzL+fNtXAYSa5/vXVohrYT1tqYD/n0MIamGQF8DxgIy2sgzPy79aaOtg9Bnu6Du49eveXjPTYV/0OrqqddJbK59x2CRuYR5LzgYeA9TCRY9Arh8cB59NZHn+UluRfdN7nBwK/DawGPpnkGS3K/43A26rqqiSvBD5C5/9mT1r+c9K2/FtQ/3pK8njaUwP7aUsN7Kd1NTDJ/sBVwDlV9R9Jr/Qm9z0wM/+u/a2pg91jQCfnPVoHJ2kF64d0rq2c9uvATuDHSQ4FaH7eM4e2zLL9UtE3jyRnA6cDZ1WzvjnbtiyfMeiVww+AI4Bbk+xo9m1J8rRZtJ2E/Hc2+6+ujq8DDwMzP9w5yfmfDVzd7Pt7oNcHvCch/37aVAN7akn96+eZtKcG9tOWGthPq2pgkn3o/GG9vqqm825NHeyTf6vqYI8x2ON1cJImWJuAZyU5IsljgT8APts8zm6OOZvOtZizbcss2y8VPfNI8hLg7cDLquq/5tK2iS2XMeiVw9VVdXBVraiqFXTePMdW1Y9m0XYS8v8s8GngFIAkR9L54Oa9s2wLyz//ncBJzTGnAN+eQ1tYPvn306Ya+CtaVP96qqptLaqB/XyadtTAflpTA9NZqvoI8M2qel9XqBV1sF/+baqDvcZgUergQnygbLEedJb47qBzB5Dzm31PAb5Mp6B8GXhys/8w4JpBbQe1X6qPPmPwHTrXlG5tHpdN6hj0y6ErvoPmg41tyZ/OHxMfA7YDW4BTWpb/C4Gb6dwNaCNw3ATn/3fA3cCDdP4BeW2bamCf/FtT//qNwYz4pNfAXr8DbaqBvfJvUw18IZ1Lum7res+/tF8OkzYGA/JvTR3sNwYzjtnBAtfBNI0kSZIkSSOapEsEJUmSJGlROcGSJEmSpDFxgiVJkiRJY+IES5IkSZLGxAmWJEmSJI2JEyxJkiRJGhMnWJIkSZI0Jk6wJEmSJGlM/n9Pd0Ir7C7uzgAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 864x259.2 with 3 Axes>"
       ]
@@ -4153,7 +3427,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAD8CAYAAABq+gXNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtIUlEQVR4nO3df5BlVX33+/dHQEDBiCIIhtxBryQXFUaYwWAMMJRyxeLxakJpKEqZJ+oYb/kDU+QRpUrASlIiPqYSLYUWEyo65mqEqDEoqJfBK4ZxhmFgBo2oOIoZFMljDCQjwvC9f5zdcmjPj+4+p6e7z36/qk71Pvu71z7ru+jznV6sffZJVSFJkiRJGt1jFrsDkiRJkjQpnGBJkiRJ0pg4wZIkSZKkMXGCJUmSJElj4gRLkiRJksbECZYkSZIkjYkTLEnSREnyF0nO7Xp+bZIrup7/zyR/3KftlUnObLZ3JDl4wTssSZooTrAkSZPma8DzAZI8BjgYeFZX/PnAjYvQL0lSCzjBkiRNmhtpJlh0JlbbgfuSHJRkX+D/AP7PJJuSbE8ylST9TpZk/yRfSPK6he+6JGm5c4IlSZooVbUTeCjJb9CZaP0zsBE4EVgF3AZ8oKpWV9Wzgf2BM/qc7gDgH4GPV9WHF7zzkqRlzwmWJGkSTa9iTU+w/rnr+deANUk2JtkGnMqjLyHs9hngb6rqbxe+y5KkSeAES5I0iaY/h/UcOpcI3kRnBWv681cfBM6squcAHwb263OeG4HTB11CKElSNydYkqRJdCOdy/7+V1Xtrqr/BTyRziTrn5tj7k1yAHDmgPO8E/g3OhMySZKGcoIlSZpE2+jcPfCmGft+VlX30lm12gZ8Gtg05FznAvslec/4uylJmjSpqsXugyRJkiRNBFewJEmSJGlMnGBJkiRJ0pg4wZIkSZKkMXGCJUmSJElj4gRLkiRJksZk78XuwBLgbRQlSZKkdhr7F8k7wWLwqJbxRY0vhT4YNz5qfNgBF1/UP3zhRYvff9/jxo0bH2Sx+2Dc+Mj/To+ZlwhKkiRJ0pgMnWAluSDJ7UluS7I1yfOa/ecmedxcXzDJ2iSHzyaW5IokR8/1NSRJkiRpMQycYCU5ETgDOK6qjgFeCNzVhM8F5jTBSrIXsBboOcGaGauq11bVN+byGpIkSZK0WIatYB0G3FtVDwBU1b1VtTPJm+lMhK5Pcj1Akg8l2dysdl08fYIkO5K8M8lXgbOAVcD6ZjVs/67jzpwZS7Ihyaomfn+SS5LcnORLSU5o4ncmeWlzzF5JLk2yqVlxe/3YRkqSJEmShhg2wboOOCLJHUk+mORkgKr6K2AnsKaq1jTHXlBVq4BjgJOTHNN1np9X1Quq6mPAZuDsqlpZVbumD6iqT/WLNR4PbKiq44H7gD8FXgS8HHhXc8xrgJ9V1WpgNfC6JEfOYTwkSZIkad4GTrCq6n7geGAd8BPgE0nW9jn8FUm2ALcAzwK6Pzv1idG7yi+ALzTb24AbqurBZntFs/804NVJtgIbgScDz5x5oiTrmtW2zVNTU2PomiRJkiTN4jbtVbUb2ABsSLINOAe4svuYZpXoPGB1Vf00yZXAfl2H/OcY+vpgVU3fSfFhYPqyxYeTTOcR4E1Vde2gE1XVFDA9syqvI5QkSZI0DsNucvGbSbpXgFYC32+27wMObLafQGcS9bMkhwKnDzhtd7u5xGbjWuANSfYBSHJUksePcD5JkiRJmrVhK1gHAO9P8kTgIeA7dC4XhM4K0OeT3F1Va5LcAtwO3AncOOCcVwKXJdkFnDjjs1aPis0xF4Ar6FwuuCVJ6FzW+LJ5nEeSJEmS5iyPXHXXWrXY3x5tfLDF7oNx4yN/Q/yQAy6+qH/4wosWv/++x40bNz7IYvfBuPER48N+xeds6BcNS5IkSZJmxwmWJEmSJI2Jlwg2V/BIkiRJap2xXyI49DbtbbDErwttdXwp9MG4cT+jtXDxpdAH48aNzz++FPpg3PjI/w6PmZcISpIkSdKYzGuClWR3kq1dj/Pn2H5HkoN77H/HjOdfm0//JEmSJGkxzPcSwV1VtXKcHWm8A/jz6SdV9fwFeA1JkiRJWhBjvUSwWZm6OMmWJNuS/Faz/8lJrktyS5LL6XEpZJJ3A/s3K2Lrm333Nz9PSXJDkk8muSPJu5OcneTrzes8oznuKUmuSrKpefzOOPOTJEmSpEHmO8GanghNP17ZFbu3qo4DPgSc1+y7EPhqVT0X+CzwGzNPWFXn06yMVdXZPV7zWOAtwHOAVwFHVdUJwBXAm5pj/hL4i6paDfx+E5MkSZKkPWIhLhG8uvl5M/B7zfZJ09tV9U9JfjqP19xUVXcDJPkucF2zfxuwptl+IXB08ssFsickObCq7us+UZJ1wDqAyy+/HNatm0d3JEmSJOnRFuI27Q80P3fPOP+od0F8oGv74a7nD3e9zmOAE6tq16ATVdUUMDX99PUjdkySJEmSYM/dpv0rwNkASU4HDupz3INJ9hnhda4D3jj9JMnKEc4lSZIkSXMyrs9gvXvI8RcDJyXZApwG/KDPcVPAbdM3uZiHNwOrktyW5BvAH83zPJIkSZI0Z6laiO8vXlZqsb892vhgi90H48YX/Bvkhxxw8UX9wxdetPj99z1u3Hh740uhD8aNjxgf9is+Z3vqEkFJkiRJmnhOsCRJkiRpTLxEcPS7G0qSJElansZ+ieBC3KZ92Rn2+YZRLtxcAteVLuv4UuiDcePGFy6+FPpg3Ljx+ceXQh+MGx81Pm4jXSKYZHdzF8Hbk9ya5I+TjO2ywyRrkxze9fyKJEeP6/ySJEmSNE6jrmDtqqqVAEkOAT4O/Bpw4WxPkGSvqtrdJ7wW2A7sBKiq147SWUmSJElaSGNbbaqqe4B1wBvTsTbJB6bjST6X5JRm+/4k70qyETgxyTuTbEqyPclU0/5MYBWwvlkl2z/JhiSrmnOclWRb0+aSrte5P8mfNStqNyU5dFw5SpIkSdIgY72LYFXd2ZzzkCGHPh7YXlXPq6qvAh+oqtVV9Wxgf+CMqvoUsBk4u6pWVtWu6cbNZYOXAKcCK4HVSV7Wde6bqupY4CvA68aWoCRJkiQNsBC3aZ/NnTh2A1d1PV+TZGOSbXQmTc8a0n41sKGqflJVDwHrgZOa2C+AzzXbNwMrfqWDybokm5NsnpqamkV3JUmSJGm4sd5FMMnT6Uye7gEe4tETuP26tn8+/bmrJPsBHwRWVdVdSS6acWzPlxoQe7Aeuff8bnrkWFVTwPTMqgbdRVCSJEmSZmucd/x7CnAZncv9CtgBrEzymCRHACf0aTo9mbo3yQHAmV2x+4ADe7TZCJyc5OAkewFnATeMIQ1JkiRJmrdRV7D2T7IV2IfOitVHgfc1sRuB7wHb6NwJcEuvE1TVvyf5cHPcDmBTV/hK4LIku4ATu9rcneTtwPV0VrOuqarPjJiLJEmSJI0kj1xN11oDLxH0i4b9AkPjxo0vXHwp9MG4cePzjy+FPhg3PmJ8NvePmJOFuMmFJEmSJLWSEyxJkiRJGpPWXyKYZF1zV8FWanv+4BiYv/m3OX9wDMzf/NucPzgG5j/+/F3BgnWL3YFF1vb8wTEw/3Zre/7gGJh/u7U9f3AMzH/MnGBJkiRJ0pg4wZIkSZKkMXGCBa295rTR9vzBMTD/dmt7/uAYmH+7tT1/cAzMf8xaf5MLSZIkSRoXV7AkSZIkaUwmaoKV5MVJvpXkO0nOb/Y9KckXk3y7+XnQbNvOpf1S0WcMLk3yL0luS/IPSZ4427bN/mUzBv1yaGLnJakkB8+l7STkn+RNzf7bk7xnjm2Xdf5JVia5KcnWJJuTnDDbts3+5ZT/Xye5J8n2rn2tqYF98m9N/YPeY9AVa0MN7Jl/i2pgr/dAm2rgEUmuT/LN5r/1W5r9raiDA/JvTR3sNwZd8T1TB6tqIh7AXsB3gacDjwVuBY4G3gOc3xxzPnDJbNs2saHtl8pjwBicBuzdHHPJpI7BkByOAK4Fvg8c3Kb8gTXAl4B9m+MOaVn+1wGnN8e8BNgwifk3/TsJOA7Y3rWvTTWwV/6tqH+DxqDZP/E1cMDvQCtq4ID821QDDwOOa7YPBO6gRX8LDsi/NXWw3xg0z/dYHVz0gRjjgJ4IXNv1/O3N41vAYV2D/q3Ztm22h7ZfKo9BeXTtezmwfhLHYEgOnwKOBXb0eVNNbP7AJ4EXjjB2yz3/a4FXNvvOAj4+ifl39X0Fj/7jqjU1sFf+M2ITW/+GjUEbamC//NtSAwfk36oaOCOvzwAvalsdnJn/jH2tqIO9xmBP1sFJukTwacBdXc9/2Ow7tKruBmh+HgKQ5PAk1wxpS7/2S9SgPKb9IfB5mMgx6JlDkpcC/1pVt3Yf3Jb8gaOA302yMckNSVZDq/I/F7g0yV3Ae+kUzEnMv5821cBhJrn+9dWiGthPW2pgP+fSwhqYZAXwXGAjLayDM/Lv1po62D0Ge7oO7j1695eM9NhX/Q6uqp10lsrn3HYJG5hHkguAh4D1MJFj0CuHfYEL6CyPP0pL8i867/ODgN8GVgOfTPL0FuX/BuCtVXVVklcAH6Hzf7MnLf85aVv+Lah/PSV5HO2pgf20pQb207oamOQA4Crg3Kr6j6RXepP7HpiZf9f+1tTB7jGgk/MerYOTtIL1QzrXVk77dWAn8OMkhwE0P++ZQ1tm2X6p6JtHknOAM4Czq1nfnG1bls8Y9MrhB8CRwK1JdjT7tiR56izaTkL+O5v9V1fH14GHgZkf7pzk/M8Brm72/T3Q6wPek5B/P22qgT21pP718wzaUwP7aUsN7KdVNTDJPnT+sF5fVdN5t6YO9sm/VXWwxxjs8To4SROsTcAzkxyZ5LHAHwCfbR7nNMecQ+dazNm2ZZbtl4qeeSR5MfA24KVV9V9zadvElssY9Mrh6qo6pKpWVNUKOm+e46rqR7NoOwn5fxb4NHAqQJKj6Hxw895ZtoXln/9O4OTmmFOBb8+hLSyf/PtpUw38FS2qfz1V1bYW1cB+Pk07amA/ramB6SxVfQT4ZlW9ryvUijrYL/821cFeY7AodXAhPlC2WA86S3x30LkDyAXNvicDX6ZTUL4MPKnZfzhwzaC2g9ov1UefMfgOnWtKtzaPyyZ1DPrl0BXfQfPBxrbkT+ePiY8B24EtwKkty/8FwM107ga0ETh+gvP/O+Bu4EE6/4C8pk01sE/+ral//cZgRnzSa2Cv34E21cBe+bepBr6AziVdt3W951/SL4dJG4MB+bemDvYbgxnH7GCB62CaRpIkSZKkEU3SJYKSJEmStKicYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxsQJliRJkiSNiRMsSZIkSRoTJ1iSJEmSNCZOsCRJkiRpTJxgSZIkSdKYOMGSJEmSpDFxgiVJkiRJY+IES5LUKkl2J9maZHuSv0/yuCRPTPJ/L3bfJEnLnxMsSVLb7KqqlVX1bOAXwB8BTwScYEmSRuYES5LUZv8f8L8D7wae0axsXbrIfZIkLWN7L3YHJElaDEn2Bk4HvgB8Hnh2Va1c1E5JkpY9V7AkSW2zf5KtwGbgB8BHFrc7kqRJ4gqWJKltds1cqUqySF2RJE0aV7AkSYL7gAMXuxOSpOXPCZYkqfWq6t+AG5tbt3uTC0nSvKWqFrsPkiRJkjQRXMGSJEmSpDFxgiVJkiRJY+IES5IkSZLGxAmWJEmSJI2JEyxJkiRJGhO/aBi8jaIkSZLUTmP/pnknWAwe1TK+qPGl0AfjxocdsNCvv+rm/vHNxy98+za8x5fyGJm/8WHx10/1j1++DqZe3z++7vLJeA8bNz5KfNy8RFCSJEmSxmToBCvJBUluT3Jbkq1JntfsPzfJ4+b6gknWJjl8NrEkVyQ5eq6vIUmSJEmLYeAEK8mJwBnAcVV1DPBC4K4mfC4wpwlWkr2AtUDPCdbMWFW9tqq+MZfXkCRJkqTFMmwF6zDg3qp6AKCq7q2qnUneTGcidH2S6wGSfCjJ5ma16+LpEyTZkeSdSb4KnAWsAtY3q2H7dx135sxYkg1JVjXx+5NckuTmJF9KckITvzPJS5tj9kpyaZJNzYrbgKuOJUmSJGm8hk2wrgOOSHJHkg8mORmgqv4K2Amsqao1zbEXVNUq4Bjg5CTHdJ3n51X1gqr6GLAZOLuqVlbVrukDqupT/WKNxwMbqup44D7gT4EXAS8H3tUc8xrgZ1W1GlgNvC7JkXMYD0mSJEmat4ETrKq6HzgeWAf8BPhEkrV9Dn9Fki3ALcCzgO7PTn1i9K7yC+ALzfY24IaqerDZXtHsPw14dZKtwEbgycAzZ54oybpmtW3z1NSAW+9IkiRJ0hwMvU17Ve0GNgAbkmwDzgGu7D6mWSU6D1hdVT9NciWwX9ch/zmGvj5YVdN3UnwYmL5s8eEk03kEeFNVXTvoRFU1BUzPrMrrCCVJkiSNw7CbXPxmku4VoJXA95vt+4ADm+0n0JlE/SzJocDpA07b3W4usdm4FnhDkn0AkhyV5PEjnE+SJEmSZm3YCtYBwPuTPBF4CPgOncsFobMC9Pkkd1fVmiS3ALcDdwI3DjjnlcBlSXYBJ874rNWjYnPMBeAKOpcLbkkSOpc1vmwe55EkSZKkORs4waqqm4Hn94m9H3h/1/O1fY5bMeP5VcBVfY6dGTulK3ZA1/ZFM9od0Px8GHhH85AkSZKkPWroFw1LkiRJkmbHCZYkSZIkjUkeuTFfa7V+ACRJkqSWyrhPOPQ27W0waFTL+KLGl0IfjBtf6PiwA9Zs6B++/pTF7/8kvMdHHeOF/m+03H8Hlnv/Jz0+7L/PoPj0MRdf1D9+4UX+Dhhf2vFxm9clgkl2J9na9Th/ju13JDm4x/53zHj+tfn0T5IkSZIWw3xXsHZV1cpxdqTxDuDPp59UVc87GEqSJEnSUjTWm1w0K1MXJ9mSZFuS32r2PznJdUluSXI5PVbqkrwb2L9ZEVvf7Lu/+XlKkhuSfDLJHUneneTsJF9vXucZzXFPSXJVkk3N43fGmZ8kSZIkDTLfCdb0RGj68cqu2L1VdRzwIeC8Zt+FwFer6rnAZ4HfmHnCqjqfZmWsqs7u8ZrHAm8BngO8Cjiqqk6g8+XCb2qO+UvgL6pqNfD7TUySJEmS9oiFuETw6ubnzcDvNdsnTW9X1T8l+ek8XnNTVd0NkOS7wHXN/m3Ammb7hcDRyS8XyJ6Q5MCqum8erydJkiRJc7IQ34P1QPNzN4+ewI16k44HurYf7nr+cNfrPAY4sVkFW1lVT+s1uUqyLsnmJJunpqZG7JYkSZIkdeypLxr+CnA2QJLTgYP6HPdgkn1GeJ3rgDdOP0mystdBVTVVVauqatW6detGeDlJkiRJesS4PoP17iHHXwyclGQLcBrwgz7HTQG3Td/kYh7eDKxKcluSbwB/NM/zSJIkSdKczeszWFW1V5/9K7q2NwOnNNv/RmdiNe2tfdq/DXhb1/MDmp8bgA1d+0/p2v5lrKruBbpvuCFJkiRJe8yeukRQkiRJkiaeEyxJkiRJGpNUjXpzv2Wv9QMgSZIktVSGHzI38/0erIkyaFRrFvH/fmX/+N+sHX6CI3f0D39vxej9W+z4KPntiddYCmNk3Hhb40uhD8aNG59/fCn0wbjxUePj5iWCkiRJkjQmI02wkuxubtN+e5Jbk/xxkrFN2pKsTXJ41/Mrkhw9rvNLkiRJ0jiNeongrqpaCZDkEODjwK8BF872BEn2qqrdfcJrge3AToCqeu0onZUkSZKkhTS21aaqugdYB7wxHWuTfGA6nuRzSU5ptu9P8q4kG4ETk7wzyaYk25NMNe3PBFYB65tVsv2TbEiyqjnHWUm2NW0u6Xqd+5P8WbOidlOSQ8eVoyRJkiQNMtbPYFXVnc05Dxly6OOB7VX1vKr6KvCBqlpdVc8G9gfOqKpPAZuBs6tqZVXtmm7cXDZ4CXAqsBJYneRlXee+qaqOBb4CvG5sCUqSJEnSAAtxk4vZ3OpwN3BV1/M1STYm2UZn0vSsIe1XAxuq6idV9RCwHjipif0C+FyzfTOw4lc6mKxLsjnJ5qmpqVl0V5IkSZKGG+tt2pM8nc7k6R7gIR49gduva/vn05+7SrIf8EFgVVXdleSiGcf2fKkBsQfrkS/32k2PHKtqCpieWdXrh7yYJEmSJM3GOO/49xTgMjqX+xWwA1iZ5DFJjgBO6NN0ejJ1b5IDgDO7YvcBB/ZosxE4OcnBSfYCzgJuGEMakiRJkjRvo65g7Z9kK7APnRWrjwLva2I3At8DttG5E+CWXieoqn9P8uHmuB3Apq7wlcBlSXYBJ3a1uTvJ24Hr6axmXVNVnxkxF0mSJEkaSR65mq61atRvf/7vV/aP/83a4Sc4ckf/8PdWLP63W48aHyW/PfEaS2GMjBtva3wp9MG4cePzjy+FPhg3PmJ8NvePmJOFuMmFJEmSJLWSEyxJkiRJGpPWXyKYZF1zV8FWanv+4BiYv/m3OX9wDMzf/NucPzgG5j/+/F3BgnWL3YFF1vb8wTEw/3Zre/7gGJh/u7U9f3AMzH/MnGBJkiRJ0pg4wZIkSZKkMXGCBa295rTR9vzBMTD/dmt7/uAYmH+7tT1/cAzMf8xaf5MLSZIkSRoXV7AkSZIkaUwmaoKV5MVJvpXkO0nOb/Y9KckXk3y7+XnQbNvOpf1S0WcMLk3yL0luS/IPSZ4427bN/mUzBv1yaGLnJakkB8+l7STkn+RNzf7bk7xnjm2Xdf5JVia5KcnWJJuTnDDbts3+5ZT/Xye5J8n2rn2tqYF98m9N/YPeY9AVa0MN7Jl/i2pgr/dAm2rgEUmuT/LN5r/1W5r9raiDA/JvTR3sNwZd8T1TB6tqIh7AXsB3gacDjwVuBY4G3gOc3xxzPnDJbNs2saHtl8pjwBicBuzdHHPJpI7BkByOAK4Fvg8c3Kb8gTXAl4B9m+MOaVn+1wGnN8e8BNgwifk3/TsJOA7Y3rWvTTWwV/6tqH+DxqDZP/E1cMDvQCtq4ID821QDDwOOa7YPBO6gRX8LDsi/NXWw3xg0z/dYHVz0gRjjgJ4IXNv1/O3N41vAYV2D/q3Ztm22h7ZfKo9BeXTtezmwfhLHYEgOnwKOBXb0eVNNbP7AJ4EXjjB2yz3/a4FXNvvOAj4+ifl39X0Fj/7jqjU1sFf+M2ITW/+GjUEbamC//NtSAwfk36oaOCOvzwAvalsdnJn/jH2tqIO9xmBP1sFJukTwacBdXc9/2Ow7tKruBmh+HgKQ5PAk1wxpS7/2S9SgPKb9IfB5mMgx6JlDkpcC/1pVt3Yf3Jb8gaOA302yMckNSVZDq/I/F7g0yV3Ae+kUzEnMv5821cBhJrn+9dWiGthPW2pgP+fSwhqYZAXwXGAjLayDM/Lv1po62D0Ge7oO7j1695eM9NhX/Q6uqp10lsrn3HYJG5hHkguAh4D1MJFj0CuHfYEL6CyPP0pL8i867/ODgN8GVgOfTPL0FuX/BuCtVXVVklcAH6Hzf7MnLf85aVv+Lah/PSV5HO2pgf20pQb207oamOQA4Crg3Kr6j6RXepP7HpiZf9f+1tTB7jGgk/MerYOTtIL1QzrXVk77dWAn8OMkhwE0P++ZQ1tm2X6p6JtHknOAM4Czq1nfnG1bls8Y9MrhB8CRwK1JdjT7tiR56izaTkL+O5v9V1fH14GHgZkf7pzk/M8Brm72/T3Q6wPek5B/P22qgT21pP718wzaUwP7aUsN7KdVNTDJPnT+sF5fVdN5t6YO9sm/VXWwxxjs8To4SROsTcAzkxyZ5LHAHwCfbR7nNMecQ+dazNm2ZZbtl4qeeSR5MfA24KVV9V9zadvElssY9Mrh6qo6pKpWVNUKOm+e46rqR7NoOwn5fxb4NHAqQJKj6Hxw895ZtoXln/9O4OTmmFOBb8+hLSyf/PtpUw38FS2qfz1V1bYW1cB+Pk07amA/ramB6SxVfQT4ZlW9ryvUijrYL/821cFeY7AodXAhPlC2WA86S3x30LkDyAXNvicDX6ZTUL4MPKnZfzhwzaC2g9ov1UefMfgOnWtKtzaPyyZ1DPrl0BXfQfPBxrbkT+ePiY8B24EtwKkty/8FwM107ga0ETh+gvP/O+Bu4EE6/4C8pk01sE/+ral//cZgRnzSa2Cv34E21cBe+bepBr6AziVdt3W951/SL4dJG4MB+bemDvYbgxnH7GCB62CaRpIkSZKkEU3SJYKSJEmStKicYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxsQJliRJkiSNiRMsSZIkSRoTJ1iSJEmSNCZOsCRJkiRpTJxgSZIkSdKYOMGSJEmSpDFxgiVJkiRJY+IES5I08ZI8Ncn/k+S7Sb6R5JokRy12vyRJk8cJliRpoiUJ8A/Ahqp6RlUdDbwDOHQ2bZP4b6Ukadb8R0OSNOnWAA9W1WXTO6pqK3BLki8n2ZJkW5L/CyDJiiTfTPJBYAtwxKL0WpK0LKWqFrsPkiQtmCRvBo6sqrfO2L838Liq+o8kBwM3Ac8E/jfgTuD5VXXTHu+wJGlZ23uxOyBJ0iIJ8OdJTgIeBp7GI5cNft/JlSRpPrxEUJI06W4Hju+x/2zgKcDxVbUS+DGwXxP7zz3TNUnSpHGCJUmadP8vsG+S103vSLKazqWA91TVg0nWNM8lSRqJEyxJ0kSrzoeNXw68qLlN++3ARcA1wKokm+msZv3L4vVSkjQpvMmFJEmSJI2JK1iSJEmSNCZOsCRJkiRpTJxgSZIkSdKYOMGSJEmSpDFxgiVJkiRJY7L3YndgCfA2ipIkSVI7ZdwndILF4FEt44saXwp9mIT4sbf1j996DDz1x/3jPzp08fv/J+/tH7/0vMXv36jjv9j9GxZfyN+P2fbh1R/tH//bV43ex2HnHzX+xdP6x1903ei/I6OOz7D32LD+jRofluCPn9o/fOiPhuc/bPxO+2L/+HUvGr2GvvdP+sfPu3T0399Rx3+U//7T5/joq/vHX/W3i1/HlnIdHMe/E8P6t9A1dLnHx81LBCVJkiRpTIZOsJJckOT2JLcl2Zrkec3+c5M8bq4vmGRtksNnE0tyRZKj5/oakiRJkrQYBk6wkpwInAEcV1XHAC8E7mrC5wJzmmAl2QtYC/ScYM2MVdVrq+obc3kNSZIkSVosw1awDgPuraoHAKrq3qrameTNdCZC1ye5HiDJh5Jsbla7Lp4+QZIdSd6Z5KvAWcAqYH2zGrZ/13Fnzowl2ZBkVRO/P8klSW5O8qUkJzTxO5O8tDlmrySXJtnUrLi9fmwjJUmSJElDDJtgXQcckeSOJB9McjJAVf0VsBNYU1VrmmMvqKpVwDHAyUmO6TrPz6vqBVX1MWAzcHZVrayqXdMHVNWn+sUajwc2VNXxwH3AnwIvAl4OvKs55jXAz6pqNbAaeF2SI+cwHpIkSZI0bwMnWFV1P3A8sA74CfCJJGv7HP6KJFuAW4BnAd2fnfrE6F3lF8AXmu1twA1V9WCzvaLZfxrw6iRbgY3Ak4FnzjxRknXNatvmqampMXRNkiRJkmZxm/aq2g1sADYk2QacA1zZfUyzSnQesLqqfprkSmC/rkP+cwx9fbCqpu+k+DAwfdniw0mm8wjwpqq6dtCJqmoKmJ5ZldcRSpIkSRqHYTe5+M0k3StAK4HvN9v3AQc220+gM4n6WZJDgdMHnLa73Vxis3Et8IYk+wAkOSrJ40c4nyRJkiTN2rAVrAOA9yd5IvAQ8B06lwtCZwXo80nurqo1SW4BbgfuBG4ccM4rgcuS7AJOnPFZq0fF5pgLwBV0LhfckiR0Lmt82TzOI0mSJElzNnCCVVU3A8/vE3s/8P6u52v7HLdixvOrgKv6HDszdkpX7ICu7YtmtDug+fkw8I7mIUmSJEl71NAvGpYkSZIkzU4euW9Ea7V+ACRJkqSWyrhPOPQugm0waFTL+KLGl0IfJiG+6ub+8c3Hw+F394/vPGzx+z9q/OKL+scvvGjxx3+xx2dYfCF/P2bbh9cP+EaNy9ctfA7DXn/Y79h/+1z/+D+eATev6h8/fvPov0PD+jfs/MP6P6z9sPjUgNv5rrucoQl+7r/1D5/xj8P/+43a/1F//4b1f9Tf32H//UaJTx8z6ntksevcYtbB2Zx/1NcfNv6T/nfAsPi4eYmgJEmSJI3JvCZYSXYn2dr1OH+O7XckObjH/nfMeP61+fRPkiRJkhbDfC8R3FVVK8fZkcY7gD+fflJVPe9gKEmSJElL0VgvEWxWpi5OsiXJtiS/1ex/cpLrktySpOfV1EneDezfrIitb/bd3/w8JckNST6Z5I4k705ydpKvN6/zjOa4pyS5Ksmm5vE748xPkiRJkgaZ7wRreiI0/XhlV+zeqjoO+BBwXrPvQuCrVfVc4LPAb8w8YVWdT7MyVlVn93jNY4G3AM8BXgUcVVUn0Ply4Tc1x/wl8BdVtRr4/SYmSZIkSXvEQlwieHXz82bg95rtk6a3q+qfkvx0Hq+5qaruBkjyXeC6Zv82YE2z/ULg6OSXC2RPSHJgVd3XfaIk64B1AJdffjmsWzeP7kiSJEnSoy3EbdofaH7unnH+Ue+C+EDX9sNdzx/uep3HACdW1a5BJ6qqKWD6hqI14O6wkiRJkjRre+o27V8BzgZIcjpwUJ/jHkyyzwivcx3wxuknSVaOcC5JkiRJmpNxfQbr3UOOvxg4KckW4DTgB32OmwJum77JxTy8GViV5LYk3wD+aJ7nkSRJkqQ5m9clglW1V5/9K7q2NwOnNNv/RmdiNe2tfdq/DXhb1/MDmp8bgA1d+0/p2v5lrKruBbpvuCFJkiRJe8yeukRQkiRJkiaeEyxJkiRJGpNUjXpzv2Wv9QMgSZIktVSGHzI3C3Gb9uVn0LAWXPo/+of/5D2w7y/6xx947NDTGx8QXwp9MG7c+MLFl0IfjBs3Pv/4UuiDceOjxsfNSwQlSZIkaUxGmmAl2d3cpv32JLcm+eMkY5u0JVmb5PCu51ckOXpc55ckSZKkcRr1EsFdVbUSIMkhwMeBXwMunO0JkuxVVbv7hNcC24GdAFX12lE6K0mSJEkLaWyrTVV1D7AOeGM61ib5wHQ8yeeSnNJs35/kXUk2AicmeWeSTUm2J5lq2p8JrALWN6tk+yfZkGRVc46zkmxr2lzS9Tr3J/mzZkXtpiSHjitHSZIkSRpkrJ/Bqqo7m3MeMuTQxwPbq+p5VfVV4ANVtbqqng3sD5xRVZ8CNgNnV9XKqto13bi5bPAS4FRgJbA6ycu6zn1TVR0LfAV43dgSlCRJkqQBFuImF7O51eFu4Kqu52uSbEyyjc6k6VlD2q8GNlTVT6rqIWA9cFIT+wXwuWb7ZmDFr3QwWZdkc5LNU1NTs+iuJEmSJA031tu0J3k6ncnTPcBDPHoCt1/X9s+nP3eVZD/gg8CqqroryUUzju35UgNiD9YjX+61mx45VtUUMD2zKl4/5NUkSZIkaRbGece/pwCX0bncr4AdwMokj0lyBHBCn6bTk6l7kxwAnNkVuw84sEebjcDJSQ5OshdwFnDDGNKQJEmSpHkbdQVr/yRbgX3orFh9FHhfE7sR+B6wjc6dALf0OkFV/XuSDzfH7QA2dYWvBC5Lsgs4savN3UneDlxPZzXrmqr6zIi5SJIkSdJI8sjVdK1Vw77e+dL/0T/8J++BfX/RP/7AYxf/26mXc3wp9MG4ceMLF18KfTBu3Pj840uhD8aNjxifzf0j5mQhbnIhSZIkSa3kBEuSJEmSxqT1lwgmWdfcVbCV2p4/OAbmb/5tzh8cA/M3/zbnD46B+Y8/f1ewYN1id2CRtT1/cAzMv93anj84Bubfbm3PHxwD8x8zJ1iSJEmSNCZOsCRJkiRpTJxgQWuvOW20PX9wDMy/3dqePzgG5t9ubc8fHAPzH7PW3+RCkiRJksbFFSxJkiRJGpOJmmAleXGSbyX5TpLzm31PSvLFJN9ufh4027Zzab9U9BmDS5P8S5LbkvxDkifOtm2zf9mMQb8cmth5SSrJwXNpOwn5J3lTs//2JO+ZY9tlnX+SlUluSrI1yeYkJ8y2bbN/OeX/10nuSbK9a19ramCf/FtT/6D3GHTF2lADe+bfohrY6z3Qphp4RJLrk3yz+W/9lmZ/K+rggPxbUwf7jUFXfM/UwaqaiAewF/Bd4OnAY4FbgaOB9wDnN8ecD1wy27ZNbGj7pfIYMAanAXs3x1wyqWMwJIcjgGuB7wMHtyl/YA3wJWDf5rhDWpb/dcDpzTEvATZMYv5N/04CjgO2d+1rUw3slX8r6t+gMWj2T3wNHPA70IoaOCD/NtXAw4Djmu0DgTto0d+CA/JvTR3sNwbN8z1WBxd9IMY4oCcC13Y9f3vz+BZwWNegf2u2bZvtoe2XymNQHl37Xg6sn8QxGJLDp4BjgR193lQTmz/wSeCFI4zdcs//WuCVzb6zgI9PYv5dfV/Bo/+4ak0N7JX/jNjE1r9hY9CGGtgv/7bUwAH5t6oGzsjrM8CL2lYHZ+Y/Y18r6mCvMdiTdXCSLhF8GnBX1/MfNvsOraq7AZqfhwAkOTzJNUPa0q/9EjUoj2l/CHweJnIMeuaQ5KXAv1bVrd0HtyV/4Cjgd5NsTHJDktXQqvzPBS5NchfwXjoFcxLz76dNNXCYSa5/fbWoBvbTlhrYz7m0sAYmWQE8F9hIC+vgjPy7taYOdo/Bnq6De4/e/SUjPfZVv4OraiedpfI5t13CBuaR5ALgIWA9TOQY9MphX+ACOsvjj9KS/IvO+/wg4LeB1cAnkzy9Rfm/AXhrVV2V5BXAR+j83+xJy39O2pZ/C+pfT0keR3tqYD9tqYH9tK4GJjkAuAo4t6r+I+mV3uS+B2bm37W/NXWwewzo5LxH6+AkrWD9kM61ldN+HdgJ/DjJYQDNz3vm0JZZtl8q+uaR5BzgDODsatY3Z9uW5TMGvXL4AXAkcGuSHc2+LUmeOou2k5D/zmb/1dXxdeBhYOaHOyc5/3OAq5t9fw/0+oD3JOTfT5tqYE8tqX/9PIP21MB+2lID+2lVDUyyD50/rNdX1XTeramDffJvVR3sMQZ7vA5O0gRrE/DMJEcmeSzwB8Bnm8c5zTHn0LkWc7ZtmWX7paJnHkleDLwNeGlV/ddc2jax5TIGvXK4uqoOqaoVVbWCzpvnuKr60SzaTkL+nwU+DZwKkOQoOh/cvHeWbWH5578TOLk55lTg23NoC8sn/37aVAN/RYvqX09Vta1FNbCfT9OOGthPa2pgOktVHwG+WVXv6wq1og72y79NdbDXGCxKHVyID5Qt1oPOEt8ddO4AckGz78nAl+kUlC8DT2r2Hw5cM6jtoPZL9dFnDL5D55rSrc3jskkdg345dMV30HywsS350/lj4mPAdmALcGrL8n8BcDOduwFtBI6f4Pz/DrgbeJDOPyCvaVMN7JN/a+pfvzGYEZ/0Gtjrd6BNNbBX/m2qgS+gc0nXbV3v+Zf0y2HSxmBA/q2pg/3GYMYxO1jgOpimkSRJkiRpRJN0iaAkSZIkLSonWJIkSZI0Jk6wJEmSJGlMnGBJkiRJ0pg4wZIkSZKkMXGCJUmSJElj4gRLkiRJksbECZYkSZIkjcn/D2oiQisLB6HDAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1gAAAD8CAYAAABq+gXNAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAtFklEQVR4nO3df5BlVX33+/dHQEHBiCIIhtxBryQXFUaYwWAMMJRyxeLx0YTSUJQyT9Qx3vIHpsgVpUrASlIgXlOJlkKLCRUd82iEqDEoqJfBK4ZxhmFgBo2oOIoZFMljDCQjwvC9f5zdcmjPj+4+p6e7z36/qk71Pvu71z7ru+jznV6sffZJVSFJkiRJGt1jFrsDkiRJkjQpnGBJkiRJ0pg4wZIkSZKkMXGCJUmSJElj4gRLkiRJksbECZYkSZIkjYkTLEnSxEvytCT/M8l3k3wjyTVJjlzsfkmSJo8TLEnSREsS4B+ADVX1zKo6CngncMhs2ibx30pJ0qz5j4YkadKtAR6sqsumd1TVVuCWJF9OsiXJtiT/HSDJiiTfTPJBYAtw+KL0WpK0LKWqFrsPkiQtmCRvAY6oqrfN2L838Piq+o8kBwE3Ac8C/jfgTuAFVXXTHu+wJGlZ23uxOyBJ0iIJ8OdJTgQeBp7OI5cNft/JlSRpPrxEUJI06W4Hjuux/yzgqcBxVbUS+DGwbxP7zz3TNUnSpHGCJUmadP8v8Lgkr5/ekWQ1nUsB76mqB5OsaZ5LkjQSJ1iSpIlWnQ8bvwJ4cXOb9tuBC4FrgFVJNtNZzfqXxeulJGlSeJMLSZIkSRoTV7AkSZIkaUycYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxmTvxe7AEuBtFCVJkqR2yrhP6ASLwaNaxhc1vhT6MAnxY27rH7/1aHjaj/vHf3TI4vf/T97bP37puYvfv1HHf7H7Nyy+kL8fs+3Daz7aP/63rx69j8POP2r8i6f2j7/4utF/R0Ydn2HvsWH9GzU+LMEfP61/+JAfDc9/2Pid+sX+8etePHoNfe+f9I+fe+nov7+jjv8o//2nz/HR1/SPv/pvF7+OLeU6OI5/J4b1b6Fr6HKPj5uXCEqSJEnSmAydYCU5P8ntSW5LsjXJ85v95yR5/FxfMMnaJIfNJpbkiiRHzfU1JEmSJGkxDJxgJTkBOB04tqqOBl4E3NWEzwHmNMFKshewFug5wZoZq6rXVdU35vIakiRJkrRYhq1gHQrcW1UPAFTVvVW1M8lb6EyErk9yPUCSDyXZ3Kx2XTR9giQ7krwryVeBM4FVwPpmNWy/ruPOmBlLsiHJqiZ+f5JLktyc5EtJjm/idyZ5WXPMXkkuTbKpWXF7w9hGSpIkSZKGGDbBug44PMkdST6Y5CSAqvorYCewpqrWNMeeX1WrgKOBk5Ic3XWen1fVC6vqY8Bm4KyqWllVu6YPqKpP9Ys1ngBsqKrjgPuAPwVeDLwCeHdzzGuBn1XVamA18PokR8xhPCRJkiRp3gZOsKrqfuA4YB3wE+ATSdb2OfyVSbYAtwDPBro/O/WJ0bvKL4AvNNvbgBuq6sFme0Wz/1TgNUm2AhuBpwDPmnmiJOua1bbNU1NTY+iaJEmSJM3iNu1VtRvYAGxIsg04G7iy+5hmlehcYHVV/TTJlcC+XYf85xj6+mBVTd9J8WFg+rLFh5NM5xHgzVV17aATVdUUMD2zKq8jlCRJkjQOw25y8ZtJuleAVgLfb7bvAw5otp9IZxL1sySHAKcNOG13u7nEZuNa4I1J9gFIcmSSJ4xwPkmSJEmatWErWPsD70/yJOAh4Dt0LheEzgrQ55PcXVVrktwC3A7cCdw44JxXApcl2QWcMOOzVo+KzTEXgCvoXC64JUnoXNb48nmcR5IkSZLmbOAEq6puBl7QJ/Z+4P1dz9f2OW7FjOdXAVf1OXZm7OSu2P5d2xfOaLd/8/Nh4J3NQ5IkSZL2qKFfNCxJkiRJmh0nWJIkSZI0Jnnkxnyt1foBkCRJkloq4z7h0Nu0t8GgUS3jixpfCn2YhPiqm/vHNx8Hh93dP77z0MXv/6jxiy7sH7/gwsUf/8Uen2Hxhfz9mG0f3jDgKwsvX7fwOQx7/WG/Y//tc/3j/3g63Lyqf/y4zaP/Dg3r37DzD+v/sPbD4lMDvi9l3eUMTfBz/61/+PR/HP7fb9T+j/r7N6z/o/7+DvvvN0p8+phR3yOLXecWsw7O5vyjvv6w8Z/0vwOGxcfNSwQlSZIkaUzmNcFKsjvJ1q7HeXNsvyPJQT32v3PG86/Np3+SJEmStBjme4ngrqpaOc6ONN4J/Pn0k6rqeYt4SZIkSVqKxnqJYLMydVGSLUm2JfmtZv9TklyX5JYkPa+mTnIxsF+zIra+2Xd/8/PkJDck+WSSO5JcnOSsJF9vXueZzXFPTXJVkk3N43fGmZ8kSZIkDTLfCdb0RGj68aqu2L1VdSzwIeDcZt8FwFer6nnAZ4HfmHnCqjqPZmWsqs7q8ZrHAG8Fngu8Gjiyqo4HrgDe3Bzzl8BfVNVq4PebmCRJkiTtEQtxieDVzc+bgd9rtk+c3q6qf0ry03m85qaquhsgyXeB65r924A1zfaLgKOSXy6QPTHJAVV1X/eJkqwD1gFcfvnlsG7dPLojSZIkSY+2ELdpf6D5uXvG+Ue9C+IDXdsPdz1/uOt1HgOcUFW7Bp2oqqaA6RuK1oC7w0qSJEnSrO2p27R/BTgLIMlpwIF9jnswyT4jvM51wJumnyRZOcK5JEmSJGlOxvUZrIuHHH8RcGKSLcCpwA/6HDcF3DZ9k4t5eAuwKsltSb4B/NE8zyNJkiRJczavSwSraq8++1d0bW8GTm62/43OxGra2/q0fzvw9q7n+zc/NwAbuvaf3LX9y1hV3Qt033BDkiRJkvaYPXWJoCRJkiRNPCdYkiRJkjQmqRr15n7LXusHQJIkSWqpDD9kbhbiNu3Lz6BhLbj0/+4f/pP3wON+0T/+wGOHnt74gPhS6INx48YXLr4U+mDcuPH5x5dCH4wbHzU+biNdIphkd3MXwduT3Jrkj5OM7bLDJGuTHNb1/IokR43r/JIkSZI0TqOuYO2qqpUASQ4GPg78GnDBbE+QZK+q2t0nvBbYDuwEqKrXjdJZSZIkSVpIY1ttqqp7gHXAm9KxNskHpuNJPpfk5Gb7/iTvTrIROCHJu5JsSrI9yVTT/gxgFbC+WSXbL8mGJKuac5yZZFvT5pKu17k/yZ81K2o3JTlkXDlKkiRJ0iBjvYtgVd3ZnPPgIYc+AdheVc+vqq8CH6iq1VX1HGA/4PSq+hSwGTirqlZW1a7pxs1lg5cApwArgdVJXt517puq6hjgK8Drx5agJEmSJA2wELdpn82dOHYDV3U9X5NkY5JtdCZNzx7SfjWwoap+UlUPAeuBE5vYL4DPNds3Ayt+pYPJuiSbk2yempqaRXclSZIkabix3kUwyTPoTJ7uAR7i0RO4fbu2fz79uask+wIfBFZV1V1JLpxxbM+XGhB7sB659/xueuRYVVPA9MyqeMOQV5MkSZKkWRjnHf+eClxG53K/AnYAK5M8JsnhwPF9mk5Ppu5Nsj9wRlfsPuCAHm02AiclOSjJXsCZwA1jSEOSJEmS5m3UFaz9kmwF9qGzYvVR4H1N7Ebge8A2OncC3NLrBFX170k+3By3A9jUFb4SuCzJLuCErjZ3J3kHcD2d1axrquozI+YiSZIkSSPJI1fTtVb5RcNLN74U+mDcuPGFiy+FPhg3bnz+8aXQB+PGR4zP5v4Rc7IQN7mQJEmSpFZygiVJkiRJY9L6SwSTrGvuKthKbc8fHAPzN/825w+Ogfmbf5vzB8fA/MefvytYsG6xO7DI2p4/OAbm325tzx8cA/Nvt7bnD46B+Y+ZEyxJkiRJGhMnWJIkSZI0Jk6woLXXnDbanj84Bubfbm3PHxwD82+3tucPjoH5j1nrb3IhSZIkSePiCpYkSZIkjclETbCSvCTJt5J8J8l5zb4nJ/likm83Pw+cbdu5tF8q+ozBpUn+JcltSf4hyZNm27bZv2zGoF8OTezcJJXkoLm0nYT8k7y52X97kvfMse2yzj/JyiQ3JdmaZHOS42fbttm/nPL/6yT3JNneta81NbBP/q2pf9B7DLpibaiBPfNvUQ3s9R5oUw08PMn1Sb7Z/Ld+a7O/FXVwQP6tqYP9xqArvmfqYFVNxAPYC/gu8AzgscCtwFHAe4DzmmPOAy6ZbdsmNrT9UnkMGINTgb2bYy6Z1DEYksPhwLXA94GD2pQ/sAb4EvC45riDW5b/dcBpzTEvBTZMYv5N/04EjgW2d+1rUw3slX8r6t+gMWj2T3wNHPA70IoaOCD/NtXAQ4Fjm+0DgDto0d+CA/JvTR3sNwbN8z1WBxd9IMY4oCcA13Y9f0fz+BZwaNegf2u2bZvtoe2XymNQHl37XgGsn8QxGJLDp4BjgB193lQTmz/wSeBFI4zdcs//WuBVzb4zgY9PYv5dfV/Bo/+4ak0N7JX/jNjE1r9hY9CGGtgv/7bUwAH5t6oGzsjrM8CL21YHZ+Y/Y18r6mCvMdiTdXCSLhF8OnBX1/MfNvsOqaq7AZqfBwMkOSzJNUPa0q/9EjUoj2l/CHweJnIMeuaQ5GXAv1bVrd0HtyV/4Ejgd5NsTHJDktXQqvzPAS5NchfwXjoFcxLz76dNNXCYSa5/fbWoBvbTlhrYzzm0sAYmWQE8D9hIC+vgjPy7taYOdo/Bnq6De4/e/SUjPfZVv4OraiedpfI5t13CBuaR5HzgIWA9TOQY9MrhccD5dJbHH6Ul+Red9/mBwG8Dq4FPJnlGi/J/I/C2qroqySuBj9D5v9mTlv+ctC3/FtS/npI8nvbUwH7aUgP7aV0NTLI/cBVwTlX9R9Irvcl9D8zMv2t/a+pg9xjQyXmP1sFJWsH6IZ1rK6f9OrAT+HGSQwGan/fMoS2zbL9U9M0jydnA6cBZ1axvzrYty2cMeuXwA+AI4NYkO5p9W5I8bRZtJyH/nc3+q6vj68DDwMwPd05y/mcDVzf7/h7o9QHvSci/nzbVwJ5aUv/6eSbtqYH9tKUG9tOqGphkHzp/WK+vqum8W1MH++TfqjrYYwz2eB2cpAnWJuBZSY5I8ljgD4DPNo+zm2POpnMt5mzbMsv2S0XPPJK8BHg78LKq+q+5tG1iy2UMeuVwdVUdXFUrqmoFnTfPsVX1o1m0nYT8Pwt8GjgFIMmRdD64ee8s28Lyz38ncFJzzCnAt+fQFpZP/v20qQb+ihbVv56qaluLamA/n6YdNbCf1tTAdJaqPgJ8s6re1xVqRR3sl3+b6mCvMViUOrgQHyhbrAedJb476NwB5Pxm31OAL9MpKF8GntzsPwy4ZlDbQe2X6qPPGHyHzjWlW5vHZZM6Bv1y6IrvoPlgY1vyp/PHxMeA7cAW4JSW5f9C4GY6dwPaCBw3wfn/HXA38CCdf0Be26Ya2Cf/1tS/fmMwIz7pNbDX70CbamCv/NtUA19I55Ku27re8y/tl8OkjcGA/FtTB/uNwYxjdrDAdTBNI0mSJEnSiCbpEkFJkiRJWlROsCRJkiRpTJxgSZIkSdKYOMGSJEmSpDFxgiVJkiRJY+IES5IkSZLGxAmWJEmSJI2JEyxJkiRJGhMnWJIkSZI0Jk6wJEmSJGlMnGBJkiRJ0pg4wZIkSZKkMXGCJUlqlSS7k2xNsj3J3yd5fJInJfm/FrtvkqTlzwmWJKltdlXVyqp6DvAL4I+AJwFOsCRJI3OCJUlqs/8P+N+Bi4FnNitbly5ynyRJy9jei90BSZIWQ5K9gdOALwCfB55TVSsXtVOSpGXPFSxJUtvsl2QrsBn4AfCRxe2OJGmSuIIlSWqbXTNXqpIsUlckSZPGFSxJkuA+4IDF7oQkaflzgiVJar2q+jfgxubW7d7kQpI0b6mqxe6DJEmSJE0EV7AkSZIkaUycYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxsQvGgZvoyhJkiS109i/ad4JFoNHtYwvanwp9MG48WEHLPTrr7q5f3zzcQvfvg3v8aU8RuZvfFj8DVP945evg6k39I+vu3wy3sPGjY8SHzcvEZQkSZKkMRk6wUpyfpLbk9yWZGuS5zf7z0ny+Lm+YJK1SQ6bTSzJFUmOmutrSJIkSdJiGDjBSnICcDpwbFUdDbwIuKsJnwPMaYKVZC9gLdBzgjUzVlWvq6pvzOU1JEmSJGmxDFvBOhS4t6oeAKiqe6tqZ5K30JkIXZ/keoAkH0qyuVntumj6BEl2JHlXkq8CZwKrgPXNath+XcedMTOWZEOSVU38/iSXJLk5yZeSHN/E70zysuaYvZJcmmRTs+I24KpjSZIkSRqvYROs64DDk9yR5INJTgKoqr8CdgJrqmpNc+z5VbUKOBo4KcnRXef5eVW9sKo+BmwGzqqqlVW1a/qAqvpUv1jjCcCGqjoOuA/4U+DFwCuAdzfHvBb4WVWtBlYDr09yxBzGQ5IkSZLmbeAEq6ruB44D1gE/AT6RZG2fw1+ZZAtwC/BsoPuzU58Yvav8AvhCs70NuKGqHmy2VzT7TwVek2QrsBF4CvCsmSdKsq5Zbds8NTXg1juSJEmSNAdDb9NeVbuBDcCGJNuAs4Eru49pVonOBVZX1U+TXAns23XIf46hrw9W1fSdFB8Gpi9bfDjJdB4B3lxV1w46UVVNAdMzq/I6QkmSJEnjMOwmF7+ZpHsFaCXw/Wb7PuCAZvuJdCZRP0tyCHDagNN2t5tLbDauBd6YZB+AJEcmecII55MkSZKkWRu2grU/8P4kTwIeAr5D53JB6KwAfT7J3VW1JsktwO3AncCNA855JXBZkl3ACTM+a/Wo2BxzAbiCzuWCW5KEzmWNL5/HeSRJkiRpzgZOsKrqZuAFfWLvB97f9Xxtn+NWzHh+FXBVn2Nnxk7uiu3ftX3hjHb7Nz8fBt7ZPCRJkiRpjxr6RcOSJEmSpNlxgiVJkiRJY5JHbszXWq0fAEmSJKmlMu4TDr1NexsMGtUyvqjxpdAH48YXOj7sgDUb+oevP3nx+z8J7/FRx3ih/xst99+B5d7/SY8P++8zKD59zEUX9o9fcKG/A8aXdnzc5nWJYJLdSbZ2Pc6bY/sdSQ7qsf+dM55/bT79kyRJkqTFMN8VrF1VtXKcHWm8E/jz6SdV1fMOhpIkSZK0FI31JhfNytRFSbYk2Zbkt5r9T0lyXZJbklxOj5W6JBcD+zUrYuubffc3P09OckOSTya5I8nFSc5K8vXmdZ7ZHPfUJFcl2dQ8fmec+UmSJEnSIPOdYE1PhKYfr+qK3VtVxwIfAs5t9l0AfLWqngd8FviNmSesqvNoVsaq6qwer3kM8FbgucCrgSOr6ng6Xy785uaYvwT+oqpWA7/fxCRJkiRpj1iISwSvbn7eDPxes33i9HZV/VOSn87jNTdV1d0ASb4LXNfs3wasabZfBByV/HKB7IlJDqiq++bxepIkSZI0JwvxPVgPND938+gJ3Kg36Xiga/vhrucPd73OY4ATmlWwlVX19F6TqyTrkmxOsnlqamrEbkmSJElSx576ouGvAGcBJDkNOLDPcQ8m2WeE17kOeNP0kyQrex1UVVNVtaqqVq1bt26El5MkSZKkR4zrM1gXDzn+IuDEJFuAU4Ef9DluCrht+iYX8/AWYFWS25J8A/ijeZ5HkiRJkuZsXp/Bqqq9+uxf0bW9GTi52f43OhOraW/r0/7twNu7nu/f/NwAbOjaf3LX9i9jVXUv0H3DDUmSJEnaY/bUJYKSJEmSNPGcYEmSJEnSmKRq1Jv7LXutHwBJkiSppTL8kLmZ7/dgTZRBo1qziP+PK/vH/2bt8BMcsaN/+HsrRu/fYsdHyW9PvMZSGCPjxtsaXwp9MG7c+PzjS6EPxo2PGh83LxGUJEmSpDEZaYKVZHdzm/bbk9ya5I+TjG3SlmRtksO6nl+R5KhxnV+SJEmSxmnUSwR3VdVKgCQHAx8Hfg24YLYnSLJXVe3uE14LbAd2AlTV60bprCRJkiQtpLGtNlXVPcA64E3pWJvkA9PxJJ9LcnKzfX+SdyfZCJyQ5F1JNiXZnmSqaX8GsApY36yS7ZdkQ5JVzTnOTLKtaXNJ1+vcn+TPmhW1m5IcMq4cJUmSJGmQsX4Gq6rubM558JBDnwBsr6rnV9VXgQ9U1eqqeg6wH3B6VX0K2AycVVUrq2rXdOPmssFLgFOAlcDqJC/vOvdNVXUM8BXg9WNLUJIkSZIGWIibXMzmVoe7gau6nq9JsjHJNjqTpmcPab8a2FBVP6mqh4D1wIlN7BfA55rtm4EVv9LBZF2SzUk2T01NzaK7kiRJkjTcWG/TnuQZdCZP9wAP8egJ3L5d2z+f/txVkn2BDwKrququJBfOOLbnSw2IPViPfLnXbnrkWFVTwPTMqt4w5MUkSZIkaTbGece/pwKX0bncr4AdwMokj0lyOHB8n6bTk6l7k+wPnNEVuw84oEebjcBJSQ5KshdwJnDDGNKQJEmSpHkbdQVrvyRbgX3orFh9FHhfE7sR+B6wjc6dALf0OkFV/XuSDzfH7QA2dYWvBC5Lsgs4oavN3UneAVxPZzXrmqr6zIi5SJIkSdJI8sjVdK1Vo3778/+4sn/8b9YOP8ERO/qHv7di8b/detT4KPntiddYCmNk3Hhb40uhD8aNG59/fCn0wbjxEeOzuX/EnCzETS4kSZIkqZWcYEmSJEnSmLT+EsEk65q7CrZS2/MHx8D8zb/N+YNjYP7m3+b8wTEw//Hn7woWrFvsDiyytucPjoH5t1vb8wfHwPzbre35g2Ng/mPmBEuSJEmSxsQJliRJkiSNiRMsaO01p4225w+Ogfm3W9vzB8fA/Nut7fmDY2D+Y9b6m1xIkiRJ0ri4giVJkiRJYzJRE6wkL0nyrSTfSXJes+/JSb6Y5NvNzwNn23Yu7ZeKPmNwaZJ/SXJbkn9I8qTZtm32L5sx6JdDEzs3SSU5aC5tJyH/JG9u9t+e5D1zbLus80+yMslNSbYm2Zzk+Nm2bfYvp/z/Osk9SbZ37WtNDeyTf2vqH/Qeg65YG2pgz/xbVAN7vQfaVAMPT3J9km82/63f2uxvRR0ckH9r6mC/MeiK75k6WFUT8QD2Ar4LPAN4LHArcBTwHuC85pjzgEtm27aJDW2/VB4DxuBUYO/mmEsmdQyG5HA4cC3wfeCgNuUPrAG+BDyuOe7gluV/HXBac8xLgQ2TmH/TvxOBY4HtXfvaVAN75d+K+jdoDJr9E18DB/wOtKIGDsi/TTXwUODYZvsA4A5a9LfggPxbUwf7jUHzfI/VwUUfiDEO6AnAtV3P39E8vgUc2jXo35pt22Z7aPul8hiUR9e+VwDrJ3EMhuTwKeAYYEefN9XE5g98EnjRCGO33PO/FnhVs+9M4OOTmH9X31fw6D+uWlMDe+U/Izax9W/YGLShBvbLvy01cED+raqBM/L6DPDittXBmfnP2NeKOthrDPZkHZykSwSfDtzV9fyHzb5DqupugObnwQBJDktyzZC29Gu/RA3KY9ofAp+HiRyDnjkkeRnwr1V1a/fBbckfOBL43SQbk9yQZDW0Kv9zgEuT3AW8l07BnMT8+2lTDRxmkutfXy2qgf20pQb2cw4trIFJVgDPAzbSwjo4I/9uramD3WOwp+vg3qN3f8lIj33V7+Cq2klnqXzObZewgXkkOR94CFgPEzkGvXJ4HHA+neXxR2lJ/kXnfX4g8NvAauCTSZ7RovzfCLytqq5K8krgI3T+b/ak5T8nbcu/BfWvpySPpz01sJ+21MB+WlcDk+wPXAWcU1X/kfRKb3LfAzPz79rfmjrYPQZ0ct6jdXCSVrB+SOfaymm/DuwEfpzkUIDm5z1zaMss2y8VffNIcjZwOnBWNeubs23L8hmDXjn8ADgCuDXJjmbfliRPm0XbSch/Z7P/6ur4OvAwMPPDnZOc/9nA1c2+vwd6fcB7EvLvp001sKeW1L9+nkl7amA/bamB/bSqBibZh84f1uurajrv1tTBPvm3qg72GIM9XgcnaYK1CXhWkiOSPBb4A+CzzePs5piz6VyLOdu2zLL9UtEzjyQvAd4OvKyq/msubZvYchmDXjlcXVUHV9WKqlpB581zbFX9aBZtJyH/zwKfBk4BSHIknQ9u3jvLtrD8898JnNQccwrw7Tm0heWTfz9tqoG/okX1r6eq2taiGtjPp2lHDeynNTUwnaWqjwDfrKr3dYVaUQf75d+mOthrDBalDi7EB8oW60Fnie8OOncAOb/Z9xTgy3QKypeBJzf7DwOuGdR2UPul+ugzBt+hc03p1uZx2aSOQb8cuuI7aD7Y2Jb86fwx8TFgO7AFOKVl+b8QuJnO3YA2AsdNcP5/B9wNPEjnH5DXtqkG9sm/NfWv3xjMiE96Dez1O9CmGtgr/zbVwBfSuaTrtq73/Ev75TBpYzAg/9bUwX5jMOOYHSxwHUzTSJIkSZI0okm6RFCSJEmSFpUTLEmSJEkaEydYkiRJkjQmTrAkSZIkaUycYEmSJEnSmDjBkiRJkqQxcYIlSZIkSWPiBEuSJEmSxsQJliRJkiSNiRMsSZIkSRoTJ1iSJEmSNCZOsCRJkiRpTJxgSZImSpK/SHJO1/Nrk1zR9fz/SfLHfdpemeSMZntHkoMWvMOSpIniBEuSNGm+BrwAIMljgIOAZ3fFXwDcuAj9kiS1gBMsSdKkuZFmgkVnYrUduC/JgUkeB/wfwP+ZZFOS7UmmkqTfyZLsl+QLSV6/8F2XJC13TrAkSROlqnYCDyX5DToTrX8GNgInAKuA24APVNXqqnoOsB9wep/T7Q/8I/DxqvrwgndekrTsOcGSJE2i6VWs6QnWP3c9/xqwJsnGJNuAU3j0JYTdPgP8TVX97cJ3WZI0CZxgSZIm0fTnsJ5L5xLBm+isYE1//uqDwBlV9Vzgw8C+fc5zI3DaoEsIJUnq5gRLkjSJbqRz2d//qqrdVfW/gCfRmWT9c3PMvUn2B84YcJ53Af9GZ0ImSdJQTrAkSZNoG527B940Y9/PqupeOqtW24BPA5uGnOscYN8k7xl/NyVJkyZVtdh9kCRJkqSJ4AqWJEmSJI2JEyxJkiRJGhMnWJIkSZI0Jk6wJEmSJGlMnGBJkiRJ0pjsvdgdWAK8jaIkSZLUTmP/InknWAwe1TK+qPGl0AfjxkeNDzvgogv7hy+4cPH773vcuHHjgyx2H4wbH/nf6THzEkFJkiRJGpOhE6wk5ye5PcltSbYmeX6z/5wkj5/rCyZZm+Sw2cSSXJHkqLm+hiRJkiQthoETrCQnAKcDx1bV0cCLgLua8DnAnCZYSfYC1gI9J1gzY1X1uqr6xlxeQ5IkSZIWy7AVrEOBe6vqAYCqureqdiZ5C52J0PVJrgdI8qEkm5vVroumT5BkR5J3JfkqcCawCljfrIbt13XcGTNjSTYkWdXE709ySZKbk3wpyfFN/M4kL2uO2SvJpUk2NStubxjbSEmSJEnSEMMmWNcBhye5I8kHk5wEUFV/BewE1lTVmubY86tqFXA0cFKSo7vO8/OqemFVfQzYDJxVVSuratf0AVX1qX6xxhOADVV1HHAf8KfAi4FXAO9ujnkt8LOqWg2sBl6f5Ig5jIckSZIkzdvACVZV3Q8cB6wDfgJ8IsnaPoe/MskW4Bbg2UD3Z6c+MXpX+QXwhWZ7G3BDVT3YbK9o9p8KvCbJVmAj8BTgWTNPlGRds9q2eWpqagxdkyRJkqRZ3Ka9qnYDG4ANSbYBZwNXdh/TrBKdC6yuqp8muRLYt+uQ/xxDXx+squk7KT4MTF+2+HCS6TwCvLmqrh10oqqaAqZnVuV1hJIkSZLGYdhNLn4zSfcK0Erg+832fcABzfYT6UyifpbkEOC0AaftbjeX2GxcC7wxyT4ASY5M8oQRzidJkiRJszZsBWt/4P1JngQ8BHyHzuWC0FkB+nySu6tqTZJbgNuBO4EbB5zzSuCyJLuAE2Z81upRsTnmAnAFncsFtyQJncsaXz6P80iSJEnSnOWRq+5aqxb726OND7bYfTBufORviB9ywEUX9g9fcOHi99/3uHHjxgdZ7D4YNz5ifNiv+JwN/aJhSZIkSdLsuILV/A9mSZIkSa0z9hWsoXcRbIMlvmzZ6vhS6INx415CuHDxpdAH48aNzz++FPpg3PjI/w6PmZcISpIkSdKYzGuClWR3kq1dj/Pm2H5HkoN67H/njOdfm0//JEmSJGkxzPcSwV1VtXKcHWm8E/jz6SdV9YIFeA1JkiRJWhBjvUSwWZm6KMmWJNuS/Faz/ylJrktyS5LL6XEpZJKLgf2aFbH1zb77m58nJ7khySeT3JHk4iRnJfl68zrPbI57apKrkmxqHr8zzvwkSZIkaZD5TrCmJ0LTj1d1xe6tqmOBDwHnNvsuAL5aVc8DPgv8xswTVtV5NCtjVXVWj9c8Bngr8Fzg1cCRVXU8nS8XfnNzzF8Cf1FVq4Hfb2KSJEmStEcsxCWCVzc/bwZ+r9k+cXq7qv4pyU/n8ZqbqupugCTfBa5r9m8D1jTbLwKOSn65QPbEJAdU1X3dJ0qyDlgHcPnll8O6dfPojiRJkiQ92kLcpv2B5ufuGecf9S6ID3RtP9z1/OGu13kMcEJV7Rp0oqqaAqamn75hxI5JkiRJEuy527R/BTgLIMlpwIF9jnswyT4jvM51wJumnyRZOcK5JEmSJGlOxvUZrIuHHH8RcGKSLcCpwA/6HDcF3DZ9k4t5eAuwKsltSb4B/NE8zyNJkiRJc5aqhfj+4mWlFvvbo40Ptth9MG58wb9BfsgBF13YP3zBhYvff9/jxo23N74U+mDc+IjxYb/ic7anLhGUJEmSpInnBEuSJEmSxsRLBEe/u6EkSZKk5WnslwguxG3al51hn28Y5cLNJXBd6bKOL4U+GDdufOHiS6EPxo0bn398KfTBuPFR4+PmJYKSJEmSNCYjTbCS7G5u0357kluT/HGSsU3akqxNcljX8yuSHDWu80uSJEnSOI16ieCuqloJkORg4OPArwEXzPYESfaqqt19wmuB7cBOgKp63SidlSRJkqSFNLbVpqq6B1gHvCkda5N8YDqe5HNJTm6270/y7iQbgROSvCvJpiTbk0w17c8AVgHrm1Wy/ZJsSLKqOceZSbY1bS7pep37k/xZs6J2U5JDxpWjJEmSJA0y1s9gVdWdzTkPHnLoE4DtVfX8qvoq8IGqWl1VzwH2A06vqk8Bm4GzqmplVe2abtxcNngJcAqwElid5OVd576pqo4BvgK8fmwJSpIkSdIAC3GTi9nc6nA3cFXX8zVJNibZRmfS9Owh7VcDG6rqJ1X1ELAeOLGJ/QL4XLN9M7DiVzqYrEuyOcnmqampWXRXkiRJkoYb623akzyDzuTpHuAhHj2B27dr++fTn7tKsi/wQWBVVd2V5MIZx/Z8qQGxB+uRL/faTY8cq2oKmJ5Z1aDbtEuSJEnSbI3zjn9PBS6jc7lfATuAlUkek+Rw4Pg+TacnU/cm2R84oyt2H3BAjzYbgZOSHJRkL+BM4IYxpCFJkiRJ8zbqCtZ+SbYC+9BZsfoo8L4mdiPwPWAbnTsBbul1gqr69yQfbo7bAWzqCl8JXJZkF3BCV5u7k7wDuJ7OatY1VfWZEXORJEmSpJHkkavpWmvgJYIXXMjQr39e7G+fnuT4UuiDcePGFy6+FPpg3Ljx+ceXQh+MGx8xPpv7R8zJQtzkQpIkSZJayQmWJEmSJI1J6y8RTLKuuatgK7U9f3AMzN/825w/OAbmb/5tzh8cA/Mff/6uYMG6xe7AImt7/uAYmH+7tT1/cAzMv93anj84BuY/Zk6wJEmSJGlMnGBJkiRJ0pg4wYLWXnPaaHv+4BiYf7u1PX9wDMy/3dqePzgG5j9mrb/JhSRJkiSNiytYkiRJkjQmEzXBSvKSJN9K8p0k5zX7npzki0m+3fw8cLZt59J+qegzBpcm+ZcktyX5hyRPmm3bZv+yGYN+OTSxc5NUkoPm0nYS8k/y5mb/7UneM8e2yzr/JCuT3JRka5LNSY6fbdtm/3LK/6+T3JNke9e+1tTAPvm3pv5B7zHoirWhBvbMv0U1sNd7oE018PAk1yf5ZvPf+q3N/lbUwQH5t6YO9huDrvieqYNVNREPYC/gu8AzgMcCtwJHAe8BzmuOOQ+4ZLZtm9jQ9kvlMWAMTgX2bo65ZFLHYEgOhwPXAt8HDmpT/sAa4EvA45rjDm5Z/tcBpzXHvBTYMIn5N/07ETgW2N61r001sFf+rah/g8ag2T/xNXDA70ArauCA/NtUAw8Fjm22DwDuoEV/Cw7IvzV1sN8YNM/3WB1c9IEY44CeAFzb9fwdzeNbwKFdg/6t2bZttoe2XyqPQXl07XsFsH4Sx2BIDp8CjgF29HlTTWz+wCeBF40wdss9/2uBVzX7zgQ+Pon5d/V9BY/+46o1NbBX/jNiE1v/ho1BG2pgv/zbUgMH5N+qGjgjr88AL25bHZyZ/4x9raiDvcZgT9bBSbpE8OnAXV3Pf9jsO6Sq7gZofh4MkOSwJNcMaUu/9kvUoDym/SHweZjIMeiZQ5KXAf9aVbd2H9yW/IEjgd9NsjHJDUlWQ6vyPwe4NMldwHvpFMxJzL+fNtXAYSa5/vXVohrYT1tqYD/n0MIamGQF8DxgIy2sgzPy79aaOtg9Bnu6Du49eveXjPTYV/0OrqqddJbK59x2CRuYR5LzgYeA9TCRY9Arh8cB59NZHn+UluRfdN7nBwK/DawGPpnkGS3K/43A26rqqiSvBD5C5/9mT1r+c9K2/FtQ/3pK8njaUwP7aUsN7Kd1NTDJ/sBVwDlV9R9Jr/Qm9z0wM/+u/a2pg91jQCfnPVoHJ2kF64d0rq2c9uvATuDHSQ4FaH7eM4e2zLL9UtE3jyRnA6cDZ1WzvjnbtiyfMeiVww+AI4Bbk+xo9m1J8rRZtJ2E/Hc2+6+ujq8DDwMzP9w5yfmfDVzd7Pt7oNcHvCch/37aVAN7akn96+eZtKcG9tOWGthPq2pgkn3o/GG9vqqm825NHeyTf6vqYI8x2ON1cJImWJuAZyU5IsljgT8APts8zm6OOZvOtZizbcss2y8VPfNI8hLg7cDLquq/5tK2iS2XMeiVw9VVdXBVraiqFXTePMdW1Y9m0XYS8v8s8GngFIAkR9L54Oa9s2wLyz//ncBJzTGnAN+eQ1tYPvn306Ya+CtaVP96qqptLaqB/XyadtTAflpTA9NZqvoI8M2qel9XqBV1sF/+baqDvcZgUergQnygbLEedJb47qBzB5Dzm31PAb5Mp6B8GXhys/8w4JpBbQe1X6qPPmPwHTrXlG5tHpdN6hj0y6ErvoPmg41tyZ/OHxMfA7YDW4BTWpb/C4Gb6dwNaCNw3ATn/3fA3cCDdP4BeW2bamCf/FtT//qNwYz4pNfAXr8DbaqBvfJvUw18IZ1Lum7res+/tF8OkzYGA/JvTR3sNwYzjtnBAtfBNI0kSZIkSSOapEsEJUmSJGlROcGSJEmSpDFxgiVJkiRJY+IES5IkSZLGxAmWJEmSJI2JEyxJkiRJGhMnWJIkSZI0Jk6wJEmSJGlM/n9Pd0Ir7C7uzgAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 864x259.2 with 3 Axes>"
       ]
@@ -4177,10 +3451,10 @@
      "start_time": "2020-11-23T12:10:21.693486Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.278397Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.278300Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.279905Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.279607Z"
+     "iopub.execute_input": "2023-07-04T15:30:20.908350Z",
+     "iopub.status.busy": "2023-07-04T15:30:20.908255Z",
+     "iopub.status.idle": "2023-07-04T15:30:20.909772Z",
+     "shell.execute_reply": "2023-07-04T15:30:20.909481Z"
     }
    },
    "outputs": [],
@@ -4197,10 +3471,10 @@
      "start_time": "2020-11-25T10:58:14.237045Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.281325Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.281235Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.614042Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.613750Z"
+     "iopub.execute_input": "2023-07-04T15:30:20.911039Z",
+     "iopub.status.busy": "2023-07-04T15:30:20.910952Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.035179Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.034861Z"
     }
    },
    "outputs": [
@@ -4208,55 +3482,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Household: 1_6\n",
+      "Household: 1_1\n",
       "{'HouseholdID': 1, 'SurveyYear': 2002, 'PSUID': 1, 'W2': 1, 'OutCom_B02ID': 1, 'HHIncome2002_B02ID': 2, 'AddressType_B01ID': 3, 'Ten1_B02ID': 1, 'Landlord_B01ID': -10, 'ResLength_B01ID': 3, 'HHoldCountry_B01ID': 1, 'HHoldGOR_B02ID': 7, 'HHoldNumAdults': 2, 'HHoldNumChildren': 2, 'HHoldNumPeople': 4, 'HHoldStruct_B02ID': 5, 'NumLicHolders': 2, 'HHoldEmploy_B01ID': 5, 'NumVehicles': 2, 'NumBike': 0, 'NumCar': 2, 'NumMCycle': 0, 'NumVanLorry': 0, 'NumCarVan': 2, 'WalkBus_B01ID': 1, 'Getbus_B01ID': 5, 'WalkRail_B01ID': 1, 'WalkRailAlt_B01ID': -9, 'HRPWorkStat_B02ID': 1, 'HRPSEGWorkStat_B01ID': 3, 'HHoldOAClass2011_B03ID': -10, 'Settlement2011EW_B03ID': 1, 'Settlement2011EW_B04ID': 1}\n",
-      "Person: 1_6\n",
-      "{'SurveyYear': 2002, 'IndividualID': 1, 'HouseholdID': 1, 'PSUID': 1, 'VehicleID': '1', 'PersNo': 1, 'Age_B01ID': 13, 'OfPenAge_B01ID': 2, 'Sex_B01ID': 2, 'EdAttn1_B01ID': -10, 'EdAttn2_B01ID': -10, 'EdAttn3_B01ID': -10, 'DrivLic_B02ID': 1, 'CarAccess_B01ID': 2, 'DrivDisable_B01ID': -9, 'WkPlace_B01ID': 1, 'ES2000_B01ID': 7, 'NSSec_B03ID': 2, 'SC_B01ID': 3, 'Stat_B01ID': 1, 'SVise_B01ID': 2, 'EcoStat_B02ID': 2, 'PossHom_B01ID': 2}\n",
-      "0:\tActivity(act:home, location:530, time:00:00:00 --> 12:18:00, duration:12:18:00)\n",
-      "1:\tLeg(mode:car, area:530 --> 550, time:12:18:00 --> 12:32:00, duration:0:14:00)\n",
-      "2:\tActivity(act:escort, location:550, time:12:32:00 --> 12:35:00, duration:0:03:00)\n",
-      "3:\tLeg(mode:car, area:550 --> 550, time:12:35:00 --> 12:41:00, duration:0:06:00)\n",
-      "4:\tActivity(act:work, location:550, time:12:41:00 --> 17:30:00, duration:4:49:00)\n",
-      "5:\tLeg(mode:car, area:550 --> 550, time:17:30:00 --> 17:56:00, duration:0:26:00)\n",
-      "6:\tActivity(act:home, location:550, time:17:56:00 --> 20:20:00, duration:2:24:00)\n",
-      "7:\tLeg(mode:car, area:550 --> 550, time:20:20:00 --> 20:23:00, duration:0:03:00)\n",
-      "8:\tActivity(act:other, location:550, time:20:23:00 --> 21:10:00, duration:0:47:00)\n",
-      "9:\tLeg(mode:car, area:550 --> 550, time:21:10:00 --> 21:15:00, duration:0:05:00)\n",
-      "10:\tActivity(act:home, location:550, time:21:15:00 --> 00:00:00, duration:2:45:00)\n",
-      "Person: 2_6\n",
+      "Person: 2_1\n",
       "{'SurveyYear': 2002, 'IndividualID': 2, 'HouseholdID': 1, 'PSUID': 1, 'VehicleID': '2', 'PersNo': 2, 'Age_B01ID': 13, 'OfPenAge_B01ID': 2, 'Sex_B01ID': 1, 'EdAttn1_B01ID': -10, 'EdAttn2_B01ID': -10, 'EdAttn3_B01ID': -10, 'DrivLic_B02ID': 1, 'CarAccess_B01ID': 2, 'DrivDisable_B01ID': -9, 'WkPlace_B01ID': 1, 'ES2000_B01ID': 7, 'NSSec_B03ID': 3, 'SC_B01ID': 4, 'Stat_B01ID': 1, 'SVise_B01ID': 2, 'EcoStat_B02ID': 1, 'PossHom_B01ID': 2}\n",
-      "0:\tActivity(act:work, location:530, time:00:00:00 --> 05:50:00, duration:5:50:00)\n",
-      "1:\tLeg(mode:car, area:530 --> 550, time:05:50:00 --> 05:55:00, duration:0:05:00)\n",
-      "2:\tActivity(act:home, location:550, time:05:55:00 --> 14:35:00, duration:8:40:00)\n",
-      "3:\tLeg(mode:car, area:550 --> 550, time:14:35:00 --> 14:50:00, duration:0:15:00)\n",
-      "4:\tActivity(act:escort, location:550, time:14:50:00 --> 14:58:00, duration:0:08:00)\n",
-      "5:\tLeg(mode:car, area:550 --> 550, time:14:58:00 --> 15:12:00, duration:0:14:00)\n",
-      "6:\tActivity(act:escort, location:550, time:15:12:00 --> 15:22:00, duration:0:10:00)\n",
-      "7:\tLeg(mode:car, area:550 --> 550, time:15:22:00 --> 15:31:00, duration:0:09:00)\n",
-      "8:\tActivity(act:home, location:550, time:15:31:00 --> 21:50:00, duration:6:19:00)\n",
-      "9:\tLeg(mode:car, area:550 --> 550, time:21:50:00 --> 21:56:00, duration:0:06:00)\n",
-      "10:\tActivity(act:work, location:550, time:21:56:00 --> 00:00:00, duration:2:04:00)\n",
-      "Person: 3_6\n",
-      "{'SurveyYear': 2002, 'IndividualID': 3, 'HouseholdID': 1, 'PSUID': 1, 'VehicleID': ' ', 'PersNo': 3, 'Age_B01ID': 4, 'OfPenAge_B01ID': 2, 'Sex_B01ID': 1, 'EdAttn1_B01ID': -10, 'EdAttn2_B01ID': -10, 'EdAttn3_B01ID': -10, 'DrivLic_B02ID': -9, 'CarAccess_B01ID': 4, 'DrivDisable_B01ID': -9, 'WkPlace_B01ID': -9, 'ES2000_B01ID': -9, 'NSSec_B03ID': -9, 'SC_B01ID': -9, 'Stat_B01ID': -9, 'SVise_B01ID': -9, 'EcoStat_B02ID': -9, 'PossHom_B01ID': -9}\n",
-      "0:\tActivity(act:education, location:530, time:00:00:00 --> 15:22:00, duration:15:22:00)\n",
-      "1:\tLeg(mode:car, area:530 --> 550, time:15:22:00 --> 15:31:00, duration:0:09:00)\n",
-      "2:\tActivity(act:home, location:550, time:15:31:00 --> 00:00:00, duration:8:29:00)\n",
-      "Person: 4_6\n",
-      "{'SurveyYear': 2002, 'IndividualID': 4, 'HouseholdID': 1, 'PSUID': 1, 'VehicleID': ' ', 'PersNo': 4, 'Age_B01ID': 2, 'OfPenAge_B01ID': 2, 'Sex_B01ID': 2, 'EdAttn1_B01ID': -10, 'EdAttn2_B01ID': -10, 'EdAttn3_B01ID': -10, 'DrivLic_B02ID': -9, 'CarAccess_B01ID': 4, 'DrivDisable_B01ID': -9, 'WkPlace_B01ID': -9, 'ES2000_B01ID': -9, 'NSSec_B03ID': -9, 'SC_B01ID': -9, 'Stat_B01ID': -9, 'SVise_B01ID': -9, 'EcoStat_B02ID': -9, 'PossHom_B01ID': -9}\n",
-      "0:\tActivity(act:home, location:530, time:00:00:00 --> 12:18:00, duration:12:18:00)\n",
-      "1:\tLeg(mode:car, area:530 --> 550, time:12:18:00 --> 12:32:00, duration:0:14:00)\n",
-      "2:\tActivity(act:visit, location:550, time:12:32:00 --> 14:58:00, duration:2:26:00)\n",
-      "3:\tLeg(mode:car, area:550 --> 550, time:14:58:00 --> 15:12:00, duration:0:14:00)\n",
-      "4:\tActivity(act:escort, location:550, time:15:12:00 --> 15:22:00, duration:0:10:00)\n",
-      "5:\tLeg(mode:car, area:550 --> 550, time:15:22:00 --> 15:31:00, duration:0:09:00)\n",
-      "6:\tActivity(act:home, location:550, time:15:31:00 --> 00:00:00, duration:8:29:00)\n"
+      "0:\tActivity(act:home, location:530, time:00:00:00 --> 13:53:00, duration:13:53:00)\n",
+      "1:\tLeg(mode:car, area:530 --> 550, time:13:53:00 --> 13:56:00, duration:0:03:00)\n",
+      "2:\tActivity(act:work, location:550, time:13:56:00 --> 22:00:00, duration:8:04:00)\n",
+      "3:\tLeg(mode:car, area:550 --> 550, time:22:00:00 --> 22:05:00, duration:0:05:00)\n",
+      "4:\tActivity(act:home, location:550, time:22:05:00 --> 00:00:00, duration:1:55:00)\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAAGlCAYAAACBakEVAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAABJcklEQVR4nO3deZgcZbn38e+dCUxGwr4k7AGFCLJGEA6iIKssAURAETgCHlEU5PCKKMJBUGTxqBhA5IhCEBIWNYBBkE0W2bcEIkjYJARCwhZIgJCQ5H7/qJowCTOZnklmeir5fq6rr+nuWvpX1T1d1Xc/z9ORmUiSJEmSJKm6etU7gCRJkiRJkhaMBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4izwSJKkTomI5yNiWkS8HRGTIuLiiOhb71xtiYihEXFaeX1ARGSZvTn/dRGxcwfX+ZOIGBMRMyPilA4st3JEDI+INyNickQM6+DmSJIkzcUCjyRJWhCDM7MvMAjYEjipIwtHoZ7nI8uV+TcFbgaujohDO7D8M8DxwF87+LgjgInA2sAqwM87uLwkSdJcLPBIkqQFlpkvATcAGwFExNYRcU/ZQuXRiNi+ed6IuD0ifhoRdwPvAutGxKER8VxETI2If0fEQeW8vSLipIgYFxGvRMQfImLZclpzK5yvRsQLEfFaRJzYyfwTM3MIcApwVq1Fp8y8JDNvAKbW+lgRsQuwJvC9zHwrM9/PzFGdyS1JktTMAo8kSVpgEbEmsDswKiJWp2jRchqwAnAc8OeIWLnFIocARwBLA68C5wC7ZebSwDbA6HK+Q8vL54B1gb7AefM8/LbAQGBH4OSI2GABNmUERYuageV2nR8R5y/A+lqzNTAWuCQiXo+IByNiu4X8GJIkaTFjgUeSJC2IayLiTeAu4A7gdOBg4PrMvD4zZ2fmzcBDFAWgZkMz8/HMnAnMBGYDG0VEU2a+nJmPl/MdBPwyM5/LzLeBE4AvR0TvFus6NTOnZeajwKMU3a06a0L5dwWAzPxWZn5rAdbXmjWAXYDbgP7AL4BrI2Klhfw4kiRpMWKBR5IkLYh9MnO5zFy7LIZMoxhXZv+ye9abZQFoW2DVFsuNb76Sme8AXwK+CbwcEX+NiI+Xk1cDxrVYbhzQG+jX4r6JLa6/S9HKp7NWL/++sQDraM804PnM/H3ZPesKiv3x6S58TEmStIizwCNJkha28cClZeGn+bJUZp7ZYp5suUBm3piZO1MUgZ4ELiwnTaAoGDVbi6LFz6Quyv4F4BWKLlRd5THm2X5JkqQFZYFHkiQtbJcBgyNi14hoiIg+EbF9RKzR2swR0S8i9oqIpYDpwNvArHLy5cCxEbFO+RPspwNXll27Fpoyw1HAj4ATMnN2jcstERF9KM6pepfb2tDOYlcDy5eDQzdExH4ULYfuXpBtkCRJizcLPJIkaaHKzPHA3sAPKQZQHg98j7bPO3oB36VorfMGsB3QPO7NRcClwJ3Av4H3gKMXYtw3I+IdYAzFGEH7Z+ZFzRMj4oKIuGA+y19I0eXqQODE8voh83vAzHwD2Iti8Om3gB8Ae2fmawuyIZIkafEWmbYQliRJkiRJqjJb8EiSJEmSJFWcBR5JkqSFrOza9XYrl/l195IkSeo0u2hJkiRJkiRVnC14JEmSJEmSKq53B+a1qY8kSZIkSVLXi44uYAseSZIkSZKkiqu5BU9Eh4tHkiRJkiRJ6qDOjJdsCx5JkiRJkqSK68gYPOTrx3RVDkmSpB4jVhwCwODBg9udd+TIkXPdbrlM87SxY8cuxHSSajVw4ECgtv/lWjT/T/u5qJqa39ubzXz4pTol+bDen1wd+OC16mtt8Tbva7VWtuCRJEmSJEmqOAs8kiRJkiRJFWeBR5IkSZIkqeIs8EiSJEmSJFWcBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4izwSJIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSarB7NmzuefRB+sdQ2qVBR5JkiRJkmrQq1cvvnf2j+sdQ2qVBR5JkiRJkmq089bbMeLWv5KZ9Y4izaV3vQNIkiRJklQVvxr2W96Z9i4NvRpo6tOHzCQimHzn2HpH02LOAo8kSZIkSTV68x9P1TuC1Cq7aEmSJEmSVKPMZNj1f+a0C88GYPzEl3jgn6PqnEqywCNJkiRJUs2OOuME7nvsYa742zUA9P3IUnznrBPrG0rCAo8kSZIkSTV74J+jOPcHp9OnsRGA5ZdZjhnvz6hzKskCj6Ru1Het8+e6PXT4Exx1/G11SiNJWhydfvrpDB06dM7tr33ta5x44gffvJ955plcfPHFNa3rkEMOYcyYMQs7orRQeN7VdXr3XoJZs2YRBACvTn6dXr38aN0WX4vdx1ehJEmSFhubb745o0YVY2XMnj2byZMn88wzz8yZPmrUKAYNGtTuembNmtVlGSX1bEd/+XC+eNzXeGXya5z06zPZ7mv78IPDjq53LMlf0ZLUM4wbP4XDj76ZV1+fxsorNnHxeTuz1hrLcOi3b6KpT2+efGYy48ZP4eJzd+aSK/7FvQ++zFaf7M/QX+8CwE23jeNHZ97H9Bmz+OiAZbn43J3p23fJOm+VJKmnGTRoEGeccQYATz/9NOuttx6vvvoqb731Fk1NTTz77LNMmTKFffbZh1mzZrHRRhtx6qmnsuSSS7LDDjuw7777cvfdd3PwwQfPWefs2bM54YQT6N+/P8cee2y9Nk2qmeddC+Yru+/LoA024e8P3kVm8udfXMQG66xX71iV5Gtx4bIFj6RuM23aTDbbbticy8ln3jtn2lHfv53//NIGPPaPgzlo/4/znR/cMWfa5Lem8/dr9uXs0z7L4K+M5NgjN+fxew5hzL9eZ/SYV3nt9Wmc9osHuGXEvjxy21fYYrN+/PI3/pKBJOnD+vXrR+/evZkwYQKjRo1is802Y5NNNmH06NGMGTOGAQMGcNJJJ3H22WczcuRIZs2axfDhw+cs39jYyOWXX84ee+wBFC15jjvuOAYMGGBxRz2K511da7211mGfz32ewZ/dhaX6fIQXXn6p3pF6LF+L3ccWPJK6TVNTb0bfcdCc20OHP8FDoycBcO+DLzPikuJk+ZADPs7xp9w1Z77Bu65DRLDxhivRb5UmNt5wJQA+MXAFnn9hCi9OmMoTY9/g07tfBcCMGbP5jy37d9dmSZIqprmb1qhRozjssMOYNGkSjzzyCEsvvTT9+vWjsbGRddZZB4AvfOELDBs2jEMPPRSA3Xfffa51nXzyyey2224ceeSR3b0Z0nx53tV1zrviIn7y21/Sb8WVaejVQGYSEYy68pZ6R+uRfC12Hws8knqkiJhzvbGxAYBevYLGJT942+rVK5g5azYNDQ3svP1aXH7hbt2eU5JUPYMGDWLUqFE89dRTrLfeevTv35+LLrqIvn37suGGG3LPPfe0uWxTU9NctzfffHPuv/9+Dj/8cBrLX9SRqsbzro459/Lf88SIO1lxuRXqHWWR42txwdhFS1KPsM2nVuWKEU8BMOyPY9l2q9VqXnbrLfpz9/0TeOa5NwF49933eeqZyV0RU5K0CBg0aBC33XYbyy67LA0NDSy33HJMnTqV0aNH88UvfpGXXnqJcePGAXDttdey5ZZbtrmu/fbbj+22245jjjmGmTNndtcmSAvE864Fs0a/VVm27zL1jrFI8LW4cNmCR1KPcM4Z23P40Tfzv+c9PGeAtVqtvNJHGHreLhz49RuYPqP4VZPTfrgN639s+a6KK0mqsPXXX5/Jkyez5557znXfO++8Q//+/TnjjDM45phj5gyyfOCBB853fYcddhhTp07l+OOP5+c//7k/l6wez/Ouzjn7sv8DYN011maHI/Zj9213pHHJDwb0Pfbgb9QrWmX5Wly4IjNrmzEi8/VjujiOJElS/cWKQwAYPHhwu/OOHDlyrtstl2meNnbs2IWYTlKtBg4cCNT2v1yL5v9pPxdVU/N7e7OZD3dsYOQf//aXba+b4H+O6PxA670/uTrwwWvV19riLVYcQmZG+3POzRY8kiRJkiS14+Qj/h8Af7p5JPvtPHfR8E83j2xtEalb2X5UkiRJkqQanXXxeTXdJ3U3W/BIkiRJktSOG+7+O3+7+++89OpE/vtn/zPn/invTKWhtx+tVX++CiVJkiRJasdqK/fjkxtswp9uuY711l6XiKChVy/6rbAyv/juKfWOJ1ngkSRJkiSpPRuusz7Db7iaGe+/z9BrryBJxk+cwFf3+hJ7fGaneseTHINHkiRJkqT2fP+c03hzyls8d939PDj8Rh4afhNP/+Veprw9leN/9ZN6x5Ms8EiSJEmS1J7r/3ELF5z0M5Zequ+c+5bpuzS/PuEMbrj71jomkwoWeCRJkiRJakdEEBEfur+hoaHV+6XuZoFHkiRJkqR2bLDO+lx63R8/dP+w6//MwAEfq0MiaW4OsixJkiRJUjvO/cFP2e+4r3PxX65k0Mc3JiJ46IlHmTb9Pf7889/VO55kgUeSJEmSpPasvsqq3PuH6/j7A3fxxHNPkZl8/tOfY8dPfabe0STAAo8kSZIkSTXb4VPbssOntq13DOlDHINHkiRJkiSp4izwSJIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHGRmbXNGFHbjJIkSZIkSeq0zIyOLmMLHkmSJEmSpIrrXeuMtbb0kSRJkiRJUveyBY8kSZIkSVLF1VzgiYhvAFHFi9nNbfaef6lq9qrmNru5zV6NS1WzVzW32c1t9p5/qWpus5u9E7mPoIM60oKnwyvvQcze/aqaG8xeL1XNXtXcYPZ6qGpuMHu9VDV7VXOD2euhqrnB7PVQ1dxg9nqpavYuLfBIkiRJkiSpB7LAI0mSJEmSVHEdKfD8tstSdD2zd7+q5gaz10tVs1c1N5i9HqqaG8xeL1XNXtXcYPZ6qGpuMHs9VDU3mL1eqpq9w7nDnz+XJEmSJEmqNrtoSZIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJHVKRDwfEdMi4u2ImBQRF0dE33rnaktEDI2I08rrAyIiy+zN+a+LiJ07sL5VIuLyiJgQEW9FxN0RsVWNy64cEcMj4s2ImBwRwzq7XZIkSWCBR5IkLZjBmdkXGARsCZzUkYWjUM/zkeXK/JsCNwNXR8ShNS7bF3gQ+CSwAnAJ8Ncai1wjgInA2sAqwM87mFuSJGkuFngkSdICy8yXgBuAjQAiYuuIuKdsofJoRGzfPG9E3B4RP42Iu4F3gXUj4tCIeC4ipkbEvyPioHLeXhFxUkSMi4hXIuIPEbFsOa25Fc5XI+KFiHgtIk7sZP6JmTkEOAU4q5aiU2Y+l5m/zMyXM3NWZv4WWBIYOL/lImIXYE3ge5n5Vma+n5mjOpNbkiSpmQUeSZK0wCJiTWB3YFRErA78FTiNomXLccCfI2LlFoscAhwBLA28CpwD7JaZSwPbAKPL+Q4tL58D1qVoNXPePA+/LUVRZUfg5IjYYAE2ZQRFi5qB5XadHxHn17JgRGxGUeB5pp1ZtwbGApdExOsR8WBEbNf5yJIkSRZ4JEnSgrkmIt4E7gLuAE4HDgauz8zrM3N2Zt4MPERRAGo2NDMfz8yZwExgNrBRRDSVLWIeL+c7CPhl2VrmbeAE4MsR0bvFuk7NzGmZ+SjwKEV3q86aUP5dASAzv5WZ32pvoYhYBri0zPJWO7OvAewC3Ab0B34BXBsRK3U6tSRJWuxZ4JEkSQtin8xcLjPXLosh0yjGldm/7J71ZlkA2hZYtcVy45uvZOY7wJeAbwIvR8RfI+Lj5eTVgHEtlhsH9Ab6tbhvYovr71K08ums1cu/b9S6QEQ0ASOB+zLzjBoWmQY8n5m/L7tnXUGxPz7d4bSSJEklCzySJGlhGw9cWhZ+mi9LZeaZLebJlgtk5o2ZuTNFEehJ4MJy0gSKglGztSha/EzqouxfAF6h6ELVrohoBK4BXgK+UeNjPMY82y9JkrSgLPBIkqSF7TJgcETsGhENEdEnIraPiDVamzki+kXEXhGxFDAdeBuYVU6+HDg2ItYpf53qdODKsmvXQlNmOAr4EXBCZs6uYZklgD9RtMj5z1qWKV0NLF8ODt0QEftRtBy6u5PxJUmS6N3+LJIkSbXLzPERsTfwM4oCzSzgAeDINhbpBXyXYgybpBhguXncm4soumndCfQBbgSOXohx34yIAN6hGCdo/8z8W/PEiLig3KZvtrLsNsCeFAWeN4vVAMVg0f9o6wEz842I2As4H/g1RYulvTPztYWwPZIkaTEVmbYQliRJkiRJqjK7aEmSJEmSJFWcBR5JkqSFLCIuiIi3W7lcUO9skiRp0WQXLUmSJEmSpIqzBY8kSZIkSVLFdeRXtGzqI0mSJEmS1PWi/VnmZgseSZIkSZKkiqu5BU9Eh4tHkiRJkiRJ6qDOjJdsCx5JkiRJkqSK68gYPIwdO7arckhahA0cOBCAwYMHAzBy5EgA8vVj6pZJklR9seIQ4IPjS3uajz+3nHLrXPfvdMqONa+nrXXUsi6Pf5J6otbeS5vfr6wB1Efz56eOsgWPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHEWeCRJkiRJkirOAo8kSZIkSVLFWeCRJEmSJEmqOAs8kiRJkiRJFWeBR5IkSZIkqeIs8EiSJEmSJFWcBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4izwSJIkSZIkVZwFHkmSJEmSpIqzwKNWnX766QwdOnTO7a997WuceOKJc26feeaZXHzxxTWt65BDDmHMmDELO6IkVUbftc6f6/bQ4U9w1PG31SmNJKmn8Tghtc/PqO2zwKNWbb755owaNQqA2bNnM3nyZJ555pk500eNGsWgQYPaXc+sWbO6LKMkSZIkafHgZ9T29a53APVMgwYN4owzzgDg6aefZr311uPVV1/lrbfeoqmpiWeffZYpU6awzz77MGvWLDbaaCNOPfVUllxySXbYYQf23Xdf7r77bg4++OA565w9ezYnnHAC/fv359hjj63XpklSjzJu/BQOP/pmXn19Giuv2MTF5+3MWmssw6HfvommPr158pnJjBs/hYvP3ZlLrvgX9z74Mlt9sj9Df70LADfdNo4fnXkf02fM4qMDluXic3emb98l67xVkqSFxeOEVPAzavtswaNW9evXj969ezNhwgRGjRrFZpttxiabbMLo0aMZM2YMAwYM4KSTTuLss89m5MiRzJo1i+HDh89ZvrGxkcsvv5w99tgDKKqkxx13HAMGDFgk/nEkqSOmTZvJZtsNm3M5+cx750w76vu3859f2oDH/nEwB+3/cb7zgzvmTJv81nT+fs2+nH3aZxn8lZEce+TmPH7PIYz51+uMHvMqr70+jdN+8QC3jNiXR277Clts1o9f/mZUPTZRkrQAPE5I7fMzavtswaM2NTeBGzVqFIcddhiTJk3ikUceYemll6Zfv340NjayzjrrAPCFL3yBYcOGceihhwKw++67z7Wuk08+md12240jjzyyuzdDkuquqak3o+84aM7tocOf4KHRkwC498GXGXFJcaJxyAEf5/hT7poz3+Bd1yEi2HjDlei3ShMbb7gSAJ8YuALPvzCFFydM5Ymxb/Dp3a8CYMaM2fzHlv27a7MkSQuJxwmpNn5GnT8LPGrToEGDGDVqFE899RTrrbce/fv356KLLqJv375suOGG3HPPPW0u29TUNNftzTffnPvvv5/DDz+cxsbGro4uSZUVEXOuNzY2ANCrV9C45AeH7F69gpmzZtPQ0MDO26/F5Rfu1u05JUn14XFCizM/o86fXbTUpkGDBnHbbbex7LLL0tDQwHLLLcfUqVMZPXo0X/ziF3nppZcYN24cANdeey1bbrllm+vab7/92G677TjmmGOYOXNmd22CJPV423xqVa4Y8RQAw/44lm23Wq3mZbfeoj933z+BZ557E4B3332fp56Z3BUxJUl14nFC+oCfUefPAo/atP766zN58mQ23XTTue7r27cv/fv354wzzuCYY45h8ODBRAQHHnjgfNd32GGHseGGG3L88ccze/bsro4vSZVwzhnbc/HwJ9jkM5dx6VX/YsgZn6152ZVX+ghDz9uFA79+A5t85jK23vVKnnzaE3dJWpR4nJA+4GfU+YvMrG3GiBw7dmwXx5G0KBo4cCAAgwcPBmDkyJEA5OvH1C2TJKn6YsUhwAfHl/Y0H39uOeXWue7f6ZQda15PW+uoZV0e/yT1RK29lza/X1kDqI+BAweSmdH+nHOzBY8kSZIkSVLFWeCRJEmSJEmqOAs8kiRJkiRJFWeBR5IkSZIkqeIs8EiSJEmSJFWcBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4izwSJIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHEWeCRJkiRJkiouMrO2GSNqm1GSJEmSJEmdlpnR0WVswSNJkiRJklRxvWudsdaWPpIkSZIkSepetuCRJEmSJEmquJoLPBHxDSCqeDG7uc3e8y9VzV7V3GY3t9mrcalq9qrmNru5zd7zL1XNbXazdyL3EXRQR1rwdHjlPYjZu19Vc4PZ66Wq2auaG8xeD1XNDWavl6pmr2puMHs9VDU3mL0eqpobzF4vVc3epQUeSZIkSZIk9UAWeCRJkiRJkiquIwWe33ZZiq5n9u5X1dxg9nqpavaq5gaz10NVc4PZ66Wq2auaG8xeD1XNDWavh6rmBrPXS1Wzdzh3+PPnkiRJkiRJ1WYXLUmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkqROiYjnI2JaRLwdEZMi4uKI6FvvXG2JiKERcVp5fUBEZJm9Of91EbFzB9d5W0S8GhFTIuLRiNi7xuVWjojhEfFmREyOiGGd2SZJkqRmFngkSdKCGJyZfYFBwJbASR1ZOAr1PB9Zrsy/KXAzcHVEHNqB5Y8BVs3MZYAjgMsiYtUalhsBTATWBlYBft6h1JIkSfOwwCNJkhZYZr4E3ABsBBARW0fEPWULlUcjYvvmeSPi9oj4aUTcDbwLrBsRh0bEcxExNSL+HREHlfP2ioiTImJcRLwSEX+IiGXLac2tcL4aES9ExGsRcWIn80/MzCHAKcBZtRadMvOxzJzZfBNYAlhzfstExC7lPN/LzLcy8/3MHNWZ3JIkSc0s8EiSpAUWEWsCuwOjImJ14K/AacAKwHHAnyNi5RaLHELR4mVp4FXgHGC3zFwa2AYYXc53aHn5HLAu0Bc4b56H3xYYCOwInBwRGyzApoygaFEzsNyu8yPi/PktUHbteg+4H7gdeKidx9gaGAtcEhGvR8SDEbHdAmSWJEmywCNJkhbINRHxJnAXcAdwOnAwcH1mXp+ZszPzZoqix+4tlhuamY+XrV9mArOBjSKiKTNfzszHy/kOAn6Zmc9l5tvACcCXI6J3i3WdmpnTMvNR4FGK7ladNaH8uwJAZn4rM781vwUyc0+KQtXuwI2ZObudx1gD2AW4DegP/AK4NiJWWoDckiRpMWeBR5IkLYh9MnO5zFy7LIZMoxhXZv+ye9abZQFoW6Dl2DTjm69k5jvAl4BvAi9HxF8j4uPl5NWAcS2WGwf0Bvq1uG9ii+vvUrTy6azVy79vdGShspvVDcCuEbFXO7NPA57PzN+Xy11BsT8+3fG4kiRJBQs8kiRpYRsPXFoWfpovS2XmmS3myZYLZOaNmbkzRRHoSeDCctIEioJRs7UoWvxM6qLsXwBeoehC1Rm9gY+2M89jzLP9kiRJC8oCjyRJWtguAwZHxK4R0RARfSJi+4hYo7WZI6JfROwVEUsB04G3gVnl5MuBYyNinfIn2E8HrmwxsPFCUWY4CvgRcEIN3ayIiI9HxG4R0RQRS0TEwcBnKbqqzc/VwPLl4NANEbEfRcuhuxd0OyRJ0uKrd/uzSJIk1S4zx0fE3sDPKAo0s4AHgCPbWKQX8F3gUoqWLaOB5nFvLqLopnUn0Ae4ETh6IcZ9MyICeIdinKD9M/NvzRMj4oJym77ZyrJB8atbG1Js49PAlzLzkfk9YGa+UXbjOh/4NUWLpb0z87UF3xxJkrS4ikxbCEuSJEmSJFWZXbQkSZIkSZIqzgKPJEnSQhYRF0TE261cLqh3NkmStGiyi5YkSZIkSVLFdWSQZStBkiRJkiRJXS86uoBdtCRJkiRJkiqu5hY8xS+ISpIkSZIkqSt1ZjgdW/BIkiRJkiRVXEfG4GHkc0d2VQ5JkiSp8gav+5vi7+DBH5o2cuRIAPL1Y7o1kySpWmLFIZ1azhY8kiRJkiRJFWeBR5IkSZIkqeIs8EiSJEmSJFWcBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4izwSJIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHEWeCRJkiRJkirOAo8kSZIkSVLF9a53AElalO39sQtYe+AKc25/Zs+Psf+Rg+aaZ8x9LzHiwkf50e93X2iPO+a+l+i9RAMbfLI/ADcMe5zGpt7ssO/AhfYYkiRJ8+q71vm8/cK35tweOvwJHho9ifN+9rk6ppIWDxZ4JKkLLdmngXP+ekC3P+6Y+ybQZ6kl5hR4djvoE92eQZIkSVL3scAjSXXw8B0vcOFP7maZ5fvw0Y1WnnP/8F89SJ+llmDfr28GwLc/fwUn/253+q2xDH8fMZarLxwNEQz4+Ip895c78sCtz3PleQ8z8/3ZLL1cI989eydmTJ/JDcMfp1dDL26/5im+8aNtefSel+as97knXuP8k+5g+rSZ9F97WY4563P0XbaREw68loGbrsJj903gnSnT+c6Z2/OJT61Wnx0kSZIWOePGT+Hwo2/m1densfKKTVx83s6stcYyHPrtm2jq05snn5nMuPFTuPjcnbnkin9x74Mvs9Un+zP017sAcNNt4/jRmfcxfcYsPjpgWS4+d2f69l2yzlsl9RwWeCSpC814bxbf2eOqObf3P3IQW+08gPN+eDs/vWwvVh2wLGcdfXO76xn31Btc9euHOeuPX2DZFZqY+uZ7AGy4xar8fMS+RAQ3XvkEI347mq+duA27feUTcxWKHr3npTnrOvu7t3LEKZ9h461W47KzH+DyIQ/y9ZO3BWDWrOSX13yRh24bx+XnPMRpl+21EPeGJEla1E2bNpPNths25/Ybk99jr8+vC8BR37+d//zSBnz1wA25aNjjfOcHd3DNZYMBmPzWdP5+zb785YbnGPyVkdx9w/78bshObLnTFYwe8yprrNaX037xALeM2JelllqCs4Y8xC9/M4qTv7dVXbZT6oks8EhSF2qti9ZzT7xGvzWWYbV1lgPgc/usx98u/9d81/PYvS+xzW4fZdkVmgBYerk+ALz28tucdfQ9TH7lXWa+P4t+ay4z3/W8M2U6b0+ZwcZbFS1zdtx3IGceddOc6f+x6zoAfHSjlXnlpam1b6gkSRLQ1NSb0XccNOd28xg8APc++DIjLtkDgEMO+DjHn3LXnPkG77oOEcHGG65Ev1Wa2HjDlQD4xMAVeP6FKbw4YSpPjH2DT+9efHE2Y8Zs/mPL/t21WVIlWOCRpHqI1u9u6N2LnJ1zbr8/fRYAmUm0ssz/nXoX+3xtE7baaR3G3PcSw4c8tECxlliyAYBeDcGsmdnO3JIkSZ0XLU5uGhvLc5BeQeOSH3xM7dUrmDlrNg0NDey8/VpcfuFu3Z5Tqgp/Jl2SutkaH12OSeOn8vK4twC48y/PzJm2yhpL8+zjrwHwzD9fZdL4ohXNptuswV1/fZYpk4uuWc1dtN6dOoMV+/UF4NY/j52znqa+SzDt7Rkfeuyllmmk77KNPP7ABABuu/opNnKcHUmS1A22+dSqXDHiKQCG/XEs225V+znI1lv05+77J/DMc28C8O677/PUM5O7IqZUWbbgkaQuNO8YPIM+uxaHfn9rjjp9O0792vUss3wfNtxiVcY99QYA23x+Xf4+Yizf2eMq1ttkFVZbZ1kA1l5/BQ749iBOOPAaevXqxbqfWIlj/3cHDjxmC8486kZW7LcUAzfvx6QXi4LQp3YYwJnfvpH7b3meb/xo27kyHfvzHeYMstxvrWX475/t0E17Q5IkLc7OOWN7Dj/6Zv73vIfnDLJcq5VX+ghDz9uFA79+A9NnFC2cT/vhNqz/seW7Kq5UOZFZWxP8iMiRzx3ZxXEkSZKk6hq87m+Kv4MHf2jayJEjAcjXj+nWTJKkaokVh5CZbQzq0Da7aEmSJEmSJFWcBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4izwSJIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHEWeCRJkiRJkirOAo8kSZIkSVLFWeCRJEmSJEmqOAs8kiRJkiRJFWeBR5IkSZIkqeIiM2ubMaK2GSVJkiRJktRpmRkdXcYWPJIkSZIkSRXXu9YZa23pI0mSJEmSpO5VcwueiPgGEFW8mN3cZu/5l6pmr2pus5vb7NW4VDV7VXOb3dxm7/mXquY2u9k7kfsIOqgjXbQ6vPIexOzdr6q5wez1UtXsVc0NZq+HquYGs9dLVbNXNTeYvR6qmhvMXg9VzQ1mr5eqZu/SAo8kSZIkSZJ6IAs8kiRJkiRJFdeRAs9vuyxF1zN796tqbjB7vVQ1e1Vzg9nroaq5wez1UtXsVc0NZq+HquYGs9dDVXOD2eulqtk7nDv8dSxJkiRJkqRqs4uWJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHEWeCRJkiRJkirOAo8kSeqUiHg+IqZFxNsRMSkiLo6IvvXO1ZaIGBoRp5XXB0REltmb818XETt3ct3bles7rcb5V46I4RHxZkRMjohhnXlcSZKkZhZ4JEnSghicmX2BQcCWwEkdWTgK9TwfWa7MvylwM3B1RBzakRVExBLAEOD+Diw2ApgIrA2sAvy8I48pSZI0Lws8kiRpgWXmS8ANwEYAEbF1RNxTtlB5NCK2b543Im6PiJ9GxN3Au8C6EXFoRDwXEVMj4t8RcVA5b6+IOCkixkXEKxHxh4hYtpzW3ArnqxHxQkS8FhEndjL/xMwcApwCnNXBotN3gZuAJ2uZOSJ2AdYEvpeZb2Xm+5k5qqOZJUmSWrLAI0mSFlhErAnsDoyKiNWBvwKnASsAxwF/joiVWyxyCHAEsDTwKnAOsFtmLg1sA4wu5zu0vHwOWBfoC5w3z8NvCwwEdgROjogNFmBTRlC0qBlYbtf5EXF+WzNHxNrA4cCPO/AYWwNjgUsi4vWIeDAitluAzJIkSRZ4JEnSArkmIt4E7gLuAE4HDgauz8zrM3N2Zt4MPERRAGo2NDMfz8yZwExgNrBRRDRl5suZ+Xg530HALzPzucx8GzgB+HJE9G6xrlMzc1pmPgo8StHdqrMmlH9XAMjMb2Xmt+Yz/znA/5TZarUGsAtwG9Af+AVwbUSs1Im8kiRJgAUeSZK0YPbJzOUyc+2yGDKNYlyZ/cvuWW+WBaBtgVVbLDe++UpmvgN8Cfgm8HJE/DUiPl5OXg0Y12K5cUBvoF+L+ya2uP4uRSufzlq9/PtGezNGxGBg6cy8soOPMQ14PjN/X3bPuoJif3y6g+uRJEmao3f7s0iSJHXIeODSzPz6fObJuW5k3gjcGBFNFF27LgQ+Q9GiZu0Ws65F0eJnEkVLmIXtC8ArFF2o2rMjsEVENBeYlgVmRcTGmbn3fJZ7DBi8YDElSZLmZgseSZK0sF0GDI6IXSOiISL6RMT2EdFqQSYi+kXEXhGxFDAdeBuYVU6+HDg2ItYpf4L9dODKsmvXQlNmOAr4EXBCZs6uYbH/AdYHNisvf6EoTB3WznJXA8uXg0M3RMR+FC2H7u5kfEmSJFvwSJKkhSszx0fE3sDPKAo0s4AHgCPbWKQXxS9RXUrRsmc00DzuzUUU3bTuBPoANwJHL8S4b0ZEAO9QjBO0f2b+rXliRFxQbtM3510wM6cCU1vMOw14JzPn270rM9+IiL2A84FfU/z61t6Z+dpC2B5JkrSYisxsfy5JkiRJkiT1WHbRkiRJkiRJqjgLPJIkSQtZRFwQEW+3crmg3tkkSdKiyS5akiRJkiRJFdeRQZatBEmSJEmSJHW96OgCdtGSJEmSJEmquJpb8BS/ICpJkiRJkqSu1JnhdGzBI0mSJEmSVHEdGYOHfP2YrsohSZLUY8SKQwAYPHhwu/OOHDkSgFnXHd6lmdR1Gva8COjY833LKbe2On2nU3Zsc13Ny3pOLUman+bzkI6yBY8kSZIkSVLFWeCRJEmSJEmqOAs8kiRJkiRJFWeBR5IkSZIkqeIs8EiSJEmSJFWcBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4izwSJIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHEWeCR1m75rnT/X7aHDn+Co42+rUxpJ0g4/uJ4bH35xrvuGXPs4H/vaVZz1x0fbXO6hp1/jmP+7D4DbH3uZe/41qUtzSqoOz/ek+uld7wCSJEmqjy9tty5X/uPf7PrJNebcd+Wdz3HxsZ/lMxv1b3O5LdZbiS3WWwmAO8a8TN+mJdhmg35dnleSJLXNAo+kHmHc+CkcfvTNvPr6NFZesYmLz9uZtdZYhkO/fRNNfXrz5DOTGTd+ChefuzOXXPEv7n3wZbb6ZH+G/noXAG66bRw/OvM+ps+YxUcHLMvF5+5M375L1nmrJKln2+/TAzj50keY/v4sGpdo4PlJU5nwxrs88/IUrvrHvzn3yP/gj3f9m58MH0VDr2DZpZbk9rP24PbHXuYXV/+Tc7+5Nf93w1gaegXDbnuWId/Yer6FIUmLN8/3pK5lgUdSt5k2bSabbTdszu03Jr/HXp9fF4Cjvn87//mlDfjqgRty0bDH+c4P7uCaywYDMPmt6fz9mn35yw3PMfgrI7n7hv353ZCd2HKnKxg95lXWWK0vp/3iAW4ZsS9LLbUEZw15iF/+ZhQnf2+rumynJFXFisv0Ycv1V+JvD7/I3luvzZV3PscBn1mHiJgzz2mXj+aGH+/K6istxZtvT59r+QH9luYbuw2kb9MSfHffjbs7vqQeyPM9qX4s8EjqNk1NvRl9x0Fzbg8d/gQPjS7Gbbj3wZcZcckeABxywMc5/pS75sw3eNfiw8bGG65Ev1Wa2HjDolvAJwauwPMvTOHFCVN5YuwbfHr3qwCYMWM2/7Gl3yBLUi2+vN26XHnnc2WB59/87phteez5yXOmb7PBKhz2q3+w/7brsO82a9cxqaQq8HxPqh8LPJJ6pJbfHjc2NgDQq1fQuOQHb1u9egUzZ82moaGBnbdfi8sv3K3bc0pS1e2z9doc97sHeOSZ15g2YyaDPrbSXAWe3xz1ae4f+wrXP/gig75zLY+cs3cd00palHi+Jy1c/oqWpB5hm0+tyhUjngJg2B/Hsu1Wq9W87NZb9Ofu+yfwzHNvAvDuu+/z1DOT57+QJAmAvk1LsN3G/fmvIXfx5c+u+6Hpz748ha0GrsKpBw9ipWUaGf/aO3NNX7ppCaZOe7+74kqqMM/3pK5lCx5JPcI5Z2zP4UffzP+e9/CcQfdqtfJKH2Hoebtw4NdvYPqMWQCc9sNtWP9jy3dVXElapHz5s+uy3+l/Z/jx239o2vEXPcgzE6aQmeyw6Wpsus4K3DFm4pzpe261Fgec8Xf+ct8LDrIsab4835O6VmRmbTNGZL5+TBfHkSRJqr9YcQgAgwcPbnfekSNHAjDrusO7NJO6TsOeFwEde75vOeXWVqfvdMqOba6reVnPqSVJ8xMrDiEzo/0552YXLUmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHEWeCRJkiRJkirOAo8kSZIkSVLFWeCRJEmSJEmqOAs8kiRJkiRJFWeBR5IkSZIkqeIs8EiSJEmSJFWcBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4iIza5sxorYZJUmSJEmS1GmZGR1dxhY8kiRJkiRJFde71hlrbekjSZIkSZKk7mULHkmSJEmSpIqrucATEd8AoooXs5vb7D3/UtXsVc1tdnObvRqXqmavam6zm9vsPf9S1dxmN3snch9BB3WkBU+HV96DmL37VTU3mL1eqpq9qrnB7PVQ1dxg9nqpavaq5gaz10NVc4PZ66GqucHs9VLV7F1a4JEkSZIkSVIPZIFHkiRJkiSp4jpS4Pltl6XoembvflXNDWavl6pmr2puMHs9VDU3mL1eqpq9qrnB7PVQ1dxg9nqoam4we71UNXuHc4c/fy5JkiRJklRtdtGSJEmSJEmqOAs8kiRJkiRJFVdTgSciPh8RYyPimYj4QVeHWlgi4qKIeCUi/lnvLB0REWtGxG0R8a+IeDwijql3plpFRJ+IeCAiHi2zn1rvTB0REQ0RMSoirqt3lo6KiOcjYkxEjI6Ih+qdp1YRsVxE/Ckinixf8/9R70y1iIiB5b5uvkyJiP+ud65aRMSx5f/nPyPi8ojoU+9MtYqIY8rcj/f0/d3aMSgiVoiImyPi6fLv8vXM2JY2su9f7vfZEbFFPfPNTxvZ/7d8j3ksIq6OiOXqGLFVbeT+SZl5dETcFBGr1TNjW+Z3vhURx0VERsRK9cjWnjb2+ykR8VKL9/fd65mxNW3t84g4ujxnfzwiflavfPPTxj6/ssX+fj4iRtcxYpvayL5ZRNzXfP4VEZ+qZ8bWtJF704i4tzx3HBkRy9QzY1va+lzU04+n88nd44+l88lehWNpW9l7/PG0rewtptd2PM3M+V6ABuBZYF1gSeBRYMP2lusJF+CzwCDgn/XO0sHcqwKDyutLA09VaJ8H0Le8vgRwP7B1vXN1IP//A4YD19U7SyeyPw+sVO8cnch9CfBf5fUlgeXqnakT29AATATWrneWGrKuDvwbaCpvXwUcWu9cNWbfCPgn8BGgN3ALsF69c80n74eOQcDPgB+U138AnFXvnB3IvgEwELgd2KLeGTuYfRegd3n9rJ6439vIvUyL698BLqh3zlqzl/evCdwIjOupx6c29vspwHH1ztaJ3J8r3xcby9ur1DtnR14vLab/Aji53jk7sN9vAnYrr+8O3F7vnDXmfhDYrrx+OPCTeudsI3urn4t6+vF0Prl7/LF0PtmrcCxtK3uPP562lb28XfPxtJYWPJ8CnsnM5zJzBnAFsHcNy9VdZt4JvFHvHB2VmS9n5iPl9anAvyg+lPV4WXi7vLlEeanESN4RsQawB/C7emdZXJTfFn0W+D1AZs7IzDfrGqpzdgSezcxx9Q5So95AU0T0piiWTKhznlptANyXme9m5kzgDuALdc7UpjaOQXtTFDUp/+7TnZlq1Vr2zPxXZo6tU6SatZH9pvI1A3AfsEa3B2tHG7mntLi5FD30eDqf862zgePpobmh0ueKreU+EjgzM6eX87zS7cFqML99HhEBHABc3q2hatRG9gSaW78sSw88praReyBwZ3n9ZuCL3RqqRvP5XNSjj6dt5a7CsXQ+2atwLG0re48/nrZTA6j5eFpLgWd1YHyL2y9SkWLDoiAiBgCbU7SEqYQoujmNBl4Bbs7MqmT/FcU/zuw65+isBG6KiIcj4oh6h6nRusCrwMVRdI37XUQsVe9QnfBleujJ6Lwy8yXg58ALwMvAW5l5U31T1eyfwGcjYsWI+AjFN6Vr1jlTR/XLzJehOJADq9Q5z+LocOCGeoeoVUT8NCLGAwcBJ9c7T60iYi/gpcx8tN5ZOumosjn/RT2t68d8rA98JiLuj4g7ImLLegfqhM8AkzLz6XoH6YD/Bv63/D/9OXBCfePU7J/AXuX1/anA8XSez0WVOZ5W8fNcs/lk7/HH0nmzV+l42jJ7R4+ntRR4opX7elzFa1EUEX2BPwP/PU/VsUfLzFmZuRlFVfdTEbFRnSO1KyL2BF7JzIfrnWUBfDozBwG7Ad+OiM/WO1ANelM0Gf5NZm4OvEPRzLYyImJJihOkP9Y7Sy3KDyp7A+sAqwFLRcTB9U1Vm8z8F0WT4JuBv1F0GZ4534WkFiLiRIrXzLB6Z6lVZp6YmWtSZD6q3nlqURZgT6SHn0DPx2+AjwKbURTCf1HXNLXrDSwPbA18D7iqbBFTJQdSkS9MWjgSOLb8Pz2WslVyBRxOcb74MEV3kBl1zjNfVf1cVNXc0Hb2KhxLW8teleNpy+wU+7lDx9NaCjwvMndFdw16YNPDRU1ELEHxxA7LzBH1ztMZZVeb24HP1zdJTT4N7BURz1N0Q9whIi6rb6SOycwJ5d9XgKspulf2dC8CL7Zo5fUnioJPlewGPJKZk+odpEY7Af/OzFcz831gBLBNnTPVLDN/n5mDMvOzFM3Nq/QtL8CkiFgVoPzbI7tQLIoi4qvAnsBBWXZor5jh9NAuFK34KEUR+dHyuLoG8EhE9K9rqhpl5qTyy6rZwIVU43gKxTF1RNld/gGKFsk9cnDr1pTdhvcFrqx3lg76KsWxFIoveyrxesnMJzNzl8z8JEVR7dl6Z2pLG5+LevzxtMqf59rKXoVjaQ37vcceT1vJ3uHjaS0FngeB9SJinfKb6i8Df1nQ8Gpb+W3L74F/ZeYv652nIyJi5eYR1SOiieLD5JN1DVWDzDwhM9fIzAEUr/G/Z2YlWjUARMRSEbF083WKQdB6/K/HZeZEYHxEDCzv2hF4oo6ROqNq3za+AGwdER8p32t2pOjjWwkRsUr5dy2KDwJV2vdQHD+/Wl7/KnBtHbMsNiLi88D3gb0y891656lVRKzX4uZeVOB4CpCZYzJzlcwcUB5XX6QYOHJinaPVpPlDY+kLVOB4WroG2AEgItan+OGC1+oZqIN2Ap7MzBfrHaSDJgDbldd3oCJfPLQ4nvYCTgIuqG+i1s3nc1GPPp5W/PNcq9mrcCydT/YefzxtLXunjqdZ24jOu1OM4vwscGIty/SEC8WJ/8vA++XO+Fq9M9WYe1uKbnCPAaPLy+71zlVj9k2AUWX2f9JDfwWhnW3Ynor9ihbFWDaPlpfHK/Z/uhnwUPmauQZYvt6ZOpD9I8DrwLL1ztLB3KdSHNj+CVxK+YsrVbgA/6AoAj4K7FjvPO1k/dAxCFgRuJXiA8CtwAr1ztmB7F8or08HJgE31jtnB7I/QzGeYPMxtSf+ekZruf9c/p8+BoykGCiy7llryT7P9Ofpub+i1dp+vxQYU+73vwCr1jtnjbmXBC4rXzOPADvUO2dHXi/AUOCb9c7Xif2+LfBweVy6H/hkvXPWmPsYis93TwFnAlHvnG1kb/VzUU8/ns4nd48/ls4nexWOpW1l7/HH07ayzzNPu8fTKGeUJEmSJElSRdXSRUuSJEmSJEk9mAUeSZIkSZKkirPAI0mSJEmSVHEWeCRJkiRJkirOAo8kSZIkSVLFWeCRJEmSJEmqOAs8kiRJkiRJFWeBR5IkSZIkqeIs8EiSJEmSJFWcBR5JkiRJkqSKs8AjSZIkSZJUcRZ4JEmSJEmSKs4CjyRJkiRJUsVZ4JEkSZIkSao4CzySJEmSJEkVZ4FHkiRJkiSp4izwSJIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJKnLRcT2EfFivXNICyoiTomIy+qdo6oi4vaI+K9651hURcSAiMiI6N3Nj3tQRNzUnY+5KIuIxyNi+3bmWSsi3o6Ihu5JJakKLPBI6nYR8XxE7DTPfYdGxF31yrQoK08Amy+zI2Jai9sH1Tvfoqx8rU+b5zk4r5see7EtqkXECRFx/Tz3Pd3GfV/u3nSLlvK9e0xEvBsREyPiNxGxXDnNYthCUs/3klayfKiIlJnDMnOXeuSpooi4MSJ+3Mr9e0fERGDTzLx9fuvIzBcys29mziqXtXgqyQKPtDhpauo9sTwp65JLU1PvifXexp6moaGhS/d5Q0NDu/u8PAHsm5l9gReAwS3uG9Y8X3d/49tVGpdo7NJ93rhEY0df5y33d9/MPKpLNryFej2Xffr06dJ936dPn1r3/Z3Ap6P8Zjsi+gNLAIPmue9j5bw1qff/SFMX79+m2vcvABHxXeAs4HvAssDWwNrAzRGx5MLfA3M9dkREl57HNvbp2mNmY58OHzO7/b1kUdPU2MXnQY01P6dDgUMiIua5/xBgWGbOXKgbLmmxsUiczEuqzXvvzeqXrx/TZeuPFYf0WyjridgA+A2wGfAScEJm/qWcNhR4F1gH+AzwKPBF4AfAV4FJwIGZOaqcfzXgXOCzwNvA2Zl5zsLIWYvZs2f3Gzx4cJetf+TIkZ3e51E0/76MYv8cS/Gh7DvApcBWFMeIu4FvZuaLUbR0OC4zt2ixjmOBz2XmXhHRCPwUOABoBK4Gjs3MaZ3N2BkzZs7od8spt3bZ+nc6ZccFfp1HxMeA31O8xt8Hbs3ML5XTPgH8CvhkOW1IZp5e7t+zKPYvwFXA9zNzeivP5T+APYHGiHi7nH/9zJywoNnnZ/r06f3Gjh3bZesfOHBgrfv+QYqCzmbAwxT//7cB685z37MAEfEXYFvgDeCszLywvP8UYCPgPWAv4P+1fJCIWAL4A7AkxfvOjM5uWy3emz6938yHX+qy9ff+5Oo1v7YjYhngVODwzPxbeffzEXEA8BzwX8APi1ljH+DZzNy0nG/tiLgb2AS4F/hKZr5Wrndr4JfAhsA44JjmlgwRcTvFe9L2wCBgY+CZTm5uu2ZMn9Vv5HNHdtXqGbzubxbGe0kDxfvCocAU4BfzTH8e+K/MvKW8fQrwscw8uLy9LfAziv09FfifzBwaEXsApwEfBd4Cfp+Zp5SrbS6KvlnWJ3YGBpaPs2253m2AIcD6wFMUz+M95bTbKd6jdqCV10BXem/GrH6zrju8y9bfsOdFtT6n1wAXUJzH3AkQEctTvG9v1fJ5i4hPAedT7MtpFAWg/xcRA4B/U7zXnVqua+uI+BUw1AKgtHiyBY+kHqX8wDQSuAlYBTgaGBYRA1vMdgBwErASMJ3i5PCR8vafKD4cUH67O5KiCLQ6sCPw3xGxa7dsTDX0B1ag+Nb9CIrjwsXl7bUoTiabuwH8BRgYEeu1WP4rwPDy+lkUJ6CbUbSMWB04uWvjV9ZPKF7jywNrUBRmiIilgVuAvwGrUezH5mrViRQtJDYDNgU+RfF/0Kzlc/mfwG7AhBbf9ndpcacnKQst91MUcSj//gO4a5777gQuB16k2N/7AadHxI4tVrc3xfvKckDLFm9NFB/SpgMHdHVxpwfaBugDjGh5Z2a+DdxA8WHzdODK8vW3aYvZvgIcRvEevyRwHEBErA78laKwsEJ5/58jYuUWyx5C8V61NEUBaHH3dYqiwObAFhSv4ZpExFoUz9W5wMoU7y2jy8nvULyPLAfsARxZFurgg/+h5crn9t551rsCxfN4DrAixTH5rxGxYovZWn0NLC7KLz6uotjHzQ4AnszMR+eZfQhFoX8ZioLbVa2s70SK97ijbN0lLd4s8Eiql2si4s3mC8W3U1B8gO0LnJmZMzLz78B1wIEtlr06Mx/OzPcoWom8l5l/KPuhX0lxoguwJbByZv64XNdzwIWAY258YDbwo8ycnpnTMvP1zPxzZr6bmVMpWuRsB5CZ7wLXUj4XZaHn48BfymbmX6dosfNGuezpuK9hntd6RHydomXO2sBqmfleZjaPP7UnMDEzf1HePzUz7y+nHQT8ODNfycxXKb6xPaTF48z1XHbTtvVkd/DBB9HPUHz4+cc8991B0XLn++X+Hg38jrn3672ZeU1mzm6xX5ehKMI9CxzWPAbGYmYl4LU2upK8XE5vy8WZ+VSLD7mblfcfDFyfmdeX+/tm4CFg9xbLDs3MxzNzZma+v+CbUSmtvZccAPwqM8dn5hvAGR1Y30HALZl5eWa+X77/jwbIzNszc0z5PDxGUQjdrsb17gE8nZmXls/T5cCTQMvmrG29BhYnlwD7l8ViKIo9l7Qy3/vAxyJipcx8OzPv67aEkirHAo+ketknM5drvgDfKu9fDRifmbNbzDuOojVIs0ktrk9r5Xbf8vrawGrzFJJ+CCyUrmSLiFfLQhkAEfGRiPi/iBgXEVMoWjgsFx/8SsdwPii2fQW4piz8rAx8BHi4xb7+W3n/4m6u13rZ/ed4IIAHovi1lOY+A2tSdhtqxWrM3WJhXHlfs7meS3EnsG3Z7WHlzHwauAfYprxvI4oPnc0FyWbzvt+Mb2XdW1N0LTkzM7NL0vd8rwErRevjEq1aTm9Ly3FK3mXu9+z953nP3rZcX7PWno/FRWvvJasx9z7pSKumNt9vImKriLgtIl6NiLeAbzL/ol1L875XNedq+X/V1mtgsVEW9l8F9o6IdSm+lBreyqxfo2gd+2REPBgRe3ZjTEkVY4FHUk8zAVgz5h48cy2KsXg6ajzw73lOiJfOzN3bXXLxMe+H0+9SjKWwVdkcvLm1Q/NAkDdRfKjbjKLQ03wy+hpFce0TLfb1slkM7Kx5ZObEzPx6Zq4GfAM4vxyXZzxFE/zWTKD4ANxsrfK+Oaud92EWVt6Kupdi4N8jKMZtITOnUOyzI8q/E4AVyq5xzeZ9v2ltP95E0VLi1ohYXAvG91J0T9u35Z0RsRRF98Bb6fhrcDxw6Tzv2Utl5pkt5lncX9fzepmiUNNsrXmmv0NRfG/Wv8X1+b3fDKfolrtmZi5LMV5M83Ggvedg3veq5lxdN4BUdf2BouXOIcBNmTlp3hky8+nMPJCiO9tZwJ/K/7MPzdqlSSVVggUeST3N/RQnpMdHxBLl4LGDgSs6sa4HgCkR8f2IaIqIhojYKCK2XHhxFzlLUxRq3izHUfhRy4lld4w/Af9LMUbGzeX9sym6v50dEatAMZ6G4x21LiL2j4g1ypuTKU7MZ1F0R+wfEf8dEY0RsXREbFXOdzlwUkSsHBErUYxvNL+foJ4ErBgRy3bRZvRoZdePhygGRv5Hi0l3lffdmZnjKVr1nBERfSJiE4pvy4fNu75W1v8zig/Bt5bPx2IlM9+i6CZ4bkR8vny/HgD8kWJMo0spXoMDovZfu7oMGBwRu5bv130iYvsW/yv6sKuA70TEGmXLtB/MM3008OXy+Zl3jJ5hwE4RcUBE9I6IFcviPRTHgjcy871ykN+vtFjuVYouoeu2kel6YP2I+Eq53i9RDOJ83QJs56LqD8BOFF2cW+ueRUQcHBErl8fZN8u7W+sWOom2nxNJiwkLPJJ6lCwGKt2L4hvg1yjG5vnPzHyyE+uaRVEc2ozilyZeoxhfY7H8wFujXwFNFPvqPopuVvMaTnFC+sd5xt/4PsUv2txXdu+6haI10OJuZES83eJyNUVT/Puj+IWrv1D8wsy/y65CO1O8bicCTwOfK9dzGkXB4jFgDMXA4qe19aDl/8zlwHNld5fV2pp3EXYHxbfed7W47x/lfc2/BHQgMICi1cHVFOMY3VzLyjPzJxQDLd9SFkQXK2WR64fAzyl+wel+ilYhO2bmdIpiD8DrEfFIDesbTzGo9Q8pigjjKX6C3fPVQmvvJRcCN1L8mMAjzDPoNfA/FK10JlMU5OZ0AcrMFyjGN/ouxS/IjaYYwB2KbtM/joipFMXkq1os9y7F+Gx3l+8tW7d8wMx8nWI8se8Cr1N0Sd0zu+FXsqomM5+nKDIvRXEsaM3ngcfL48UQ4MttdMcdAuwXEZMjott+LVRSzxKLb9dxafHT1NR74nvvzeqy7gR9+jRMmjZtZv/251x8NDQ0TJw9e3aX7fNevXpNmjVrlvu8hcYlGifOmDmjy/b5kr2XnDT9/enu81b06dNn4vTp07ts3zc2Nk567733Ftt939Snz8T3unD/9mlsnDRtMd6/82rs03vijOldd8xcsrFh0vT3PGZ2p6bG3hPfm9GF50FLNkyaNt3nVFL9WOCRJEmSJEmqOJu8SpIkSZIkVZwFHkmSJEmSpIqzwCNJkiRJklRxFngkSZIkSZIqzgKPJEmSJElSxVngkSRJkiRJqjgLPJIkSZIkSRVngUeSJEmSJKniLPBIkiRJkiRVnAUeSZIkSZKkirPAI0mSJEmSVHEWeCRJkiRJkirOAo8kSZIkSVLF/X9N1PQQ1narygAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAACkCAYAAADsQZkEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAeE0lEQVR4nO3dd5wddb3/8dcnu2mUSAmhJRBQRAlqRJAiIgpIuSYWxCuigtgLIl4VUB6KDUFsKD/gWgClqVQJSgkoVboEJRGUHhISmpSQTUJ2P78/ZjYsububs5ts5szm9Xw8zmNPmZl97+Rsvue89ztzIjORJEmSJElSfQ2pOoAkSZIkSZKWjwWPJEmSJElSzVnwSJIkSZIk1ZwFjyRJkiRJUs1Z8EiSJEmSJNWcBY8kSZIkSVLNWfBIkiRJkiTVnAWPJEmSJElSzVnwSJKkfomIByOiLSLmRcTciDgtItaoOldPIuL0iPhOeX18RGSZvTP/JRGxRx+2NyYizomI2RHxTETcEBHbN7DehhFxcbleRsT45fixJEmSAAseSZK0fCZl5hrANsB2wFF9WTkKVb4eWavM/zpgKnBhRBzU4LprALcCbwDWAX4N/LGBkqsDuAzYt1+JJUmSumHBI0mSlltmzgIuBbYGiIgdIuKvEfF0RNwZEbt2LhsRV0fEdyPiBmA+sHlEHBQR90fEcxHxQEQcUC47JCKOioiHIuKxiPhNRLysfKxzFs6BEfFwRDwREV/rZ/45mXkCcDRwXCOlU2ben5k/ysxHM7M9M38ODAO2XMZ6czPzJIpySJIkaYWw4JEkScstIsYB+wB3RMTGwB+B71DMbPkScH5ErNdllQ8BnwDWBB4HfgrsnZlrAjsB08rlDiovbwU2p5g1c+JS335nilJlN+DrEfHq5fhRLgDGlNsjIk6KiJMaWTEiJlIUPPcux/eXJEnqFwseSZK0PC6KiKeB64FrgGOADwJ/ysw/ZWZHZk4FbqMogDqdnpnTM3MxsJjisKWtI2JkOSNmerncAcCPytky84AjgfdHRGuXbX0zM9sy807gTorDrfprdvl1HYDM/ExmfmZZK0XEKOCMMsszy/H9JUmS+sWCR5IkLY93ZeZamblpWYa0AZsC+5WHZz1dFkA7Axt2WW9m55XMfB74b+BTwKMR8ceIeFX58EbAQ13WewhoBdbvct+cLtfnU8zy6a+Ny69PNbpCRIwEpgA3Zeb3luN7S5Ik9ZsFjyRJWtFmAmeUxU/nZfXMPLbLMtl1hcy8PDP3oCiB7gZ+UT40m6Iw6rQJxYyfuQOU/d3AY8A9jSwcEcOBi4BZwCcHKJMkSdIyWfBIkqQV7UxgUkTsGREtETEiInaNiLHdLRwR60fE5IhYHVgIzAPay4fPAQ6LiM3KT6c6BvhdeWjXClNm+BzwDeDIzOxoYJ2hwHlAG/DhRtbpsu4IYHh5c3h5W5Ikqd9al72IJElS4zJzZkS8E/g+RUHTDtwCfLqHVYYA/0NxDpukOMFy53lvTqU4TOtaYARwOXDICoz7dEQE8DzFeYL2y8zLOh+MiFPKn+lT3ay7E/AOioLn6WIzQHGy6OuW8X3buly/u/Pb9T2+JElSITJz2UtJkiRJkiSpaXmIliRJkiRJUs1Z8EiSJK1gEXFKRMzr5nJK1dkkSdLg5CFakiRJkiRJNecMHkmSJEmSpJrry6doOdVHkiRJkiRp4PX50zWdwSNJkiRJklRzDc/giehzeSRJkiRJkqQ+6s/5kp3BI0mSJEmSVHN9OQcP+eShA5VDkiRJNRPrnvCS21cefVVFSSRJA2X3o3cDYNKkSQBMmTIFsB8YSEuPr41yBo8kSZIkSVLNWfBIkiRJkiTVnAWPJEmSJElSzVnwSJIkSZIk1ZwFjyRJkiRJUs1Z8EiSJEmSJNWcBY8kSZIkSVLNWfBIkiRJkiTVnAWPJEmSJElSzVnwSJIkSZIk1ZwFjyRJkiRJUs1Z8EiSJEmSJNWcBY8kSZIkSVLNWfBIkiRJkiTVnAWPJEmSJElSzVnwSJIkSZIk1ZwFjyRJkiRJUs1Z8EiSJEmSJNWcBY8kSZIkSVLNWfBIkiRJkiTVnAWPJEmSJEkaVObPf4Fv/+BmPv6FKwH4933/4ZLL76841cCy4JEkSZIkSYPKRw6ZyvBhLdx46xwAxm60Jkcdc2PFqQaWBY8kSZIkSRpU7nvgGb7y+W0ZOrSoPUaObCWz4lADzIJHkiRJkiQNKsOGtdDWtpiI4vZ9DzzN8GEt1YYaYK1VB5AkSZIkSVqRvnn49uz1vouYOWseB3zyMm64eTann/j2qmMNKAseSZIkSZI0qOzx1k3Z5nVjuOm2OWQmJxzzFkavO7LqWAPKgkeSJEmSJA06sx6dR3t7snhxB9f+dRYA75n0iopTDRzPwSNplbbGJie95PbpZ8/gc1/5S0VpJElSFU667CTOv/H8JbcPP+NwfviHHyy5fcrlJ3PeX89taFtfPO2L3DPrnhWeUVLfHHzIVA4+5ErOn3IvUy6/nymX388lVzxQdawB5QweSZIkSau0CeMmcM30a9h3x33p6Ojg2fnPMH/h80senz5zOp/Z67PL3E57R/tAxpTUBzfdNocZN36o6hgrlQWPJPXgoZnPcvAhU3n8yTbWW3ckp524B5uMHcVBn72CkSNaufve//DQzGc57Wd78Ovf/pMbb32U7d+wAaf/v+LkbVf85SG+cexNLFzUzsvHv4zTfrYHa6wxrOKfSpIkLW3CuAmcfFkxq/fBxx9k/JjxPPXcUzzX9hzDhw7n4ccfZt6CeXzylE/S3tHOlhttyaHvOJRhrcM44McfYK/X78Vt993Ou974ziXb7Ojo4Pg/fJ/1Ro3h4N0OrupHk1ZZO263ATPufpKtXrVu1VFWGgseSau0trbFTHzLWUtuP/WfBUzea3MAPnf41Xz4v1/NgftvxalnTefzR1zDRWdOAuA/zyzkzxe9h4svvZ9JH5jCDZfuxy9P2J3tdv8t0/7xOGM3WoPv/PAWrrzgPay++lCOO+E2fnTyHXz9y9tX8nNKkqSejR41mpYhLcx9ei4zZk5nq7ETeOK5J5gxcwarj1idseuO5UcX/5DjP3w8Y0eP49gLjmXKrVPYd8d9ARjWOowTPnoCAFNuu4T2jna+d8ExjB+zGQfsckCVP5q0yjrw/Vux416/Z4MxqzF8eAuZEAF/v+6DVUcbMBY8klZpI0e2Mu2aF194nX72DG6bNheAG299lAt+/V8AfOh9r+IrR1+/ZLlJe25GRPCarUaz/piRvGar0QBM2HIdHnz4WR6Z/Rwz7nmKN+3zewAWLepgx+02WFk/liRJ6qMJm2zNjJnTmT5zOu/dcT+eePYJps+czuojVmf0qNEMax3G2NHjAHj7xLdz8S1/WFLw7Lr1W1+yrZ9c8mPeMmFXyx2pQgd/fipnnLwnr9lqXYYMiarjrBQWPJLUoIgXB4bhw1sAGDIkGD7sxf9KhwwJFrd30NLSwh67bsI5v9h7peeUJEl9N2HcVkyfOYMH5j7A+DHjWW/Uepx347msNnw1tthwC26/7/Ye1x0xdMRLbm81bgLTHpjGfjvux7ChHp4tVWGTjddk8t6bVx1jpfJTtCSpBzu9cUN+e8G/ADjr3HvYefuNGl53h2034IabZ3Pv/U8DMH/+C/zr3v8MRExJkrQCTBi3NTf96ybWHDmKliEtjFptFPMWzGPGzBnsOXEv5jw9l1lPFh+zfOWdU3nt+Nf2uK29X78322/xRr517jdpb/fEy1IVXrXF2nzgE5dyzvn3cMGUe5dcBjNn8EhSD376vV05+JCpHH/i7UtOstyo9Uavxuknvp39P34pCxcVL+y+89WdeOUr1h6ouJIkaTlstv5mPDv/Gd72mre9eN+YzWhb1MZ6L1uPL7/ry3zr3G8tOcnyO7ad1Ov23rvTfjy/8HmOvfB7HPmerzJkiH9bl1amtgWLGT6shSv+8tCS+yKC90x6RYWpBlZkZmMLRmQ+eegAx5EkSVJdxLonvOT2lUdfVVESSdJA2f3o3QCYNKkoNadMmQKA/cDAiXVPIDP7fOIga2RJkiRJkjSoPDLrOd79oUsYs+XPWf9VP2ffAy/hkVnPVR1rQFnwSJIkSZKkQeUjh0xl8l6bMXv6x5h118eYtOfmfOSQqVXHGlAWPJIkSZIkaVB5/Mk2PnLABFpbh9DaOoSDPrAVjz/ZVnWsAWXBI0mSJEmSBpXR64zkzN/fTXt7B+3tHZz5+7tZd+0RVccaUH6KliRJkiRJGlRO/dnufO7wqznsqGuJgJ2225BTf9b4p+LWkQWPJEmSJEkaVDYZO4qLz5pcdYyVyoJHkiRJkiQNCoccfjXRyweM//TYXVdalpXNgkeSJEmSJA0K204cs+T6N467iW8evkOFaVYuCx5JkiRJkjQoHLj/Vkuu/+R/p73k9mDnp2hJkiRJkqRBp7dDtQYjCx5JkiRJkqSa8xAtSZIkSZI0KKy5yUlEOXVnftsLjNr0ZAAyk4jg2Yc+XWW8AWXBI0mSJEmSBoXnHv5M1REq4yFakiRJkiRJNWfBI0mSJEmSVHMWPJIkSZIkSTVnwSNJkiRJklRzFjySJEmSJEk1Z8EjSZIkSZJUcxY8kiRJkiRJNWfBI0mSJEmSVHMWPJIkSZIkSTVnwSNJkiRJklRzFjySJEmSJEk1Z8EjSZIkSZJUcxY8kiRJkiRJNWfBI0mSJEmSVHMWPJIkSZIkSTVnwSNJkiRJklRzkZmNLRjR2IKSJEmSJEnqt8yMvq7jDB5JkiRJkqSaa210wUZn+kiSJEmSJGnlcgaPJEmSJElSzTVc8ETEJ4Go48Xs5jZ781/qmr2uuc1ubrPX41LX7HXNbXZzm735L3XNbXaz9yP3J+ijvszg6fPGm4jZV7665gazV6Wu2euaG8xehbrmBrNXpa7Z65obzF6FuuYGs1ehrrnB7FWpa/YBLXgkSZIkSZLUhCx4JEmSJEmSaq4vBc/PByzFwDP7ylfX3GD2qtQ1e11zg9mrUNfcYPaq1DV7XXOD2atQ19xg9irUNTeYvSp1zd7n3OHHn0uSJEmSJNWbh2hJkiRJkiTVXEMFT0TsFRH3RMS9EXHEQIdaUSLi1Ih4LCLuqjpLX0TEuIj4S0T8MyKmR8ShVWdqVESMiIhbIuLOMvs3q87UFxHREhF3RMQlVWfpq4h4MCL+ERHTIuK2qvM0KiLWiojzIuLu8jm/Y9WZGhERW5b7uvPybER8oepcjYiIw8rfz7si4pyIGFF1pkZFxKFl7unNvr+7G4MiYp2ImBoR/y6/rl1lxp70kH2/cr93RMS2VebrTQ/Zjy//j/l7RFwYEWtVGLFbPeT+dpl5WkRcEREbVZmxJ7293oqIL0VERsToKrItSw/7/eiImNXl//d9qszYnZ72eUQcUr5mnx4R368qX2962Oe/67K/H4yIaRVG7FEP2SdGxE2dr78i4o1VZuxOD7lfFxE3lq8dp0TEqCoz9qSn90XNPp72krvpx9JestdhLO0pe9OPpz1l7/J4Y+NpZvZ6AVqA+4DNgWHAncBWy1qvGS7ALsA2wF1VZ+lj7g2BbcrrawL/qtE+D2CN8vpQ4GZgh6pz9SH/F4GzgUuqztKP7A8Co6vO0Y/cvwY+Vl4fBqxVdaZ+/AwtwBxg06qzNJB1Y+ABYGR5+/fAQVXnajD71sBdwGpAK3AlsEXVuXrJ+3/GIOD7wBHl9SOA46rO2Yfsrwa2BK4Gtq06Yx+zvx1oLa8f14z7vYfco7pc/zxwStU5G81e3j8OuBx4qFnHpx72+9HAl6rO1o/cby3/Xxxe3h5Tdc6+PF+6PP5D4OtV5+zDfr8C2Lu8vg9wddU5G8x9K/CW8vrBwLerztlD9m7fFzX7eNpL7qYfS3vJXoextKfsTT+e9pS9vN3weNrIDJ43Avdm5v2ZuQj4LfDOBtarXGZeCzxVdY6+ysxHM/Nv5fXngH9SvClrelmYV94cWl5qcaKniBgL/Bfwy6qzrCrKvxbtAvwKIDMXZebTlYbqn92A+zLzoaqDNKgVGBkRrRRlyeyK8zTq1cBNmTk/MxcD1wDvrjhTj3oYg95JUWpSfn3XyszUqO6yZ+Y/M/OeiiI1rIfsV5TPGYCbgLErPdgy9JD72S43V6dJx9NeXm/9GPgKTZobav1asbvcnwaOzcyF5TKPrfRgDehtn0dEAO8DzlmpoRrUQ/YEOme/vIwmHFN7yL0lcG15fSqw70oN1aBe3hc19XjaU+46jKW9ZK/DWNpT9qYfT5fRATQ8njZS8GwMzOxy+xFqUjYMBhExHng9xUyYWojiMKdpwGPA1MysS/afUPzidFSco78SuCIibo+IT1QdpkGbA48Dp0VxaNwvI2L1qkP1w/tp0hejS8vMWcAPgIeBR4FnMvOKalM17C5gl4hYNyJWo/hL6biKM/XV+pn5KBQDOTCm4jyrooOBS6sO0aiI+G5EzAQOAL5edZ5GRcRkYFZm3ll1ln76XDmd/9RmO/SjF68E3hwRN0fENRGxXdWB+uHNwNzM/HfVQfrgC8Dx5e/pD4Ajq43TsLuAyeX1/ajBeLrU+6LajKd1fD/XqZfsTT+WLp29TuNp1+x9HU8bKXiim/uarvEajCJiDeB84AtLtY5NLTPbM3MiRav7xojYuuJIyxQR7wAey8zbq86yHN6UmdsAewOfjYhdqg7UgFaKKcMnZ+brgecpptnWRkQMo3iBdG7VWRpRvlF5J7AZsBGwekR8sNpUjcnMf1JMCZ4KXEZxyPDiXleSuoiIr1E8Z86qOkujMvNrmTmOIvPnqs7TiLKA/RpN/gK6FycDLwcmUhThP6w0TeNagbWBHYAvA78vZ8TUyf7U5A8mXXwaOKz8PT2MclZyDRxM8XrxdorDQRZVnKdXdX1fVNfc0HP2Ooyl3WWvy3jaNTvFfu7TeNpIwfMIL210x9KEUw8Hm4gYSvEPe1ZmXlB1nv4oD7W5Gtir2iQNeRMwOSIepDgM8W0RcWa1kfomM2eXXx8DLqQ4vLLZPQI80mWW13kUhU+d7A38LTPnVh2kQbsDD2Tm45n5AnABsFPFmRqWmb/KzG0ycxeK6eZ1+isvwNyI2BCg/NqUh1AMRhFxIPAO4IAsD2ivmbNp0kMouvFyihL5znJcHQv8LSI2qDRVgzJzbvnHqg7gF9RjPIViTL2gPFz+FooZyU15cuvulIcNvwf4XdVZ+uhAirEUij/21OL5kpl3Z+bbM/MNFKXafVVn6kkP74uafjyt8/u5nrLXYSxtYL837XjaTfY+j6eNFDy3AltExGblX6rfD1y8vOHVs/KvLb8C/pmZP6o6T19ExHqdZ1SPiJEUbybvrjRUAzLzyMwcm5njKZ7jf87MWsxqAIiI1SNizc7rFCdBa/pPj8vMOcDMiNiyvGs3YEaFkfqjbn9tfBjYISJWK/+v2Y3iGN9aiIgx5ddNKN4I1GnfQzF+HlhePxD4Q4VZVhkRsRdwODA5M+dXnadREbFFl5uTqcF4CpCZ/8jMMZk5vhxXH6E4ceSciqM1pPNNY+nd1GA8LV0EvA0gIl5J8cEFT1QZqI92B+7OzEeqDtJHs4G3lNffRk3+8NBlPB0CHAWcUm2i7vXyvqipx9Oav5/rNnsdxtJesjf9eNpd9n6Np9nYGZ33oTiL833A1xpZpxkuFC/8HwVeKHfGR6vO1GDunSkOg/s7MK287FN1rgazvxa4o8x+F036KQjL+Bl2pWafokVxLps7y8v0mv2eTgRuK58zFwFrV52pD9lXA54EXlZ1lj7m/ibFwHYXcAblJ67U4QJcR1EC3gnsVnWeZWT9P2MQsC5wFcUbgKuAdarO2Yfs7y6vLwTmApdXnbMP2e+lOJ9g55jajJ+e0V3u88vf078DUyhOFFl51kayL/X4gzTvp2h1t9/PAP5R7veLgQ2rztlg7mHAmeVz5m/A26rO2ZfnC3A68Kmq8/Vjv+8M3F6OSzcDb6g6Z4O5D6V4f/cv4Fggqs7ZQ/Zu3xc1+3jaS+6mH0t7yV6HsbSn7E0/nvaUfallljmeRrmgJEmSJEmSaqqRQ7QkSZIkSZLUxCx4JEmSJEmSas6CR5IkSZIkqeYseCRJkiRJkmrOgkeSJEmSJKnmLHgkSZIkSZJqzoJHkiRJkiSp5ix4JEmSJEmSas6CR5IkSZIkqeYseCRJkiRJkmrOgkeSJEmSJKnmLHgkSZIkSZJqzoJHkiRJkiSp5ix4JEmSJEmSas6CR5IkSZIkqeYseCRJkiRJkmrOgkeSJEmSJKnmLHgkSZIkSZJqzoJHkiRJkiSp5ix4JEmSJEmSas6CR5IkSZIkqeYseCRJkiRJkmrOgkeSJEmSJKnmLHgkSZIkSZJqzoJHkiRJkiSp5ix4JEmSJEmSas6CR5IkaSWIiF0j4pGqcwwWEXF0RJxZdQ5JkpqFBY8kSRWIiAcjYvel7jsoIq6vKtNgFhHzulw6IqKty+0Dqs43WEXEkRHxp6Xu+3cP971/5aaTJGlwaa06gCRJK9PIka1zFixoX3+gtj9iRMvctrbFGwzU9uuopaVlTkdHx4Dt8yFDhsxtb2/vdZ9n5hqd1yPiQeBjmXnl0stFRGtmLl7xKVeu4UOHz1m0eNGA7fNhrcPmLnxhYSPP82uBIyKiJTPbI2IDYCiwzVL3vaJctiER4WtYSZKW4uAoSVqlLFjQvn4+eeiAbT/WPWGFvKmOiFcDJwMTgVnAkZl5cfnY6cB8YDPgzcCdwL7AEcCBwFxg/8y8o1x+I+BnwC7APODHmfnTFZGzER0dHetPmjRpwLY/ZcqUfu/ziNgVOJNi/xwGTI2IzwNnANtTvFa6AfhUZj5SzjL5UmZu22UbhwFvzczJETEc+C7wPmA4cCFwWGa29TdjfyxavGj9K4++asC2v/vRuzW6z2+lKHQmArdTPAf/Amy+1H33AUTExcDOwFPAcZn5i/L+o4GtgQXAZOCLXb9JRAwFfgMMo3juL+rvzyZJUl15iJYkSU2mfLM6BbgCGAMcApwVEVt2Wex9wFHAaGAhcCPwt/L2ecCPym0NKbd1J7AxsBvwhYjYc6X8MPWwAbAOsCnwCYrXR6eVtzcB2oATy2UvBraMiC26rP8B4Ozy+nHAKynKi1dQ7POvD2z85lUWLTdTlDiUX68Drl/qvmuBc4BHgI2A9wLHRMRuXTb3Torn9lrAWZ13RsRI4CKK34P3We5IklZVFjySJFXnooh4uvMCnFTevwOwBnBsZi7KzD8DlwD7d1n3wsy8PTMXUMwSWZCZv8nMduB3wOvL5bYD1svMb5Xbuh/4BeD5Tl7UAXwjMxdmZltmPpmZ52fm/Mx8jmJGzlsAMnM+8AfKf4uy6HkVcHFEBPBxihk7T5XrHoP7+hpeLHPeTFHwXLfUfddQzNw5PDMXZOY04JfAh7ps58bMvCgzO7rMiBoFXEYxA+gj5fNfkqRVkgWPJEnVeVdmrtV5AT5T3r8RMDMzO7os+xDFbJBOc7tcb+vmduc5ZzYFNlqqSPoqMGDnZ6mhx8uiDICIWC0i/jciHoqIZylml6wVES3lImfzYtn2AeCisvhZD1gNuL3Lvr6svH9Vdi2wc0SsTVE2/hv4K7BTed/WwN1AZynWaenn/Mxutr0D8FqKMjQHJL0kSTXhOXgkSWo+s4FxETGkS8mzCfCvfmxrJvBAZm6xzCVXXUsXA/8DbAlsn5lzImIicAcQ5eNXAKPL+/enOHcPwBMU5dqEzJw10KFr5EbgZRSHv90AkJnPRsTs8r7Z5WWdiFizS8mzCcX5pzp1V+BcAfwduCoids3Mud0sI0nSKsEZPJIkNZ+bgeeBr0TE0PJEwJOA3/ZjW7cAz0bE4RExMiJaImLriNhuxcUddNakKGqejoh1gG90fbD8lK3zgOMpzt0ztby/g+Lwtx9HxBiAiNh4VT/fUXk41W0UJ0a+rstD15f3XZuZMylm9XwvIkZExGuBj9LlXDu9bP/7FLOqroqI0Ss6vyRJdWHBI0lSkylPEjsZ2JtiVshJwIcz8+5+bKudohyaCDxQbu+XFDMq1L2fACMp9tVNFIdZLe1sYHfg3KU+Vv1w4F7gpvLwrispZgOt6q6hOGH49V3uu668r/Pj0fcHxlPM5rmQ4rxIUxvZeGZ+m+JEy1eWpZwkSauc8HBlSdKqZOTI1jkLFrQP2PlnRoxomdvWtniDgdp+HbW0tMzp6OgYsH0+ZMiQue3t7e7zLoYPHT5n0eJFA7bPh7UOm7vwhYXuc0mSmogFjyRJkiRJUs15iJYkSZIkSVLNWfBIkiRJkiTVnAWPJEmSJElSzVnwSJIkSZIk1ZwFjyRJkiRJUs1Z8EiSJEmSJNWcBY8kSZIkSVLNWfBIkiRJkiTVnAWPJEmSJElSzVnwSJIkSZIk1ZwFjyRJkiRJUs1Z8EiSJEmSJNWcBY8kSZIkSVLN/X/8HgyscRQidgAAAABJRU5ErkJggg==",
       "text/plain": [
-       "<Figure size 1152x432 with 4 Axes>"
+       "<Figure size 1152x216 with 1 Axes>"
       ]
      },
      "metadata": {
@@ -4280,10 +3521,10 @@
      "start_time": "2020-11-25T10:58:58.698118Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.615601Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.615502Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.617874Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.617586Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.036715Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.036600Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.039028Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.038731Z"
     }
    },
    "outputs": [
@@ -4321,10 +3562,10 @@
      "start_time": "2020-11-23T12:10:22.120024Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.619316Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.619223Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.642288Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.642019Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.040385Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.040279Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.067718Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.067432Z"
     }
    },
    "outputs": [],
@@ -4360,17 +3601,17 @@
      "start_time": "2020-11-23T12:10:26.315503Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.643711Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.643632Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.645756Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.645493Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.069288Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.069199Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.071523Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.071208Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "5.576190476190479"
+       "6.72619047619048"
       ]
      },
      "execution_count": 45,
@@ -4407,10 +3648,10 @@
    "execution_count": 46,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.647119Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.647038Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.649345Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.649108Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.072959Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.072856Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.075231Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.074957Z"
     }
    },
    "outputs": [],
@@ -4443,13 +3684,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 47,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.653329Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.653246Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.697114Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.696833Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.076458Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.076355Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.125627Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.125278Z"
     }
    },
    "outputs": [],
@@ -4460,26 +3701,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 48,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.698626Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.698535Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.701568Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.701296Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.127248Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.127152Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.130642Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.130351Z"
     }
    },
    "outputs": [
     {
      "data": {
       "image/svg+xml": [
-       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"412359.219677291 275282.5661909206 2.0 2.0\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,550567.1323818412)\"><circle cx=\"412360.219677291\" cy=\"275283.5661909206\" r=\"0.06\" stroke=\"#555555\" stroke-width=\"0.02\" fill=\"#66cc99\" opacity=\"0.6\" /></g></svg>"
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"100.0\" height=\"100.0\" viewBox=\"399092.6858456063 290041.69041773543 2.0 2.0\" preserveAspectRatio=\"xMinYMin meet\"><g transform=\"matrix(1,0,0,-1,0,580085.3808354709)\"><circle cx=\"399093.6858456063\" cy=\"290042.69041773543\" r=\"0.06\" stroke=\"#555555\" stroke-width=\"0.02\" fill=\"#66cc99\" opacity=\"0.6\" /></g></svg>"
       ],
       "text/plain": [
-       "<POINT (412360.22 275283.566)>"
+       "<POINT (399093.686 290042.69)>"
       ]
      },
-     "execution_count": 49,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4490,13 +3731,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 49,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.703008Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.702901Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.810213Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.809901Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.131979Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.131892Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.268527Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.268216Z"
     }
    },
    "outputs": [],
@@ -4506,17 +3747,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 50,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-11-24T18:51:18.843528Z",
      "start_time": "2020-11-24T18:51:18.545189Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.811781Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.811696Z",
-     "iopub.status.idle": "2023-06-22T10:53:19.898663Z",
-     "shell.execute_reply": "2023-06-22T10:53:19.898363Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.270114Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.270010Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.359504Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.359141Z"
     }
    },
    "outputs": [
@@ -4524,16 +3765,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Person: 3_6_0\n",
-      "{'SurveyYear': 2002, 'IndividualID': 3, 'HouseholdID': 1, 'PSUID': 1, 'VehicleID': ' ', 'PersNo': 3, 'Age_B01ID': 4, 'OfPenAge_B01ID': 2, 'Sex_B01ID': 1, 'EdAttn1_B01ID': -10, 'EdAttn2_B01ID': -10, 'EdAttn3_B01ID': -10, 'DrivLic_B02ID': -9, 'CarAccess_B01ID': 4, 'DrivDisable_B01ID': -9, 'WkPlace_B01ID': -9, 'ES2000_B01ID': -9, 'NSSec_B03ID': -9, 'SC_B01ID': -9, 'Stat_B01ID': -9, 'SVise_B01ID': -9, 'EcoStat_B02ID': -9, 'PossHom_B01ID': -9}\n",
-      "0:\tActivity(act:education, location:POINT (389504.0975327159 300671.958420758), time:00:00:00 --> 15:22:00, duration:15:22:00)\n",
-      "1:\tLeg(mode:car, area:POINT (389504.0975327159 300671.958420758) --> POINT (391760.05992191617 419989.19293296064), time:15:22:00 --> 15:31:00, duration:0:09:00)\n",
-      "2:\tActivity(act:home, location:POINT (391760.05992191617 419989.19293296064), time:15:31:00 --> 00:00:00, duration:8:29:00)\n"
+      "Person: 5_2_1\n",
+      "{'SurveyYear': 2002, 'IndividualID': 5, 'HouseholdID': 2, 'PSUID': 1, 'VehicleID': ' ', 'PersNo': 1, 'Age_B01ID': 18, 'OfPenAge_B01ID': 1, 'Sex_B01ID': 2, 'EdAttn1_B01ID': -10, 'EdAttn2_B01ID': -10, 'EdAttn3_B01ID': -10, 'DrivLic_B02ID': 3, 'CarAccess_B01ID': 6, 'DrivDisable_B01ID': 2, 'WkPlace_B01ID': -9, 'ES2000_B01ID': 6, 'NSSec_B03ID': 1, 'SC_B01ID': 3, 'Stat_B01ID': 1, 'SVise_B01ID': 1, 'EcoStat_B02ID': 4, 'PossHom_B01ID': -9}\n",
+      "0:\tActivity(act:home, location:POINT (419883.4863206614 274232.598586247), time:00:00:00 --> 09:45:00, duration:9:45:00)\n",
+      "1:\tLeg(mode:pt, area:POINT (419883.4863206614 274232.598586247) --> POINT (408021.8785798442 447678.35816789983), time:09:45:00 --> 13:15:00, duration:3:30:00)\n",
+      "2:\tActivity(act:home, location:POINT (408021.8785798442 447678.35816789983), time:13:15:00 --> 00:00:00, duration:10:45:00)\n"
      ]
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAACkCAYAAADsQZkEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAedUlEQVR4nO3deZgcZbmG8fvNRiIBEsIaCKsIIkcQRVGRIKsgCW4IikdQjx5cAUXUA0eDigcQVMQFFxTZRQUhyI5EBAUUSFgEFWVJgITNsGaf9/xRNbEZZumeZKa6yP27rr6mumvpp6u75+t6+/uqIzORJEmSJElSfQ2pOoAkSZIkSZKWjQUeSZIkSZKkmrPAI0mSJEmSVHMWeCRJkiRJkmrOAo8kSZIkSVLNWeCRJEmSJEmqOQs8kiRJkiRJNWeBR5IkSZIkqeYs8EiSpB5FxH0RMS8inomIORHx04gYXXWunkTEaRHx1XJ6o4jIMntn/osjYrcWt3lNRDwaEU9FxIyI2KfJ9daMiLMjYm5E/CsizmpinZUi4iflfc2OiE+3klWSJK24LPBIkqS+TMrM0cC2wHbAUa2sHIUqP3OMKfNvDVwJXBARB7Ww/iHAupm5KvAR4MyIWLeJ9c4HZgMbAmsBJzSxzhRgs3KdNwNHRMRbWsgqSZJWUBZ4JElSUzLzQeBSYCuAiNg+Iv5Q9lCZERE7dS4bEdMi4piIuB54DtgkIg6KiH9GxNMRcW9EHFAuOyQijoqI+yPikYg4PSJWK+d19sI5MCIeiIjHIuLIfuafnZknURRRjmu26JSZt2Xm4s6rwHBgQm/rRMTu5TKfzcwnM3NRZt7axN29H/hKZv4rM+8CfgQc1ExOSZK0YrPAI0mSmhIRE4C9gFsjYj3gN8BXgdWBw4FfRcSaDav8J0WPl1WAR4FvA3tm5irAG4Dp5XIHlZc3A5sAo4HvdLn7HYDNgV2AL0bEy5fhoZxP0aNm8/JxfS8ivtfbCuXQrvnAjcA04M993Mf2wF+Bn0XE4xHxp4iY2Md9jAXGAzMabp4BvKKP+5IkSbLAI0mS+vTriJgLXAf8Dvga8D7gksy8JDM7MvNKiqLHXg3rnZaZd5a9XxYDHcBWETEqMx/OzDvL5Q4AvpGZ/8zMZ4AvAPtHxLCGbR2dmfMycwZF0WPrZXg8D5V/VwfIzI9l5sd6WyEz96YoVO0FXJ6ZHX3cx/rA7sA1wDrAicCFEbFGL+t0ntvoyYbbnizvV5IkqVcWeCRJUl/elpljMnPDshgyj+IcMfuWw7PmlgWgHYDGc9PM7JzIzGeB/YCDgYcj4jcRsUU5ezxwf8N69wPDgLUbbpvdMP0c/y6G9Md65d8nWlmpHGZ1KbBHREzuY/F5wH2ZeWq53rkU++ONvazzTPl31YbbVgWebiWnJElaMVngkSRJ/TETOKMs/HReVs7MYxuWycYVMvPyzNyNogh0N8X5ZaDoUbNhw6IbUPT4mTNA2d8OPEIxhKo/hgGb9rHMbXR5/H3JzH8BD/P83klbA3d2v4YkSdK/WeCRJEn9cSYwKSL2iIihETEyInaKiPW7Wzgi1o6IyRGxMrCAorfKknL2OcBhEbFx+RPsXwN+3nBi4+WizPAJ4EvAF5oYZkVEbBERe0bEqIgYHhHvA3akGKrWmwuAseXJoYdGxLsoeg5d38d6pwNHRcTYsofTh4HT+sopSZI0rO9FJEmSni8zZ0bEPsDxFAWaJcBNwEd7WGUI8BngDIqeLdOBzvPe/IRimNa1wEjgcuCTyzHu3IgI4FmK8wTtm5mXdc6MiFPKx3RwN+sGxa9ubUnxGP8O7JeZt/R2h5n5RDmM63vAdyl6LO2TmY/1kfVLwPcphqnNA45rzCpJktSTyGyp97AkSZIkSZLajEO0JEmSJEmSas4CjyRJUj9ExCkR8Uw3l1P6WK+7dZ6JiDcNVnZJkvTi4xAtSZIkSZKkmrMHjyRJkiRJUs218itadvWRJEmSJEkaeNHqCvbgkSRJkiRJqrmme/BEtFw8kiRJkiRJUov6c75ke/BIkiRJkiTVXCvn4CEfP2SgckiSJEm1F+NOAmDSpEkvmDd16lQArppy9aBmkiTVy65TdunXevbgkSRJkiRJqjkLPJIkSZIkSTVngUeSJEmSJKnmLPBIkiRJkiTVnAUeSZIkSZKkmrPAI0mSJEmSVHMWeCRJkiRJkmrOAo8kSZIkSVLNWeCRJEmSJEmqOQs8kiRJkiRJNWeBR5IkSZIkqeYs8EiSJEmSJNWcBR5JkiRJkqSas8AjSZIkSZJUcxZ4JEmSJEmSas4CjyRJkiRJUs1Z4JEkSZIkSao5CzySJEmSJEk1Z4FHkiRJkiSp5izwSJIkSZIk1ZwFHkmSJEmSpJqzwCNJkiRJklRzFngkSZIkSZJqzgKPJEmSJElSzVngkSRJkiRJqjkLPJIkSZIkSTVngUeSJEmSJKnmLPBI0gAauua32WbiWUsvx37rTy9YZtp1s9j7PRcu1/uddt0s/nDTQ0uvn/LT2zj93LuW631IkiR1tfcxb33e9ctvvYyTf/PtitJIK5ZhVQeQpBezUaOGMf13Bwz6/U67fhajVx7OG147HoCDP/DKQc8gSZIkafBY4JGkClx29X0c+j/Xssa4kWz7yrWW3j7luBsYvfJwDv/EqwHY6o1ncvE5k9log1U5/dy7OOG7NxMRvHLLNTjjlD2Yetk/+eqJN7FwUQfjxo7krB/swbz5SzjltNsZOiQ48xd3c/KxO3H1tTOXbnf67Y9y8Gd+y3PzFrHpRmP4ycm7MnbMSHaa/Etet+06XHPdLOY+tYBTT9qVN71+vap2kSRJepGZM3cOJ1z4deY+O5cxK4/h8H0+y9pj1ub4C45jxPCVmPnYA8yZ+wiffdtnuWL6Fdw16y9ssd4WHPH2zwHw53v+zM+mncaixYsYv/p4PrvPEYxaaVTFj0pqHxZ4JGkAzZu3mG0mnrX0+hcO3Y599tyEDx96Nb/99Tt46SZj2O9Dl/a5nTvvfpxjvnET11/6btYYN4on/jUfgB22H88NV+xHRPDjM+7g+JNv5sSv7MjBB/3H8wpFV187c+m23v+xyzn52J2Y+Mb1+eL//ZGjj7+Rb31tIgCLl3Rw01X7c8mV93L08Tdy1QXvWJ67Q5IkvcgtXLyQ//7+R5Zef2re07xh89cDcPIl32a3rXdj92324NJbLuW7l36HL7/nKwA8M+9pTjjwRP7w1z/wv2cfxbc+dBIbrfkZPv6jj3HPw/ew5qprcta1Z3L8+7/OqBGjOPe6c/jlH3/Bf+70/koep9SOLPBI0gDqbojW9NsfZeMNV2WzTccC8L59t+CHp9/e63Z+e+1M3jV5M9YYV3xLtfrYkQDMeugZ9vvQpTw851kWLlzCxhuu1ut2nnxqAXOfXMDEN64PwIH7v5x9P3jJ0vnv2PulALx667W4b+ZTLTxSSZIkGDFsBD/46A+XXr/81sv420N/A+AvM//ClP2OBmC3rXfjR1f+e7nXb/56IoKN19qYsaPHssnamwCw4ZobMWfubB576lHuf/R+Dj31EAAWLVnElhO2HKyHJdWCBR5JqkBEdHv7sKFD6OjIpdfnL1gMQCZ0t8onPz+NT390WybvuQnTrpvFlONvWKZcK40YCsDQoUNYvLhjmbYlSZLUm8bPQ8OHDgdgSAxZOl1cD5Z0LGHIkCG8etNXc+S7jhr0nFJd+CtakjTItthsLPfe/yT/uHcuAOec/9el8zbaYFVuue1RAG6Z8Qj33l/0otll4gTOu/DvPP7EPIClQ7SefGoh6627MgA/O/cvS7ezyugRPP3Mwhfc92qrrsTYMSP5/R8fBOCM8+5m4hs8z44kSRp4r5jwCq654xoArr7tKrbaYKum1335+ltyxwN38uDjxWeY+QvnM+uxmX2sJa1Y7MEjSQOo6zl43rLzhhz7pR344Td34a37X8Qa40ayw+vGc8fdjwPwzkkv5fSf38U2E89iu1etzcs2HQPAK7YYx5GHbcfESb9i6NDgVf+xJqd9d3emHPE69v3gJay37mi2f8063PtAURCatMfGvOsDv+HCS//Jycfu9LxMP/vu7ktPsrzJhqvx0+/sNij7QpIkrdg+vucnOOHCr3Pe9T9fepLlZo1ZeQxHvO0IjvnVMSxaXHyJ9YGdP8j6a0wYqLhS7URm9r0UEBGZjx8ywHEkSZKk+opxJwEwadKkF8ybOnUqAFdNuXpQM0mS6mXXKbuQmd2f06EXDtGSJEmSJEmqOQs8kiRJkiRJNWeBR5IkSZIkqeYs8EiSJEmSJNWcBR5JkiRJkqSas8AjSZIkSZJUcxZ4JEmSJEmSas4CjyRJkiRJUs1Z4JEkSZIkSao5CzySJEmSJEk1Z4FHkiRJkiSp5izwSJIkSZIk1ZwFHkmSJEmSpJqzwCNJkiRJklRzFngkSZIkSZJqzgKPJEmSJElSzVngkSRJkiRJqjkLPJIkSZIkSTVngUeSJEmSJKnmLPBIkiRJkiTVnAUeSZIkSZKkmrPAI0mSJEmSVHMWeCRJkiRJkmrOAo8kSZIkSVLNWeCRJEmSJEmqOQs8kiRJkiRJNWeBR5IkSZIkqeYs8EiSJEmSJNWcBR5JkiRJkqSai8xsbsGI5haUJEmSJElSv2VmtLqOPXgkSZIkSZJqblizCzbb00eSJEmSJEmDyx48kiRJkiRJNdd0gSci/huIOl7Mbm6zt/+lrtnrmtvs5jZ7PS51zV7X3GY3t9nb/1LX3GY3ez9yf4QWtdKDp+WNtxGzD7665gazV6Wu2euaG8xehbrmBrNXpa7Z65obzF6FuuYGs1ehrrnB7FWpa/YBLfBIkiRJkiSpDVngkSRJkiRJqrlWCjw/HLAUA8/sg6+uucHsValr9rrmBrNXoa65wexVqWv2uuYGs1ehrrnB7FWoa24we1Xqmr3l3OHPn0uSJEmSJNWbQ7QkSZIkSZJqrqkCT0S8JSL+GhH3RMTnBzrU8hIRP4mIRyLijqqztCIiJkTENRFxV0TcGRGHVJ2pWRExMiJuiogZZfajq87UiogYGhG3RsTFVWdpVUTcFxG3R8T0iPhz1XmaFRFjIuKXEXF3+Zp/fdWZmhERm5f7uvPyVEQcWnWuZkTEYeX7846IOCciRladqVkRcUiZ+85239/dtUERsXpEXBkRfy//jq0yY096yL5vud87IuI1VebrTQ/Zv17+j7ktIi6IiDEVRuxWD7m/UmaeHhFXRMT4KjP2pLfPWxFxeERkRKxRRba+9LDfp0TEgw3/3/eqMmN3etrnEfHJ8jP7nRFxfFX5etPDPv95w/6+LyKmVxixRz1k3yYibuj8/BURr60yY3d6yL11RPyx/Ow4NSJWrTJjT3o6Lmr39rSX3G3flvaSvQ5taU/Z27497Sl7w/zm2tPM7PUCDAX+AWwCjABmAFv2tV47XIAdgW2BO6rO0mLudYFty+lVgL/VaJ8HMLqcHg7cCGxfda4W8n8aOBu4uOos/ch+H7BG1Tn6kftnwH+V0yOAMVVn6sdjGArMBjasOksTWdcD7gVGldfPAw6qOleT2bcC7gBeAgwDrgI2qzpXL3lf0AYBxwOfL6c/DxxXdc4Wsr8c2ByYBrym6owtZt8dGFZOH9eO+72H3Ks2TH8KOKXqnM1mL2+fAFwO3N+u7VMP+30KcHjV2fqR+83l/8WVyutrVZ2zlddLw/wTgS9WnbOF/X4FsGc5vRcwreqcTeb+EzCxnP4g8JWqc/aQvdvjonZvT3vJ3fZtaS/Z69CW9pS97dvTnrKX15tuT5vpwfNa4J7M/GdmLgTOBfZpYr3KZea1wBNV52hVZj6cmbeU008Dd1EclLW9LDxTXh1eXmpxoqeIWB94K/DjqrOsKMpvi3YETgXIzIWZObfSUP2zC/CPzLy/6iBNGgaMiohhFMWShyrO06yXAzdk5nOZuRj4HfD2ijP1qIc2aB+Koibl37cNZqZmdZc9M+/KzL9WFKlpPWS/onzNANwArD/owfrQQ+6nGq6uTJu2p7183vomcARtmhtq/Vmxu9wfBY7NzAXlMo8MerAm9LbPIyKAdwPnDGqoJvWQPYHO3i+r0YZtag+5NweuLaevBN45qKGa1MtxUVu3pz3lrkNb2kv2OrSlPWVv+/a0jxpA0+1pMwWe9YCZDddnUZNiw4tBRGwEvIqiJ0wtRDHMaTrwCHBlZtYl+7co3jgdFeforwSuiIibI+IjVYdp0ibAo8BPoxga9+OIWLnqUP2wP236YbSrzHwQOAF4AHgYeDIzr6g2VdPuAHaMiHER8RKKb0onVJypVWtn5sNQNOTAWhXnWRF9ELi06hDNiohjImImcADwxarzNCsiJgMPZuaMqrP00yfK7vw/abehH714GfCmiLgxIn4XEdtVHagf3gTMycy/Vx2kBYcCXy/fpycAX6g2TtPuACaX0/tSg/a0y3FRbdrTOh7Pdeole9u3pV2z16k9bczeanvaTIEnurmt7SpeL0YRMRr4FXBol6pjW8vMJZm5DUVV97URsVXFkfoUEXsDj2TmzVVnWQZvzMxtgT2Bj0fEjlUHasIwii7D38/MVwHPUnSzrY2IGEHxAekXVWdpRnmgsg+wMTAeWDki3ldtquZk5l0UXYKvBC6jGDK8uNeVpAYRcSTFa+asqrM0KzOPzMwJFJk/UXWeZpQF2CNp8w/Qvfg+sCmwDUUh/MRK0zRvGDAW2B74LHBe2SOmTt5DTb4wafBR4LDyfXoYZa/kGvggxefFmymGgyysOE+v6npcVNfc0HP2OrSl3WWvS3vamJ1iP7fUnjZT4JnF8yu669OGXQ9fbCJiOMUTe1Zmnl91nv4oh9pMA95SbZKmvBGYHBH3UQxD3Dkizqw2Umsy86Hy7yPABRTDK9vdLGBWQy+vX1IUfOpkT+CWzJxTdZAm7Qrcm5mPZuYi4HzgDRVnalpmnpqZ22bmjhTdzev0LS/AnIhYF6D825ZDKF6MIuJAYG/ggCwHtNfM2bTpEIpubEpRRJ5RtqvrA7dExDqVpmpSZs4pv6zqAH5EPdpTKNrU88vh8jdR9Ehuy5Nbd6ccNvwO4OdVZ2nRgRRtKRRf9tTi9ZKZd2fm7pn5aoqi2j+qztSTHo6L2r49rfPxXE/Z69CWNrHf27Y97SZ7y+1pMwWePwGbRcTG5TfV+wMXLWt49az8tuVU4K7M/EbVeVoREWt2nlE9IkZRHEzeXWmoJmTmFzJz/czciOI1/tvMrEWvBoCIWDkiVumcpjgJWtv/elxmzgZmRsTm5U27AH+pMFJ/1O3bxgeA7SPiJeX/ml0oxvjWQkSsVf7dgOJAoE77Hor288By+kDgwgqzrDAi4i3A54DJmflc1XmaFRGbNVydTA3aU4DMvD0z18rMjcp2dRbFiSNnVxytKZ0HjaW3U4P2tPRrYGeAiHgZxQ8XPFZloBbtCtydmbOqDtKih4CJ5fTO1OSLh4b2dAhwFHBKtYm618txUVu3pzU/nus2ex3a0l6yt3172l32frWn2dwZnfeiOIvzP4Ajm1mnHS4UH/wfBhaVO+NDVWdqMvcOFMPgbgOml5e9qs7VZPZXAreW2e+gTX8FoY/HsBM1+xUtinPZzCgvd9bsfboN8OfyNfNrYGzVmVrI/hLgcWC1qrO0mPtoiobtDuAMyl9cqcMF+D1FEXAGsEvVefrI+oI2CBgHXE1xAHA1sHrVOVvI/vZyegEwB7i86pwtZL+H4nyCnW1qO/56Rne5f1W+T28DplKcKLLyrM1k7zL/Ptr3V7S62+9nALeX+/0iYN2qczaZewRwZvmauQXYueqcrbxegNOAg6vO14/9vgNwc9ku3Qi8uuqcTeY+hOL47m/AsUBUnbOH7N0eF7V7e9pL7rZvS3vJXoe2tKfsbd+e9pS9yzJ9tqdRLihJkiRJkqSaamaIliRJkiRJktqYBR5JkiRJkqSas8AjSZIkSZJUcxZ4JEmSJEmSas4CjyRJkiRJUs1Z4JEkSZIkSao5CzySJEmSJEk1Z4FHkiRJkiSp5izwSJIkSZIk1ZwFHkmSJEmSpJqzwCNJkiRJklRzFngkSZIkSZJqzgKPJEmSJElSzVngkSRJkiRJqjkLPJIkSZIkSTVngUeSJEmSJKnmLPBIkiRJkiTVnAUeSZIkSZKkmrPAI0mSJEmSVHMWeCRJkiRJkmrOAo8kSZIkSVLNWeCRJEmSJEmqOQs8kiRJkiRJNWeBR5IkSZIkqeYs8EiSJEmSJNWcBR5JkiRJkqSas8AjSdIgiIiNIiIjYtgg3+8BEXHFYN6nlk1E7BQRs6rOIUmS6sUCjyRJyyAi7ouIeRHxTMPlOxVleUERKTPPyszdq8hTR12ex44uz+0BVed7MSvfS7t2ue2giLiuqkySJNXJoH6LKEnS8jBq1LDZ8+cvWXugtj9y5NA58+YtXqeFVSZl5lUDlWdFMHTo0NkdHR0D9pwOGTJkzpIlS/p8TjNzdOd0RNwH/Fd3z21EDMvMxcs35eBbafhKsxcuXjhg+33EsBFzFixa0Mp7SZIk9ZMFHklS7cyfv2TtfPyQAdt+jDtpmQ94I2IocBxwEPAUcGKX+ffRUDyIiCnASzPzfeX1HYDjgS2Bp4H/zczTIuKtwFeBTYEngVMzc0q52WvLv3MjAmA3YPPyfnYot/sG4CTgZcDfgEMy8w/lvGnA74GdgVcCfwTem5mPLev+6EtHR8fakyZNGrDtT506dZme04jYCTgTOBk4DLgyIj4FnAG8juIz1fXAwZk5KyL2Bw7PzNc0bOMw4M2ZOTkiVgKOAd4NrARcAByWmfOWJWerFi5euPZVU64esO3vOmWX5VY8ioiXA98HtgEeBL6QmReV804DngM2Bt4EzADeCXweOBCYA7wnM28tlx9P8VzuCDwDfDMzv728skqSVAWHaEmSNDA+DOwNvAp4DfCuZleMiA2ASykOQNekOKCdXs5+Fng/MAZ4K/DRiHhbOW/H8u+YzBydmX/sst3Vgd8A3wbGAd8AfhMR4xoWey/wAWAtYARweLO5VwDrAKsDGwIfofgc9dPy+gbAPKBzeN5FwOYRsVnD+u8Fzi6nj6Mosm0DvBRYD/jiwMavr4gYDkwFrqB4bX4SOCsiNm9Y7N3AUcAawAKKAuUt5fVfUrzeiYgh5bZmUOz3XYBDI2KPQXkwkiQNEAs8kiQtu19HxNyGy4cpDja/lZkzM/MJ4P9a2N4BwFWZeU5mLsrMxzNzOkBmTsvM2zOzIzNvA84BJja53bcCf8/MMzJzcWaeA9wNNHad+Wlm/q3sSXIeRQFChQ7gS5m5IDPnlc/LrzLzucx8mqJHzkSAzHwOuBB4D0BZ6NkCuCiK7lUfpuix80S57teA/St4TO3mee8l4Hvl7dsDo4FjM3NhZv4WuJhy/5YuyMybM3M+RY+o+Zl5emYuAX5OUWwF2A5YMzO/XG7rn8CPcP9LkmrOAo8kScvubZk5puHyI2A8MLNhmftb2N4E4B/dzYiI10XENRHxaEQ8CRxM0UOhGeO7yXE/RS+GTrMbpp+jOKhW4dGyeABARLwkIn4QEfdHxFMUQ+TGlMPzoOit01mAeC/w67LwsybwEuDmhkLGZeXtK7rnvZeAj5W3jwdmZmZHw7JdX7tzGqbndXO987W8ITC+SyHpf4ABOxeRJEmDwQKPJEkD42GKQk2nDbrMf5biIL9T44loZ1KcY6c7Z1MM/5mQmasBpwBRzss+Mj1EcXDbaAOK85mob13372coznH0usxclX8Pket8Pq4A1oiIbSgKPZ3Dsx6jKDi8oqGYsVrjCZ71Ag8BE8rhVZ36+9qdCdzbpSi7SmbutVySSpJUEQs8kiQNjPOAT0XE+hExluJkr42mA/tHxPCI6HqOnrOAXSPi3RExLCLGlUUCgFWAJzJzfkS8lqJnSKdHKYYRbdJDpkuAl0XEe8vt7kdxEueLl+FxrshWoSjUzC3Pb/Slxpnlr2z9Evg6xbl7rixv76AYEvTNiFgLICLW8xwwvbqRoih6RPme2YliaOG5/djWTcBTEfG5iBgVEUMjYquI2G75xZUkafBZ4JEkadlNjYhnGi4XUBzAX05xItdbgPO7rPO/FL10/gUczb97d5CZDwB7UfQQeYKiGLR1OftjwJcj4mmKk/Ke17DecxTngbm+HHqyfeMdZubjFCd+/gzwOHAEsPdg/ErWi9S3gFEUPXJuoBhm1dXZwK7AL7r8rPrngHuAG8rhXVdR9AZSNzJzITAZ2JNif38PeH9m3t2PbS2hKA5tA9xbbu/HwGrLK68kSVWIzL56c0uS1F5GjRo2e/78JQN2voyRI4fOmTdv8Tp9L6nlZejQobM7OjoG7DkdMmTInCVLlvicdrHS8JVmL1y8cMD2+4hhI+YsWLTA/S5J0iCwwCNJkiRJklRzDtGSJEmSJEmqOQs8kiRJkiRJNWeBR5IkSZIkqeYs8EiSJEmSJNWcBR5JkiRJkqSas8AjSZIkSZJUcxZ4JEmSJEmSas4CjyRJkiRJUs1Z4JEkSZIkSao5CzySJEmSJEk1Z4FHkiRJkiSp5izwSJIkSZIk1ZwFHkmSJEmSpJr7fx/eU5RH7ZQ4AAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABHgAAACkCAYAAADsQZkEAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAAsTAAALEwEAmpwYAAAaZ0lEQVR4nO3deZhcdZ3v8fe3OywhQcIWMKzGq4jDSFxARgOiLAoaBObqiBmEx+uo46jAFRdGH1yRIG4ELnovCjgsERdkiDNqcEEhCiqSsAgiW0wCCcgiiUnApL/3j3Mam9jVXdWkc+qXvF/PU0+f6j6n+lMn3fmd+vTvnIrMRJIkSZIkSeXqaTqAJEmSJEmSnh4LHkmSJEmSpMJZ8EiSJEmSJBXOgkeSJEmSJKlwFjySJEmSJEmFs+CRJEmSJEkqnAWPJEmSJElS4Sx4JEmSJEmSCmfBI0mSWoqIeyNiZUQsj4ilEXFBRIxvOlcrEXFhRHyqXt49IrLO3p//uxFxSIePOXAfLI+IOW1s89qIuDYiHo2IJRFxXkRs2cZ2b4yIn0fEioi4upOckiRp42bBI0mShjMtM8cDLwL2AT7SycZRafKYY0Kdf2/gKuA7EXF8h48xLTPH17dD21h/K+BTwCRgT2Bn4Mw2tnsY+CIwo8N8kiRpI2fBI0mS2pKZi4HvAXsBRMR+9WyTRyNifkQc2L9uRFwdEadFxFxgBTA5Io6PiLsjYllE3BMR0+t1eyLiIxGxICIeiIj/iIit6q/1z8I5LiL+EBF/jIgPjzD/ksw8C/gYcMZolk6ZeWlmfj8zV2TmI8B5wMvb2O6HmfkN4L7RyiZJkjZMFjySJKktEbELcDhwY0TsBPwX1SyVbYCTgW9HxPYDNjkWeDuwJfAgMBM4LDO3BF4GzKvXO76+vRKYDIwHzlnr208F9gAOAk6NiD2fxlO5HJhYPx4RcW5EnDvMNpdExIMRMSci9h7B9zwAuHUE20mSJLXFgkeSJA3nioh4FLgW+CnwaeCfgf/OzP/OzL7MvAr4NVUB1O/CzLw1M1cDq4E+YK+IGJuZ92dmf+ExHfh8Zt6dmcuBU4A3RcSYAY/18cxcmZnzgflUp1uNVP/smG0AMvNdmfmuIdafDuwO7Ab8BPhBRExo95vV1/w5Djh1JGElSZLaYcEjSZKGc2RmTsjM3eoyZCVV2fGG+vSsR+sCaCrwzAHbLexfyMw/A/8EvBO4PyL+KyKeV395ErBgwHYLgDHADgM+t2TA8gqqWT4jtVP98eF2Vs7MuXW5tCIzTwceBfZvZ9uI2A+4FPifmXnHSMJKkiS1w4JHkiSNxELgorr46b+Ny8yBFwfOgRtk5g8y8xCqEuh2quvSQDWjZrcBq+5KNeNn6ShlPwp4APjdCLdPIIZbKSJeCFwJvDUzfzTC7yVJktQWCx5JkjQSFwPTIuLVEdEbEZtHxIERsfNgK0fEDhFxRESMAx4HlgNr6i/PAk6KiGfVb8H+aeCy+tSudabO8G7go8ApmdnXxja7RsTLI2LT+jm+H9gOmDvMdnsB3wfek5mzO8jYGxGbU81g6qm/5ybtbi9JkjZeFjySJKljmbkQeD3w71QXUF4IvJ/WxxY9wPuoZus8DLwC6L/uzfnARcDPgHuAVcB71mHcRyPiz8DNVNcIekNmnt//xYj4ckR8ucW2WwJfAh4BFgOvobpQ9EPDfM/3AdsDX42I5fWtnYssHwusrL/n/vXyeUNuIUmSBERmDr+WJEmSJEmSupYzeCRJkiRJkgpnwSNJkjQC9aldywe5tTrdq3+7wbZZHhFtvTOXJEnSYDxFS5IkSZIkqXDO4JEkSZIkSSrcmA7WdaqPJEmSJEnS6ItON3AGjyRJkiRJUuHansET0XF5JEmSJEmSpA6N5HrJzuCRJEmSJEkqXCfX4CEfOmG0ckiSVJzY9iwApk2b1nASbexmz54NeKwmSdKGoP8Ys1PO4JEkSZIkSSqcBY8kSZIkSVLhLHgkSZIkSZIKZ8EjSZIkSZJUOAseSZIkSZKkwlnwSJIkSZIkFc6CR5IkSZIkqXAWPJIkSZIkSYWz4JEkSZIkSSqcBY8kSZIkSVLhLHgkSZIkSZIKZ8EjSZIkSZJUOAseSZIkSZKkwlnwSJIkSZIkFc6CR5IkSZIkqXAWPJIkSZIkSYWz4JEkSZIkSSqcBY8kSZIkSVLhLHgkSZIkSZIKZ8EjSZIkSZJUOAseSZIkSZKkwlnwSJIkSZIkFc6CR5IkSZIkqXAWPJIkSZIkSYWz4JEkSZIkSSqcBY8kSZIkSVLhLHgkSZIkSZIKN6bpANLGbPyu57L8D+968v6Fl/6WX89byjmfeWWDqSRpZLbccks++clPArD11lvT19fHn/70JwBOPvlkVq9evc6+11577cVRRx315PeTpBJ5LChpXbLgkSRJ68SyZcs48cQTATjmmGNYuXIlV1xxxZNf7+npoa+vr5lwkiRJGzgLHqlLLVj4GG99z1U8+NBKtt92LBeccwi77vwMjv+3OYzdfAy33/kICxY+xgVnH8LXvn4bv/jV/bz0xTty4f85FIA5P1nAR2dcx+NPrOHZu2/FBWcfwvjxmzb8rCRtbE444QSWLVvG5MmTufvuu7nmmmt429vexmabbcbjjz/OzJkzWbx4MWeeeSYzZ85k4cKFAJx22mmcf/75LFq0iHe84x3stttu9Pb2MmvWLK6//vqGn5UkjT6PBSV1yoJHatDKlauZ8opLnrz/8COrOOI1kwF49wev5i3/tCfHHfN8zr/kVt77oZ9yxcXTAHjkT4/z4yuO5srv3c20N89m7vfewFfOOph9Dv46825+kJ0njedTn/slP7z8aMaN24Qzzvo1n//SjZz6/pc28jwlbdx22mknTj31VPr6+hg7diynnHIKfX197L333hx77LHMmDGDa665hqlTpzJr1iy23nprttlmG+666y6OPfZYbrrpJmbOnMm4ceP47Gc/y7x585p+SpK0TngsKGldsuCRGjR27Bjm/XT6k/f7z7sG+MWv7ufyr70WgGPf+Dw+8LFrn1xv2qufRUTw98/fjh0mjuXvn78dAH+3xzbc+4fHWHTfMn77u4d5+eHfAOCJJ/r4h312XF9PS5KeYu7cuU+emjVu3DhOPPFEJk2aRGYyZkx1KHLttdfyiU98glmzZjF16lTmzp0LwJQpU9h333058sgjAdh0003ZfvvtG3kekrSueSwoaV2y4JEKERFPLm+2WS8APT3BZpv+9de4pydYvaaP3t5eDjlwV2add9h6zylJa1u1atWTy9OnT+fmm2/m9NNPZ+LEiZx22mkAPPzwwyxbtozdd9+dqVOncu655wLV/30zZsxg8eLFT3nMCRMmrLf8ktQNPBaUNBzfJl3qUi/b95l8/fI7ALjkm79j6ksntb3tfi/ZkbnX38eddz8KwIoVf+GOOx8ZjZiS1JEtttiChx56CICDDjroKV+75pprOProoxk3bhwLFiwA4MYbb+R1r3vdk+tMnjx5/YWVpAZ5LCipUxY8UpeaefqBXHDpb3nB/hdz0Tdu46zTD2h72+2324ILzzmUY/7le7xg/4vZ79WXcfvvHdQlNe/yyy/nLW95C2eccQY9PU89DPn5z3/O/vvvz7XX/vU0hMsuu4ze3l5mzpzJ2WefzfTp09d+SEnaIHksKKlTkZntrRiR+dAJoxxHkqRyxLZnATBt2rSGk2hjN3v2bAA8VpMkqXyx7VlkZgy/5lM5g0eSJEmSJKlwFjySJEmSJEmFs+CRJEmSJEkqnAWPJEmSJElS4Sx4JEmSJEmSCmfBI0mSJEmSVDgLHkmSJEmSpMJZ8EiSJEmSJBXOgkeSJEmSJKlwFjySJEmSJEmFs+CRJEmSJEkqnAWPJEmSJElS4Sx4JEmSJEmSCmfBI0mSJEmSVDgLHkmSJEmSpMJZ8EiSJEmSJBXOgkeSJEmSJKlwFjySJEmSJEmFs+CRJEmSJEkqnAWPJEmSJElS4Sx4JEmSJEmSCmfBI0mSJEmSVDgLHkmSJEmSpMJZ8EiSJEmSJBXOgkeSJEmSJKlwFjySJEmSJEmFs+CRJEmSJEkqnAWPJEmSJElS4Sx4JEmSJEmSCheZ2d6KEe2tKEmSJEmSpBHLzOh0G2fwSJIkSZIkFW5Muyu2O9NHkiRJkiRJ65czeCRJkiRJkgrXdsETEe8AosSb2c1t9u6/lZq91NxmN7fZy7iVmr3U3GY3t9m7/1ZqbrObfQS5306HOpnB0/GDdxGzr3+l5gazN6XU7KXmBrM3odTcYPamlJq91Nxg9iaUmhvM3oRSc4PZm1Jq9lEteCRJkiRJktSFLHgkSZIkSZIK10nB8/9GLcXoM/v6V2puMHtTSs1eam4wexNKzQ1mb0qp2UvNDWZvQqm5wexNKDU3mL0ppWbvOHf49ueSJEmSJEll8xQtSZIkSZKkwrVV8ETEayLidxFxZ0R8aLRDrSsRcX5EPBARtzSdpRMRsUtE/CQibouIWyPihKYztSsiNo+IX0bE/Dr7x5vO1ImI6I2IGyPiu01n6VRE3BsRN0fEvIj4ddN52hUREyLiWxFxe/0z/w9NZ2pHROxR7+v+22MRcWLTudoRESfVv5+3RMSsiNi86UztiogT6ty3dvv+HmwMiohtIuKqiPh9/XHrJjO20iL7G+r93hcRL2ky31BaZD+z/j/mpoj4TkRMaDDioFrk/mSdeV5EzImISU1mbGWo462IODkiMiK2ayLbcFrs949FxOIB/78f3mTGwbTa5xHxnvqY/daI+ExT+YbSYp9fNmB/3xsR8xqM2FKL7FMi4rr+46+I2LfJjINpkXvviPhFfew4OyKe0WTGVlq9Lur28XSI3F0/lg6RvYSxtFX2rh9PW2Uf8PX2xtPMHPIG9AJ3AZOBTYH5wPOH264bbsABwIuAW5rO0mHuZwIvqpe3BO4oaJ8HML5e3gS4Htiv6Vwd5P/fwKXAd5vOMoLs9wLbNZ1jBLm/BrytXt4UmNB0phE8h15gCbBb01nayLoTcA8wtr7/DeD4pnO1mX0v4BZgC2AM8EPgOU3nGiLv34xBwGeAD9XLHwLOaDpnB9n3BPYArgZe0nTGDrMfCoypl8/oxv3eIvczBiy/F/hy0znbzV5/fhfgB8CCbh2fWuz3jwEnN51tBLlfWf+/uFl9f2LTOTv5eRnw9c8Bpzads4P9Pgc4rF4+HLi66Zxt5v4V8Ip6+a3AJ5vO2SL7oK+Lun08HSJ314+lQ2QvYSxtlb3rx9NW2ev7bY+n7czg2Re4MzPvzswngK8Dr29ju8Zl5s+Ah5vO0anMvD8zf1MvLwNuo3pR1vWysry+u0l9K+JCTxGxM/Ba4CtNZ9lY1H8tOgD4KkBmPpGZjzYaamQOAu7KzAVNB2nTGGBsRIyhKkvuazhPu/YErsvMFZm5GvgpcFTDmVpqMQa9nqrUpP545PrM1K7BsmfmbZn5u4Yita1F9jn1zwzAdcDO6z3YMFrkfmzA3XF06Xg6xPHWF4AP0KW5oehjxcFy/yswIzMfr9d5YL0Ha8NQ+zwiAngjMGu9hmpTi+wJ9M9+2YouHFNb5N4D+Fm9fBXwj+s1VJuGeF3U1eNpq9wljKVDZC9hLG2VvevH02E6gLbH03YKnp2AhQPuL6KQsmFDEBG7Ay+kmglThKhOc5oHPABclZmlZP8i1S9OX8M5RiqBORFxQ0S8vekwbZoMPAhcENWpcV+JiHFNhxqBN9GlB6Nry8zFwGeBPwD3A3/KzDnNpmrbLcABEbFtRGxB9ZfSXRrO1KkdMvN+qAZyYGLDeTZGbwW+13SIdkXEaRGxEJgOnNp0nnZFxBHA4syc33SWEXp3PZ3//G479WMIzwX2j4jrI+KnEbFP04FGYH9gaWb+vukgHTgROLP+Pf0scEqzcdp2C3BEvfwGChhP13pdVMx4WuLruX5DZO/6sXTt7CWNpwOzdzqetlPwxCCf67rGa0MUEeOBbwMnrtU6drXMXJOZU6ha3X0jYq+GIw0rIl4HPJCZNzSd5Wl4eWa+CDgM+LeIOKDpQG0YQzVl+EuZ+ULgz1TTbIsREZtSHSB9s+ks7ahfqLweeBYwCRgXEf/cbKr2ZOZtVFOCrwK+T3XK8OohN5IGiIgPU/3MXNJ0lnZl5oczcxeqzO9uOk876gL2w3T5AfQQvgQ8G5hCVYR/rtE07RsDbA3sB7wf+EY9I6Ykx1DIH0wG+FfgpPr39CTqWckFeCvV8eINVKeDPNFwniGV+rqo1NzQOnsJY+lg2UsZTwdmp9rPHY2n7RQ8i3hqo7szXTj1cEMTEZtQ/cNekpmXN51nJOpTba4GXtNskra8HDgiIu6lOg3xVRFxcbOROpOZ99UfHwC+Q3V6ZbdbBCwaMMvrW1SFT0kOA36TmUubDtKmg4F7MvPBzPwLcDnwsoYztS0zv5qZL8rMA6imm5f0V16ApRHxTID6Y1eeQrEhiojjgNcB07M+ob0wl9Klp1AM4tlUJfL8elzdGfhNROzYaKo2ZebS+o9VfcB5lDGeQjWmXl6fLv9LqhnJXXlx68HUpw0fDVzWdJYOHUc1lkL1x54ifl4y8/bMPDQzX0xVqt3VdKZWWrwu6vrxtOTXc62ylzCWtrHfu3Y8HSR7x+NpOwXPr4DnRMSz6r9Uvwm48umGV2v1X1u+CtyWmZ9vOk8nImL7/iuqR8RYqheTtzcaqg2ZeUpm7pyZu1P9jP84M4uY1QAQEeMiYsv+ZaqLoHX9u8dl5hJgYUTsUX/qIOC3DUYaidL+2vgHYL+I2KL+v+YgqnN8ixARE+uPu1K9EChp30M1fh5XLx8H/GeDWTYaEfEa4IPAEZm5ouk87YqI5wy4ewQFjKcAmXlzZk7MzN3rcXUR1YUjlzQcrS39LxprR1HAeFq7AngVQEQ8l+qNC/7YZKAOHQzcnpmLmg7SofuAV9TLr6KQPzwMGE97gI8AX2420eCGeF3U1eNp4a/nBs1ewlg6RPauH08Hyz6i8TTbu6Lz4VRXcb4L+HA723TDjerA/37gL/XO+F9NZ2oz91Sq0+BuAubVt8ObztVm9hcAN9bZb6FL3wVhmOdwIIW9ixbVtWzm17dbC/s9nQL8uv6ZuQLYuulMHWTfAngI2KrpLB3m/jjVwHYLcBH1O66UcAOuoSoB5wMHNZ1nmKx/MwYB2wI/onoB8CNgm6ZzdpD9qHr5cWAp8IOmc3aQ/U6q6wn2j6nd+O4Zg+X+dv17ehMwm+pCkY1nbSf7Wl+/l+59F63B9vtFwM31fr8SeGbTOdvMvSlwcf0z8xvgVU3n7OTnBbgQeGfT+Uaw36cCN9Tj0vXAi5vO2WbuE6he390BzACi6Zwtsg/6uqjbx9Mhcnf9WDpE9hLG0lbZu348bZV9rXWGHU+jXlGSJEmSJEmFaucULUmSJEmSJHUxCx5JkiRJkqTCWfBIkiRJkiQVzoJHkiRJkiSpcBY8kiRJkiRJhbPgkSRJkiRJKpwFjyRJkiRJUuEseCRJkiRJkgpnwSNJkiRJklQ4Cx5JkiRJkqTCWfBIkiRJkiQVzoJHkiRJkiSpcBY8kiRJkiRJhbPgkSRJkiRJKpwFjyRJkiRJUuEseCRJkiRJkgpnwSNJkiRJklQ4Cx5JkiRJkqTCWfBIkiRJkiQVzoJHkiRJkiSpcBY8kiRJkiRJhbPgkSRJkiRJKpwFjyRJkiRJUuEseCRJkiRJkgpnwSNJkiRJklQ4Cx5JkiRJkqTCWfBIkiTpb0TEgRGxqOkckiSpPRY8kiRpWBFxb0QcvNbnjo+Ia5vKtCGLiOUDbn0RsXLA/elN55MkSd1nTNMBJElSa2PHjlmyatWaHUbr8TffvHfpypWrdxytxy9Nb2/vkr6+vlHb3z09PUvXrFkz7P7OzPH9yxFxL/C2zPzh2utFxJjMXL1uU0qSpBJZ8EiS1MVWrVqzQz50wqg9fmx71jopMyJiT+BLwBRgMXBKZl5Zf+1CYAXwLGB/YD7wj8CHgOOApcAxmXljvf4k4GzgAGA58IXMnLkucg6nr69vh2nTpo3a48+ePftp7e+IOBC4mGr/nARcFRHvBS4CXkp1bDcXeGdmLoqINwEnZ+ZLBjzGScArM/OIiNgMOA14I7AZ8B3gpMxc+XRySpKk9c9TtCRJ0tMSEZsAs4E5wETgPcAlEbHHgNXeCHwE2A54HPgF8Jv6/reAz9eP1VM/1nxgJ+Ag4MSIePV6eTJl2BHYBtgNeDvV8dwF9f1dgZXAOfW6VwJ7RMRzBmz/ZuDSevkM4LlUxdz/oNrnp45ufEmSNBoseCRJUruuiIhH+2/AufXn9wPGAzMy84nM/DHwXeCYAdt+JzNvyMxVVLNEVmXmf2TmGuAy4IX1evsA22fmJ+rHuhs4D3jT6D+9YvQBH83MxzNzZWY+lJnfzswVmbmMakbOKwAycwXwn9T/FnXR8zzgyogI4F+oZuw8XG/7adzXkiQVyYJHkiS168jMnNB/A95Vf34SsDAz+wasu4BqNki/pQOWVw5yv/+aM7sBk9Yqkv4dGLXr4hTowbooAyAitoiI/xsRCyLiMeBnwISI6K1XuZS/lm1vBq6oi5/tgS2AGwbs6+/Xn5ckSYXxGjySJOnpug/YJSJ6BpQ8uwJ3jOCxFgL3ZOZzhl1z45Vr3X8fsAfw0sxcEhFTgBuBqL8+B9iu/vwxVNfuAfgjVbn2d5m5eLRDS5Kk0eUMHkmS9HRdD/wZ+EBEbFJfCHga8PURPNYvgcci4oMRMTYieiNir4jYZ93F3eBsSVXUPBoR2wAfHfjF+l22vgWcSXXtnqvqz/dRnf72hYiYCBARO3m9I0mSymTBI0mSnpbMfAI4AjiMalbIucBbMvP2ETzWGqpyaApwT/14XwG2Wld5N0BfBMZS7avrqE6zWtulwMHAN9d6W/UPAncC19Wnd/2QajaQJEkqTGSuPctXkiR1i7FjxyxZtWrNqF1/ZvPNe5euXLl6x9F6/NL09vYu6evrG7X93dPTs3TNmjXub0mStM5Z8EiSJEmSJBXOU7QkSZIkSZIKZ8EjSZIkSZJUOAseSZIkSZKkwlnwSJIkSZIkFc6CR5IkSZIkqXAWPJIkSZIkSYWz4JEkSZIkSSqcBY8kSZIkSVLhLHgkSZIkSZIKZ8EjSZIkSZJUOAseSZIkSZKkwlnwSJIkSZIkFc6CR5IkSZIkqXD/H6u8XXREUWxSAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 1152x216 with 1 Axes>"
       ]
@@ -4569,17 +3810,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 51,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-11-24T18:52:43.705393Z",
      "start_time": "2020-11-24T18:52:28.634010Z"
     },
     "execution": {
-     "iopub.execute_input": "2023-06-22T10:53:19.900181Z",
-     "iopub.status.busy": "2023-06-22T10:53:19.900075Z",
-     "iopub.status.idle": "2023-06-22T10:53:20.027975Z",
-     "shell.execute_reply": "2023-06-22T10:53:20.027655Z"
+     "iopub.execute_input": "2023-07-04T15:30:21.361042Z",
+     "iopub.status.busy": "2023-07-04T15:30:21.360930Z",
+     "iopub.status.idle": "2023-07-04T15:30:21.488770Z",
+     "shell.execute_reply": "2023-07-04T15:30:21.488468Z"
     }
    },
    "outputs": [],

--- a/pam/planner/clustering.py
+++ b/pam/planner/clustering.py
@@ -86,9 +86,7 @@ class PlanClusters:
         """
         if clustering_method == "agglomerative":
             model = AgglomerativeClustering(
-                n_clusters=n_clusters,
-                linkage=linkage,
-                affinity="precomputed",  # change argument to "metric" for sklearn version>=1.4
+                n_clusters=n_clusters, linkage=linkage, metric="precomputed"
             )
             model.fit((self.distances))
         elif clustering_method == "spectral":

--- a/pam/read/matsim.py
+++ b/pam/read/matsim.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from datetime import timedelta
 from typing import Literal, Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ addopts = "-rav --strict-markers -n2 --nbmake --nbmake-kernel=pam --cov=. --cov-
 testpaths = ["tests", "examples", "mkdocs_plugins"]
 # to mark a test, decorate it with `@pytest.mark.[marker-name]`
 markers = ["high_mem", "limit_memory"]
+filterwarnings = [
+    # https://github.com/pytest-dev/pytest-xdist/issues/825
+    "ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning",
+]
 
 [tool.coverage.run]
 branch = true

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,16 +1,17 @@
-click >= 8.1, < 9
+click < 9
 gdal < 3.6
 geopandas >= 0.13, < 0.14
-ipykernel >= 5.2, < 6
-lxml >= 4.6, < 5
-matplotlib >= 3.2, < 4
-pandas >= 1.3, < 2
-plotly >= 4.10, < 5
-prettytable >= 3.3, < 4
+ipykernel < 7
+lxml < 5
+matplotlib >= 3, < 4
+numpy >= 1, < 2
+pandas >= 1.5, < 3
+plotly >= 4, < 6
+prettytable >= 3, < 4
 python-Levenshtein >= 0.21, < 0.22
-rich >= 12.5, < 13
-Rtree >= 0.9, < 1
+rich >= 12, < 14
+Rtree >= 1, < 2
 s2sphere < 0.3
 scikit-learn >= 1.2, < 2
-shapely > 2.0, < 3
-xlrd >= 2.0, < 3
+shapely >= 1, < 3
+xlrd >= 2, < 3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
-nbmake ~= 1.3
-pre-commit ~= 3.3
-pytest ~= 7.3
-pytest-cov ~= 4.1
-pytest-mock ~= 3.10
-pytest-timeout ~= 2.1
-pytest-xdist ~= 3.3
+nbmake < 2
+pre-commit < 4
+pytest < 8
+pytest-cov < 5
+pytest-mock < 4
+pytest-timeout < 3
+pytest-xdist < 4

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,9 +1,6 @@
-colorama
 jupyter < 2
-jupyter_contrib_nbextensions < 0.6
-mike ~= 1.1
-mkdocs ~= 1.4
-mkdocs-click ~= 0.6.0
-mkdocs-jupyter ~= 0.24.1
-mkdocstrings-python ~= 1.1
-tabulate < 1
+mike < 2
+mkdocs < 2
+mkdocs-click < 0.7
+mkdocs-jupyter < 0.25
+mkdocstrings-python < 2

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ requirements = {
 
 setup(
     name="pam",
-    version="0.2.5-dev",
+    version="0.2.5.dev",
     author="Fred Shone",
     author_email="",
     description="Pandemic Activity Modeller/Modifier",

--- a/tests/test_08_write.py
+++ b/tests/test_08_write.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import geopandas as gp
 import lxml
 import pandas as pd
+import pytest
 from shapely.geometry import Point
 
 from pam import write
@@ -729,6 +730,9 @@ def test_write_to_csv_some_locs(population_heh, tmpdir):
     assert len(acts_df) == 6
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future:DeprecationWarning"
+)
 def test_write_to_csv_convert_locs(population_heh, tmpdir):
     population_heh.to_csv(tmpdir, crs="EPSG:27700")
 

--- a/tests/test_15_cropping.py
+++ b/tests/test_15_cropping.py
@@ -161,6 +161,7 @@ def test_simple_cropping(test_plan, test_zoning_system):
     assert activity_zones == ["g", "h", "e"]
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered in intersects:RuntimeWarning")
 def test_complex_cropping(test_plan, test_zoning_system):
     """Through-trips and multiple entries to the core area (e)."""
     boundary = test_zoning_system.loc["e"].geometry


### PR DESCRIPTION
PAM should now work on any version from python 3.9 to 3.11, with the CI updated to test the extremes of this range.
It would also be possible to test with some dependencies set to lower bounds to ensure that breaking changes don't creep in (e.g., I've tested locally with pandas=1.5, plotly=4, gdal=3.5 and everything passes, just with some deprecation warnings).

I've put explicit warning ignores for persistent deprecation warnings that are the fault of dependencies, not us.