### PR TITLE
fix for #221

### DIFF
--- a/.github/workflows/build_pipeline.yml
+++ b/.github/workflows/build_pipeline.yml
@@ -133,7 +133,7 @@ jobs:
 
     - name: Send build success notification
       if: success()
-      uses: rtCamp/action-slack-notify@v2.0.0
+      uses: rtCamp/action-slack-notify@v2.2.0
       env:
         SLACK_MESSAGE: ${{ github.repository }} build ${{ github.run_number }} launched by ${{ github.actor }} has succeeded
         SLACK_TITLE: Build Success
@@ -144,7 +144,7 @@ jobs:
 
     - name: Send build failure notification
       if: failure()
-      uses: rtCamp/action-slack-notify@v2.0.0
+      uses: rtCamp/action-slack-notify@v2.2.0
       env:
         SLACK_COLOR: '#FF0000'
         SLACK_MESSAGE: ${{ github.repository }} build ${{ github.run_number }} launched by ${{ github.actor }} has failed

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Send build success notification
       if: success()
-      uses: rtCamp/action-slack-notify@v2.0.0
+      uses: rtCamp/action-slack-notify@v2.2.0
       env:
         SLACK_MESSAGE: ${{ github.repository }} Daily scheduled CI Build ${{ github.run_number }} has succeeded
         SLACK_TITLE: Daily CI Build Success
@@ -49,7 +49,7 @@ jobs:
 
     - name: Send build failure notification
       if: failure()
