### PR TITLE
Update install instructions and docker entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ ARG MAMBA_DOCKERFILE_ACTIVATE=1
 
 RUN pip install --no-deps -e .
 
-ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "ipython"]
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -49,25 +49,36 @@ supply or utility demand.
 The PAM package is not yet indexed online.
 To install it, we recommend the following:
 
+### As a user
+<!--- --8<-- [start:docs-install-user] -->
 ``` shell
 git clone git@github.com:arup-group/pam.git
 cd pam
-mamba create -n pam -c city-modelling-lab --file requirements/base.txt
+mamba create -n pam -c conda-forge -c city-modelling-lab --file requirements/base.txt
 mamba activate pam
 pip install --no-deps .
 ```
-
+<!--- --8<-- [end:docs-install-user] -->
+### As a developer
+<!--- --8<-- [start:docs-install-dev] -->
+``` shell
+git clone git@github.com:arup-group/pam.git
+cd pam
+mamba create -n pam -c conda-forge -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt
+mamba activate pam
+pip install --no-deps -e .
+```
+<!--- --8<-- [end:docs-install-dev] -->
 For more detailed instructions, see our [documentation](https://arup-group.github.io/pam/latest/installation/).
 
 ## Contributing
 
 There are many ways to make both technical and non-technical contributions to PAM.
-Before making contributions to the PAM source code, see our contribution guidelines and follow the instructions below to install and work in a test environment.
+Before making contributions to the PAM source code, see our contribution guidelines and follow the [development install instructions](#as-a-developer).
 
-You can install the optional dev libraries using the `dev` option, i.e., `pip install -e '.[dev]'`
+If you are using `pip` to install PAM instead of the recommended `mamba`, you can install the optional test and documentation libraries using the `dev` option, i.e., `pip install -e '.[dev]'`
 
-If you plan to make changes to the code then please make regular use of the following tools to verify the codebase
-while you work:
+If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:
 
 - `pre-commit`: run `pre-commit install` in your command line to load inbuilt checks that will run every time you commit your changes. 
 The checks are: 1. check no large files have been staged, 2. lint python files for major errors, 3. format python files to conform with the [pep8 standard](https://peps.python.org/pep-0008/). 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ supply or utility demand.
 <!--- --8<-- [end:docs] -->
 ## Installation
 
-The PAM package is not yet indexed online.
-To install it, we recommend the following:
+To install PAM, we recommend using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager:
 
 ### As a user
 <!--- --8<-- [start:docs-install-user] -->

--- a/docs/contributing/coding.md
+++ b/docs/contributing/coding.md
@@ -13,21 +13,15 @@ To create a development environment for PAM, with all libraries required for dev
 2. Open the command line (or the "miniforge prompt" in Windows).
 3. Download (a.k.a., clone) the PAM repository: `git clone git@github.com:arup-group/pam.git`
 4. Change into the `pam` directory: `cd pam`
-5. Create the PAM mamba environment: `mamba create -n pam -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt`
+5. Create the PAM mamba environment: `mamba create -n pam -c conda-forge -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt`
 6. Activate the PAM mamba environment: `mamba activate pam`
-7. Install the PAM package into the environment, in editable mode and ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps -e ./pam`
+7. Install the PAM package into the environment, in editable mode and ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps -e .`
 
 All together:
 
-``` shell
-git clone git@github.com:arup-group/pam.git
-cd pam
-mamba create -n pam -c city-modelling-lab --file requirements/base.txt --file requirements/dev.txt
-mamba activate pam
-pip install --no-deps -e .
-```
+--8<-- "README.md:docs-install-dev"
 
-If installing directly with pip, you can install these libraries using the `dev` option, i.e., `pip install -e ./pam[dev]`
+If installing directly with pip, you can install these libraries using the `dev` option, i.e., `pip install -e '.[dev]'`
 Either way, you should add your environment as a jupyter kernel, so the example notebooks can run in the tests: `ipython kernel install --user --name=pam`
 
 If you plan to make changes to the code then please make regular use of the following tools to verify the codebase while you work:

--- a/docs/contributing/coding.md
+++ b/docs/contributing/coding.md
@@ -7,7 +7,7 @@ This means we would like help with profiling and implementing parallel compute, 
 
 ## Setting up a development environment
 
-To create a development environment for PAM, with all libraries required for development and quality assurance installed, it is easiest to install PAM using a [mamba](https://mamba.readthedocs.io/en/latest/index.html) environment, as follows:
+To create a development environment for PAM, with all libraries required for development and quality assurance installed, it is easiest to install PAM using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
 
 1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
 2. Open the command line (or the "miniforge prompt" in Windows).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,19 +7,13 @@ It is easiest to install PAM using a [mamba](https://mamba.readthedocs.io/en/lat
 2. Open the command line (or the "miniforge prompt" in Windows).
 3. Download (a.k.a., clone) the PAM repository: `git clone git@github.com:arup-group/pam.git`
 4. Change into the `pam` directory: `cd pam`
-5. Create the PAM mamba environment: `mamba create -n pam -c city-modelling-lab --file requirements/base.txt`
+5. Create the PAM mamba environment: `mamba create -n pam -c conda-forge -c city-modelling-lab --file requirements/base.txt`
 6. Activate the PAM mamba environment: `mamba activate pam`
 7. Install the PAM package into the environment, ignoring dependencies (we have dealt with those when creating the mamba environment): `pip install --no-deps .`
 
 All together:
 
-``` shell
-git clone git@github.com:arup-group/pam.git
-cd pam
-mamba create -n pam -c city-modelling-lab --file requirements/base.txt
-mamba activate pam
-pip install --no-deps .
-```
+--8<-- "README.md:docs-install-user"
 
 We do not recommend trying to install PAM directly with pip (e.g. in a virtual environment) as you need to first install underlying native geospatial libraries, the method for which differs by operating system.
 If you choose to install into a virtual environment, ensure you have `libgdal` and `libspatialindex` installed on your device before installing with pip. 
@@ -43,11 +37,15 @@ jupyter notebook
 If you would like to use a different name to `pam` for your mamba environment, the installation becomes (where `[my-env-name]` is your preferred name for the environment):
 
 ``` shell
-mamba create -n [my-env-name] -c city-modelling-lab --file requirements/base.txt
+mamba create -n [my-env-name] -c conda-forge -c city-modelling-lab --file requirements/base.txt
 mamba activate [my-env-name]
 ipython kernel install --user --name=[my-env-name]
 ```
 
 ## Setting up a development environment
+
+The install instructions are slightly different to create a development environment compared to a user environment:
+
+--8<-- "README.md:docs-install-dev"
 
 For installation instructions specific to developing the PAM codebase, see our [development documentation][setting-up-a-development-environment].

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 
 ## Setting up a user environment
 
-As a PAM user, it is easiest to install PAM using a [mamba](https://mamba.readthedocs.io/en/latest/index.html) environment, as follows:
+As a PAM user, it is easiest to install PAM using the [mamba](https://mamba.readthedocs.io/en/latest/index.html) package manager, as follows:
 
 1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
 2. Open the command line (or the "miniforge prompt" in Windows).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,9 @@
 
 # Installation
 
-It is easiest to install PAM using a [mamba](https://mamba.readthedocs.io/en/latest/index.html) environment, as follows:
+## Setting up a user environment
+
+As a PAM user, it is easiest to install PAM using a [mamba](https://mamba.readthedocs.io/en/latest/index.html) environment, as follows:
 
 1. Install mamba with the [Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) executable for your operating system.
 2. Open the command line (or the "miniforge prompt" in Windows).
@@ -18,7 +20,7 @@ All together:
 We do not recommend trying to install PAM directly with pip (e.g. in a virtual environment) as you need to first install underlying native geospatial libraries, the method for which differs by operating system.
 If you choose to install into a virtual environment, ensure you have `libgdal` and `libspatialindex` installed on your device before installing with pip. 
 
-## Running the example notebooks
+### Running the example notebooks
 If you have followed the non-developer installation instructions above, you will need to install `jupyter` into your `pam` environment to run the [example notebooks](https://github.com/arup-group/pam/tree/main/examples):
 
 ``` shell
@@ -33,7 +35,7 @@ ipython kernel install --user --name=pam
 jupyter notebook
 ```
 
-## Choosing a different environment name
+### Choosing a different environment name
 If you would like to use a different name to `pam` for your mamba environment, the installation becomes (where `[my-env-name]` is your preferred name for the environment):
 
 ``` shell
@@ -48,4 +50,4 @@ The install instructions are slightly different to create a development environm
 
 --8<-- "README.md:docs-install-dev"
 
-For installation instructions specific to developing the PAM codebase, see our [development documentation][setting-up-a-development-environment].
+For more detailed installation instructions specific to developing the PAM codebase, see our [development documentation][setting-up-a-development-environment].


### PR DESCRIPTION
Fixes #228
Fixes #229

This cleans up some parts of the documentation surrounding installation. E.g., now the short-form install instructions are:

![image](https://github.com/arup-group/pam/assets/17178478/f19e4a8b-75a4-4305-b3ca-9c7fcc353983)

I've also slipped in updating the dockerfile, so that the entry point to the image is plain bash, instead of `python`.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. 
All others should be checked by the reviewer(s). 
You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [x] Memory profiling tests pass (see [here](https://arup-group.github.io/pam/contributing/coding/#memory-profiling) for more details)
- [x] Tests added to cover contribution
- [ ] Documentation updated