-      uses: rtCamp/action-slack-notify@v2.0.0
+      uses: rtCamp/action-slack-notify@v2.2.0
       env:
         SLACK_COLOR: '#FF0000'
         SLACK_LINK_NAMES: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix for [#221](https://github.com/arup-group/pam/issues/221), improved "pt simplification" ([#222])
+
 ### Added
 - Anaconda package of PAM, available on the `city-modelling-lab` channel ([#211])
 - Python versions 3.9 to 3.11 support ([#192], [#210]).
@@ -27,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **internal** Contribution guidelines and issue/pull request templates ([#207]).
 
 ### Changed
-- Fix for #221, improved "pt simplification" ([#222])
 - Recommended installation instructions, to use [mamba](https://mamba.readthedocs.io/en/latest/index.html) instead of pip ([#192], [#211]).
 - **internal** Source code and example notebook code layout to align with pep8 guidelines and to remove unused dependency imports ([#196], [#201]).
 - **internal** development toolkit, moving from internal scripts to pytest plugins ([#193]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **internal** Contribution guidelines and issue/pull request templates ([#207]).
 
 ### Changed
+- Fix for #221, improved "pt simplification" ([#222])
 - Recommended installation instructions, to use [mamba](https://mamba.readthedocs.io/en/latest/index.html) instead of pip ([#192], [#211]).
 - **internal** Source code and example notebook code layout to align with pep8 guidelines and to remove unused dependency imports ([#196], [#201]).
 - **internal** development toolkit, moving from internal scripts to pytest plugins ([#193]).
@@ -72,6 +73,7 @@ This is the first version of PAM which follows semantic versioning and can be co
 [v0.2.1]: https://github.com/arup-group/pam/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/arup-group/pam/compare/initial_version...v0.2.0
 
+[#222]: https://github.com/arup-group/pam/pull/222
 [#211]: https://github.com/arup-group/pam/pull/211
 [#210]: https://github.com/arup-group/pam/pull/210
 [#207]: https://github.com/arup-group/pam/pull/207

--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ You can also run these checks yourself at any time to ensure staged changes are 
 - `pytest` - run the unit test suite, check test coverage, and test that the example notebooks successfully run.
 - `pytest -p memray -m "high_mem" --no-cov` (not available on Windows) - after installing memray (`mamba install memray pytest-memray`), test that memory and time performance does not exceed benchmarks.
 
-For more information, see our [documentation](https://arup-group.github.io/pam/contributing/coding/).
+For more information, see our [documentation](https://arup-group.github.io/pam/0.2/contributing/coding/).
 
 ## Building the documentation
 
 If you are unable to access the online documentation, you can build the documentation locally.
-First, [install a development environment of PAM](https://arup-group.github.io/pam/contributing/coding/), then deploy the documentation using [mike](https://github.com/jimporter/mike):
+First, [install a development environment of PAM](https://arup-group.github.io/pam/0.2/contributing/coding/), then deploy the documentation using [mike](https://github.com/jimporter/mike):
 
 ```
 mike deploy 0.2

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mamba activate pam
 pip install --no-deps .
 ```
 
-For more detailed instructions, see our [documentation](https://arup-group.github.io/pam/0.2/installation/).
+For more detailed instructions, see our [documentation](https://arup-group.github.io/pam/latest/installation/).
 
 ## Contributing
 
@@ -76,12 +76,12 @@ You can also run these checks yourself at any time to ensure staged changes are 
 - `pytest` - run the unit test suite, check test coverage, and test that the example notebooks successfully run.
 - `pytest -p memray -m "high_mem" --no-cov` (not available on Windows) - after installing memray (`mamba install memray pytest-memray`), test that memory and time performance does not exceed benchmarks.
 
-For more information, see our [documentation](https://arup-group.github.io/pam/0.2/contributing/coding/).
+For more information, see our [documentation](https://arup-group.github.io/pam/latest/contributing/coding/).
 
 ## Building the documentation
 
 If you are unable to access the online documentation, you can build the documentation locally.
-First, [install a development environment of PAM](https://arup-group.github.io/pam/0.2/contributing/coding/), then deploy the documentation using [mike](https://github.com/jimporter/mike):
+First, [install a development environment of PAM](https://arup-group.github.io/pam/latest/contributing/coding/), then deploy the documentation using [mike](https://github.com/jimporter/mike):
 
 ```
 mike deploy 0.2

--- a/pam/activity.py
+++ b/pam/activity.py
@@ -61,6 +61,64 @@ class Plan:
             if isinstance(p, Leg):
                 yield p
 
+    def simplify_pt_trips(self, skip=["pt interaction", "pt_interaction"]) -> None:
+        """Remove pt interaction events and simplify legs to single leg with mode.
+
+        pt interaction events result from complex matsim plans.
+
+        """
+        if set(skip).intersection(self.activity_classes):
+            self.day = list(self.tripify(skip=skip))
+
+    def tripify(
+        self, skip: list[str] = ["pt interaction", "pt_interaction"]
+    ) -> Iterator[PlanComponent]:
+        """Yield plan trips and activities based on ignoring certain activities.
+
+        Args:
+          ignore (list[str], optional): activities to ignore. Defaults to ["pt interaction", "pt_interaction"].
+
+        Returns:
+            Iterator: PlanComponents
+        """
+        if self.day:
+            seq = 0
+            modes = {}
+            start_location = self.day[0].location
+            start_time = self.day[0].end_time
+            distance = 0
+            for component in self:
+                if isinstance(component, Leg):
+                    modes[component.mode] = modes.get(component.mode, 0) + component.distance
+                    distance += component.distance
+                    attributes = component.attributes  # trips collect attributes from last leg
+                if isinstance(component, Activity):
+                    if component.act not in skip:
+                        while True:
+                            if modes:
+                                yield Leg(
+                                    seq=seq,
+                                    mode=max(modes, key=modes.get),
+                                    start_area=start_location.area,
+                                    end_area=component.location.area,
+                                    start_link=start_location.link,
+                                    end_link=component.location.link,
+                                    start_loc=start_location.loc,
+                                    end_loc=component.location.loc,
+                                    start_time=start_time,
+                                    end_time=component.start_time,
+                                    distance=distance,
+                                    purp=component.act,
+                                    attributes=attributes,
+                                )
+                            yield component
+                            break
+                        modes = {}
+                        start_location = component.location
+                        start_time = component.end_time
+                        distance = 0
+                        seq += 1
+
     def trips(self, ignore: list[str] = ["pt interaction", "pt_interaction"]) -> str:
         """Yield plan trips based on ignoring certain activities.
 
@@ -80,6 +138,7 @@ class Plan:
                 if isinstance(component, Leg):
                     modes[component.mode] = modes.get(component.mode, 0) + component.distance
                     distance += component.distance
+                    attributes = component.attributes
                 elif component.act not in ignore:
                     yield Trip(
                         seq=seq,
@@ -94,6 +153,7 @@ class Plan:
                         end_time=component.start_time,
                         distance=distance,
                         purp=component.act,
+                        attributes=attributes,
                     )
                     modes = {}
                     start_location = component.location
@@ -870,29 +930,6 @@ class Plan:
             )
         ]
 
-    def simplify_pt_trips(self) -> None:
-        """Remove pt interaction events and simplify legs to single leg with mode = pt.
-
-        pt interaction events result from complex matsim plans.
-
-        """
-        pt_trip = False
-        for idx, component in list(self.reversed()):
-            if component.act == "pt interaction":  # this is a pt trip
-                if not pt_trip:  # this is a new pt leg
-                    trip_end_time = self[idx + 1].end_time
-                    trip_end_location = self[idx + 1].end_location
-
-                pt_trip = True
-                self.day.pop(idx + 1)
-                self.day.pop(idx)
-            else:
-                if pt_trip:  # this is the start of the pt trip - modify the first leg
-                    self[idx].mode = "pt"
-                    self[idx].end_time = trip_end_time
-                    self[idx].end_location = trip_end_location
-                pt_trip = False
-
     def get_home_duration(self):
         """Get the total duration of home activities."""
         # total time spent at home
@@ -1159,7 +1196,8 @@ class Leg(PlanComponent):
             self.start_location == other.start_location
             and self.end_location == other.end_location
             and self.mode == other.mode
-            and self.duration == other.duration
+            and self.start_time == other.start_time
+            and self.end_time == other.end_time
         )
 
     @property

--- a/pam/read/matsim.py
+++ b/pam/read/matsim.py
@@ -449,7 +449,20 @@ def get_attributes_from_person(elem):
     ident = elem.xpath("@id")[0]
     attributes = {}
     for attr in elem.xpath("./attributes/attribute"):
-        attributes[attr.get("name")] = attr.text
+        data = attr.get("class")
+        if data == "java.lang.String":
+            attributes[attr.get("name")] = attr.text
+        elif data == "java.lang.Boolean":
+            attributes[attr.get("name")] = attr.text == "true"
+        elif data == "java.lang.Integer":
+            attributes[attr.get("name")] = int(attr.text)
+        elif data == "java.lang.Double":
+            attributes[attr.get("name")] = float(attr)
+        elif data == "org.matsim.vehicles.PersonVehicles":
+            attributes[attr.get("name")] = attr.text
+        # last try:
+        else:
+            attributes[attr.get("name")] = attr.text
     return ident, attributes
 
 

--- a/pam/read/matsim.py
+++ b/pam/read/matsim.py
@@ -449,20 +449,21 @@ def get_attributes_from_person(elem):
     ident = elem.xpath("@id")[0]
     attributes = {}
     for attr in elem.xpath("./attributes/attribute"):
-        data = attr.get("class")
-        if data == "java.lang.String":
-            attributes[attr.get("name")] = attr.text
-        elif data == "java.lang.Boolean":
-            attributes[attr.get("name")] = attr.text == "true"
-        elif data == "java.lang.Integer":
-            attributes[attr.get("name")] = int(attr.text)
-        elif data == "java.lang.Double":
-            attributes[attr.get("name")] = float(attr)
-        elif data == "org.matsim.vehicles.PersonVehicles":
-            attributes[attr.get("name")] = attr.text
+        attribute_type = attr.get("class")
+        attribute_name = attr.get("name")
+        if attribute_type == "java.lang.String":
+            attributes[attribute_name] = attr.text
+        elif attribute_type == "java.lang.Boolean":
+            attributes[attribute_name] = attr.text.lower() == "true"
+        elif attribute_type == "java.lang.Integer":
+            attributes[attribute_name] = int(attr.text)
+        elif attribute_type == "java.lang.Double":
+            attributes[attribute_name] = float(attr)
+        elif attribute_type == "org.matsim.vehicles.PersonVehicles":
+            attributes[attribute_name] = attr.text
         # last try:
         else:
-            attributes[attr.get("name")] = attr.text
+            attributes[attribute_name] = attr.text
     return ident, attributes
 
 

--- a/pam/write/matsim.py
+++ b/pam/write/matsim.py
@@ -179,6 +179,7 @@ def create_person_element(pid, person, keep_non_selected: bool = False):
     person_xml = et.Element("person", {"id": str(pid)})
 
     attributes = et.SubElement(person_xml, "attributes", {})
+
     for k, v in person.attributes.items():
         if k == "vehicles":  # todo make something more robust for future 'special' classes
             attribute = et.SubElement(

--- a/tests/test_02_activity_trips.py
+++ b/tests/test_02_activity_trips.py
@@ -1,11 +1,11 @@
 import pytest
 from shapely import Point
 
-from pam.activity import Activity, Leg, Plan
+from pam.activity import Activity, Leg, Plan, Trip
 
 
 @pytest.mark.parametrize(
-    ["day", "expected"],
+    "day,expected",
     [
         ([], []),
         ([Activity(act="home", loc=Point(0, 0))], []),
@@ -15,7 +15,7 @@ from pam.activity import Activity, Leg, Plan
                 Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0)),
                 Activity(act="work", loc=Point(100, 0)),
             ],
-            [Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0))],
+            [Trip(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0))],
         ),
         (
             [
@@ -27,7 +27,24 @@ from pam.activity import Activity, Leg, Plan
                 Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
                 Activity(act="work", loc=Point(0, 1000)),
             ],
-            [Leg(mode="bus", distance=1120, start_loc=Point(0, 0), end_loc=Point(0, 1000))],
+            [Trip(mode="bus", distance=1120, start_loc=Point(0, 0), end_loc=Point(0, 1000))],
+        ),
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="pt interaction", loc=Point(100, 0)),
+                Leg(mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)),
+                Activity(act="pt interaction", loc=Point(100, 1000)),
+                Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+                Leg(mode="car", distance=1200, start_loc=Point(100, 1000), end_loc=Point(0, 0)),
+                Activity(act="home", loc=Point(0, 0)),
+            ],
+            [
+                Trip(mode="bus", distance=1120, start_loc=Point(0, 0), end_loc=Point(0, 1000)),
+                Trip(mode="car", distance=1200, start_loc=Point(0, 1000), end_loc=Point(0, 0)),
+            ],
         ),
     ],
 )
@@ -38,22 +55,94 @@ def test_iter_trips(day, expected):
 
 
 @pytest.mark.parametrize(
-    ["day", "expected"],
+    "day,expected",
     [
         ([], []),
-        ([Activity(act="home", loc=Point(0, 0))], [Activity(act="home", loc=Point(0, 0))]),
+        ([Activity(act="home", loc=Point(0, 0))], []),
         (
             [
                 Activity(act="home", loc=Point(0, 0)),
                 Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0)),
                 Activity(act="work", loc=Point(100, 0)),
             ],
+            [[Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0))]],
+        ),
+        (
             [
                 Activity(act="home", loc=Point(0, 0)),
-                Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0)),
-                Activity(act="work", loc=Point(100, 0)),
+                Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="pt interaction", loc=Point(100, 0)),
+                Leg(mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)),
+                Activity(act="pt interaction", loc=Point(100, 1000)),
+                Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+            ],
+            [
+                [
+                    Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                    Leg(
+                        mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)
+                    ),
+                    Leg(
+                        mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)
+                    ),
+                ]
             ],
         ),
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="pt interaction", loc=Point(100, 0)),
+                Leg(mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)),
+                Activity(act="pt interaction", loc=Point(100, 1000)),
+                Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+                Leg(mode="car", distance=1200, start_loc=Point(100, 1000), end_loc=Point(0, 0)),
+                Activity(act="home", loc=Point(0, 0)),
+            ],
+            [
+                [
+                    Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                    Leg(
+                        mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)
+                    ),
+                    Leg(
+                        mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)
+                    ),
+                ],
+                [Leg(mode="car", distance=1200, start_loc=Point(100, 1000), end_loc=Point(0, 0))],
+            ],
+        ),
+    ],
+)
+def test_iter_trip_legs(day, expected):
+    plan = Plan()
+    plan.day = day
+    assert list(plan.trip_legs()) == expected
+
+
+@pytest.mark.parametrize(
+    "day",
+    [
+        [],
+        [Activity(act="home", loc=Point(0, 0))],
+        [
+            Activity(act="home", loc=Point(0, 0)),
+            Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+            Activity(act="work", loc=Point(100, 0)),
+        ],
+    ],
+)
+def test_tripify_unchanged(day):
+    plan = Plan()
+    plan.day = day.copy()
+    assert list(plan.tripify()) == day
+
+
+@pytest.mark.parametrize(
+    "day,expected",
+    [
         (
             [
                 Activity(act="home", loc=Point(0, 0)),
@@ -70,9 +159,96 @@ def test_iter_trips(day, expected):
                 Activity(act="work", loc=Point(0, 1000)),
             ],
         ),
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="pt interaction", loc=Point(100, 0)),
+                Leg(mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)),
+                Activity(act="pt interaction", loc=Point(100, 1000)),
+                Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+                Leg(mode="car", distance=1200, start_loc=Point(0, 1000), end_loc=Point(0, 0)),
+                Activity(act="home", loc=Point(0, 0)),
+            ],
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="bus", distance=1120, start_loc=Point(0, 0), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+                Leg(mode="car", distance=1200, start_loc=Point(0, 1000), end_loc=Point(0, 0)),
+                Activity(act="home", loc=Point(0, 0)),
+            ],
+        ),
     ],
 )
-def test_tripify(day, expected):
+def test_tripify_changed(day, expected):
     plan = Plan()
     plan.day = day
     assert list(plan.tripify()) == expected
+
+
+@pytest.mark.parametrize(
+    "day",
+    [
+        [],
+        [Activity(act="home", loc=Point(0, 0))],
+        [
+            Activity(act="home", loc=Point(0, 0)),
+            Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+            Activity(act="work", loc=Point(100, 0)),
+        ],
+    ],
+)
+def test_simplify_pt_trips_unchanged(day):
+    plan = Plan()
+    plan.day = day.copy()
+    plan.simplify_pt_trips()
+    assert plan.day == day
+
+
+@pytest.mark.parametrize(
+    "day,expected",
+    [
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="pt interaction", loc=Point(100, 0)),
+                Leg(mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)),
+                Activity(act="pt interaction", loc=Point(100, 1000)),
+                Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+            ],
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="bus", distance=1120, start_loc=Point(0, 0), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+            ],
+        ),
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="pt interaction", loc=Point(100, 0)),
+                Leg(mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)),
+                Activity(act="pt interaction", loc=Point(100, 1000)),
+                Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+                Leg(mode="car", distance=1200, start_loc=Point(0, 1000), end_loc=Point(0, 0)),
+                Activity(act="home", loc=Point(0, 0)),
+            ],
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="bus", distance=1120, start_loc=Point(0, 0), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+                Leg(mode="car", distance=1200, start_loc=Point(0, 1000), end_loc=Point(0, 0)),
+                Activity(act="home", loc=Point(0, 0)),
+            ],
+        ),
+    ],
+)
+def test_simplify_pt_trips_changed(day, expected):
+    plan = Plan()
+    plan.day = day
+    plan.simplify_pt_trips()
+    assert plan.day == expected

--- a/tests/test_02_activity_trips.py
+++ b/tests/test_02_activity_trips.py
@@ -1,0 +1,78 @@
+import pytest
+from shapely import Point
+
+from pam.activity import Activity, Leg, Plan
+
+
+@pytest.mark.parametrize(
+    ["day", "expected"],
+    [
+        ([], []),
+        ([Activity(act="home", loc=Point(0, 0))], []),
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="work", loc=Point(100, 0)),
+            ],
+            [Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0))],
+        ),
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="pt interaction", loc=Point(100, 0)),
+                Leg(mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)),
+                Activity(act="pt interaction", loc=Point(100, 1000)),
+                Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+            ],
+            [Leg(mode="bus", distance=1120, start_loc=Point(0, 0), end_loc=Point(0, 1000))],
+        ),
+    ],
+)
+def test_iter_trips(day, expected):
+    plan = Plan()
+    plan.day = day
+    assert list(plan.trips()) == expected
+
+
+@pytest.mark.parametrize(
+    ["day", "expected"],
+    [
+        ([], []),
+        ([Activity(act="home", loc=Point(0, 0))], [Activity(act="home", loc=Point(0, 0))]),
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="work", loc=Point(100, 0)),
+            ],
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="car", distance=1000, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="work", loc=Point(100, 0)),
+            ],
+        ),
+        (
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="walk", distance=100, start_loc=Point(0, 0), end_loc=Point(100, 0)),
+                Activity(act="pt interaction", loc=Point(100, 0)),
+                Leg(mode="bus", distance=1000, start_loc=Point(100, 0), end_loc=Point(100, 1000)),
+                Activity(act="pt interaction", loc=Point(100, 1000)),
+                Leg(mode="walk", distance=20, start_loc=Point(100, 1000), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+            ],
+            [
+                Activity(act="home", loc=Point(0, 0)),
+                Leg(mode="bus", distance=1120, start_loc=Point(0, 0), end_loc=Point(0, 1000)),
+                Activity(act="work", loc=Point(0, 1000)),
+            ],
+        ),
+    ],
+)
+def test_tripify(day, expected):
+    plan = Plan()
+    plan.day = day
+    assert list(plan.tripify()) == expected


### PR DESCRIPTION
Fixes #221.

Provides "pt" simplification based on removing "pt interaction" activities. Added coverage but am also going to test simplified plans in matsim. Will update.

## Checklist

- [x] CHANGELOG updated
- [x] Memory profiling tests pass (see [here](https://arup-group.github.io/pam/contributing/coding/#memory-profiling) for more details)
- [x] Tests added to cover contribution
- [x] Documentation updated
