### PR TITLE
Ipf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python versions 3.9 to 3.11 support ([#192], [#210]).
 - Documentation, now available at https://arup-group.github.io/pam ([#197]).
 - Time-space prism method for selecting the location of non-mandatory activities ([#252](https://github.com/arup-group/pam/pull/252)).
+- Simple IPF approach for generating synthetic populations ([#253]).
 - **internal** [Codecov](https://codecov.io) and [pre-commit](https://pre-commit.ci/) CI bots ([#202]).
 - **internal** Github action job to build PAM and run tests on a Windows machine ([#192]).
 - **internal** Contribution guidelines and issue/pull request templates ([#207]).

--- a/examples/18_advanced_ipf.ipynb
+++ b/examples/18_advanced_ipf.ipynb
@@ -13,7 +13,7 @@
    "id": "1d9a8764-65dd-4442-8224-075f427edae0",
    "metadata": {},
    "source": [
-    "This notebook demonstrates the creation of a synthetic population using an Iterative Proportinal Fitting (IPF) approach.\n",
+    "This notebook demonstrates the creation of a synthetic population using an Iterative Proportional Fitting (IPF) approach.\n",
     "\n",
     "IPF is a statistical technique that tries to adjust the values of a matrix (joint distribution) in order to match the values of expected single distributions (marginals) for each matrix dimension. We use this approach to sample from a set of persons with certain demographic attributes in a way that the observed distributions in each zone (ie from census) are met."
    ]

--- a/examples/18_advanced_ipf.ipynb
+++ b/examples/18_advanced_ipf.ipynb
@@ -1,0 +1,486 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3c56f3a8-056d-4f8a-b46e-cd44e1441a07",
+   "metadata": {},
+   "source": [
+    "# Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d9a8764-65dd-4442-8224-075f427edae0",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates the creation of a synthetic population using an Iterative Proportinal Fitting (IPF) approach.\n",
+    "\n",
+    "IPF is a statistical technique that tries to adjust the values of a matrix (joint distribution) in order to match the values of expected single distributions (marginals) for each matrix dimension. We use this approach to sample from a set of persons with certain demographic attributes in a way that the observed distributions in each zone (ie from census) are met."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "aa7cdd7f-3256-4dab-b42e-7bea3634eb7b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import itertools\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from pam.core import Person, Population\n",
+    "from pam.planner import ipf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30574bfc-87a4-4846-b881-9e4a439720c3",
+   "metadata": {},
+   "source": [
+    "# Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bad3b0e-9361-4764-a7fd-fc40f8566e55",
+   "metadata": {},
+   "source": [
+    "We start with some demographic data for each zone, as shown below. The zones dataframe includes the zone name as the index, and its columns follow a `variable|class` naming convention. The controlled variables should be part of the seed population's attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "c54ce830-3539-4616-b42f-98cd6662968e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>hhincome|high</th>\n",
+       "      <th>hhincome|medium</th>\n",
+       "      <th>hhincome|low</th>\n",
+       "      <th>age|minor</th>\n",
+       "      <th>age|adult</th>\n",
+       "      <th>carAvail|yes</th>\n",
+       "      <th>carAvail|no</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>zone</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>a</th>\n",
+       "      <td>30</td>\n",
+       "      <td>40</td>\n",
+       "      <td>30</td>\n",
+       "      <td>40</td>\n",
+       "      <td>60</td>\n",
+       "      <td>90</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b</th>\n",
+       "      <td>80</td>\n",
+       "      <td>100</td>\n",
+       "      <td>20</td>\n",
+       "      <td>90</td>\n",
+       "      <td>110</td>\n",
+       "      <td>180</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      hhincome|high  hhincome|medium  hhincome|low  age|minor  age|adult  \\\n",
+       "zone                                                                       \n",
+       "a                30               40            30         40         60   \n",
+       "b                80              100            20         90        110   \n",
+       "\n",
+       "      carAvail|yes  carAvail|no  \n",
+       "zone                             \n",
+       "a               90           10  \n",
+       "b              180           20  "
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zone_data = pd.DataFrame(\n",
+    "    {\n",
+    "        \"zone\": [\"a\", \"b\"],\n",
+    "        \"hhincome|high\": [30, 80],\n",
+    "        \"hhincome|medium\": [40, 100],\n",
+    "        \"hhincome|low\": [30, 20],\n",
+    "        \"age|minor\": [40, 90],\n",
+    "        \"age|adult\": [60, 110],\n",
+    "        \"carAvail|yes\": [90, 180],\n",
+    "        \"carAvail|no\": [10, 20],\n",
+    "    }\n",
+    ").set_index(\"zone\")\n",
+    "zone_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14e19191-2784-4c5e-a023-d7cb3bba9c66",
+   "metadata": {},
+   "source": [
+    "Let's create a seed population which includes every possible combination of attributes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "f546a8dd-0d1d-441b-a768-b483fd0d1382",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'hhincome': 'low', 'age': 'minor', 'carAvail': 'yes', 'hzone': <NA>}"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dims = {\"hhincome\": [\"low\", \"medium\", \"high\"], \"age\": [\"minor\", \"adult\"], \"carAvail\": [\"yes\", \"no\"]}\n",
+    "list(itertools.product(*dims.values()))\n",
+    "\n",
+    "# %%\n",
+    "seed_pop = Population()\n",
+    "n = 0\n",
+    "for attributes in list(itertools.product(*dims.values())):\n",
+    "    hhincome, age, carAvail = attributes\n",
+    "    person = Person(\n",
+    "        pid=n, attributes={\"hhincome\": hhincome, \"age\": age, \"carAvail\": carAvail, \"hzone\": pd.NA}\n",
+    "    )\n",
+    "    n += 1\n",
+    "    seed_pop.add(person)\n",
+    "\n",
+    "seed_pop.random_person().attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "708c2f97-907d-4fe0-9361-f8e0e90422f8",
+   "metadata": {},
+   "source": [
+    "# IPF"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc3527a8-0f0d-4094-9084-0a73cba351ae",
+   "metadata": {},
+   "source": [
+    "Now let's create a population that matches the demographic distribution of each zone:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "2c3b5f5d-37c6-4d4b-bda5-bad713634a28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pop = ipf.generate_population(seed_pop, zone_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1793b438-f84c-4024-abf5-1936eaadc5f0",
+   "metadata": {},
+   "source": [
+    "The resulting population comprises 300 persons (as defined in the zone data):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "2cd65d20-56c6-46e9-b53d-b451db535081",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "300"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(pop)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88a0c55c-dc6b-4024-8411-48f8a18b02cc",
+   "metadata": {},
+   "source": [
+    "And each person in the population is assigned a household zone:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "cd08aa2f-c2c4-4335-bcac-315a0609f63f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'hhincome': 'high', 'age': 'adult', 'carAvail': 'yes', 'hzone': 'b'}"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pop.random_person().attributes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f412df08-af9e-4a78-807e-6789f06e3097",
+   "metadata": {},
+   "source": [
+    "The resulting joint demographic distributions in each zone are shown below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "1441fecf-523d-41b5-a936-441da8da3529",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "hzone  hhincome  age    carAvail\n",
+       "a      high      adult  no           2\n",
+       "                        yes         16\n",
+       "                 minor  no           1\n",
+       "                        yes         11\n",
+       "       low       adult  no           2\n",
+       "                        yes         16\n",
+       "                 minor  no           1\n",
+       "                        yes         11\n",
+       "       medium    adult  no           2\n",
+       "                        yes         22\n",
+       "                 minor  no           2\n",
+       "                        yes         14\n",
+       "b      high      adult  no           4\n",
+       "                        yes         40\n",
+       "                 minor  no           4\n",
+       "                        yes         32\n",
+       "       low       adult  no           1\n",
+       "                        yes         10\n",
+       "                 minor  no           1\n",
+       "                        yes          8\n",
+       "       medium    adult  no           6\n",
+       "                        yes         50\n",
+       "                 minor  no           4\n",
+       "                        yes         40\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 64,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summary = (\n",
+    "    pd.DataFrame([person.attributes for hid, pid, person in pop.people()])\n",
+    "    .value_counts()\n",
+    "    .reorder_levels([3, 0, 1, 2])\n",
+    "    .sort_index()\n",
+    ")\n",
+    "\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9500b6af-2f8f-492e-a2cd-284743fa362a",
+   "metadata": {},
+   "source": [
+    "The aggregate demographic distributions match the marginals in `zone_data`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "10ff7760-3e96-4fd2-b438-ea0114328414",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>hhincome|high</th>\n",
+       "      <th>hhincome|medium</th>\n",
+       "      <th>hhincome|low</th>\n",
+       "      <th>age|minor</th>\n",
+       "      <th>age|adult</th>\n",
+       "      <th>carAvail|yes</th>\n",
+       "      <th>carAvail|no</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>zone</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>a</th>\n",
+       "      <td>30</td>\n",
+       "      <td>40</td>\n",
+       "      <td>30</td>\n",
+       "      <td>40</td>\n",
+       "      <td>60</td>\n",
+       "      <td>90</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>b</th>\n",
+       "      <td>80</td>\n",
+       "      <td>100</td>\n",
+       "      <td>20</td>\n",
+       "      <td>89</td>\n",
+       "      <td>111</td>\n",
+       "      <td>180</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      hhincome|high  hhincome|medium  hhincome|low  age|minor  age|adult  \\\n",
+       "zone                                                                       \n",
+       "a                30               40            30         40         60   \n",
+       "b                80              100            20         89        111   \n",
+       "\n",
+       "      carAvail|yes  carAvail|no  \n",
+       "zone                             \n",
+       "a               90           10  \n",
+       "b              180           20  "
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summary_aggregate = []\n",
+    "for var in dims:\n",
+    "    df = summary.groupby(level=[\"hzone\", var]).sum().unstack(level=var)\n",
+    "    df.columns = [f\"{var}|{x}\" for x in df.columns]\n",
+    "    summary_aggregate.append(df)\n",
+    "summary_aggregate = pd.concat(summary_aggregate, axis=1)\n",
+    "summary_aggregate.index.name = \"zone\"\n",
+    "summary_aggregate = summary_aggregate[zone_data.columns]\n",
+    "summary_aggregate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "id": "f6db0771-b725-4246-af5c-989e140d0835",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.testing.assert_frame_equal(\n",
+    "    summary_aggregate, zone_data, check_exact=False, atol=1\n",
+    ")  # test passes"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/18_advanced_ipf.ipynb
+++ b/examples/18_advanced_ipf.ipynb
@@ -46,7 +46,7 @@
    "id": "4bad3b0e-9361-4764-a7fd-fc40f8566e55",
    "metadata": {},
    "source": [
-    "We start with some demographic data for each zone, as shown below. The zones dataframe includes the zone name as the index, and its columns follow a `variable|class` naming convention. The controlled variables should be part of the seed population's attributes."
+    "We start with some demographic data for each zone, as shown below. The zones dataframe includes the zone name as the index, and its columns follow a `variable|class` naming convention. Alternatively, they could be provided with a mutltiIndex column, with the first level being the variable and the second level indicating the class. The controlled variables should be part of the seed population's attributes."
    ]
   },
   {

--- a/pam/planner/ipf.py
+++ b/pam/planner/ipf.py
@@ -8,20 +8,7 @@ import numpy as np
 import pandas as pd
 
 from pam.core import Person, Population
-
-
-def safe_divide(x: np.array, y: np.array) -> np.array:
-    """Safely divide two arrays. When dividing by zero, the result is set to zero.
-
-
-    Args:
-        x (np.array): Nominator array.
-        y (np.array): Denominator array.
-
-    Returns:
-        np.array: Divided array.
-    """
-    return np.divide(x, y, out=np.zeros(x.shape, dtype=np.float64), where=y != 0)
+from pam.planner.utils_planner import safe_divide
 
 
 def get_scaling_factor(X: np.ndarray, sel_dim: int, marginals: np.array) -> np.ndarray:

--- a/pam/planner/ipf.py
+++ b/pam/planner/ipf.py
@@ -186,7 +186,7 @@ def sample_population(encodings, dist, sample_pool) -> Population:
                     raise ValueError(f"Missing category in seed population: {missing_cat}")
                 else:
                     # sample persons from the appropriate demographic group
-                    persons = random.choices(sample_pool[*code], k=sample_size)
+                    persons = random.choices(sample_pool[code], k=sample_size)
                     # add to the population
                     for person in persons:
                         person_new = deepcopy(person)

--- a/pam/planner/ipf.py
+++ b/pam/planner/ipf.py
@@ -51,7 +51,7 @@ def get_max_error(X: np.ndarray, marginals: list[np.array]) -> float:
     """Get the maximum absolute percentage between a matrix and a set of marginals.
 
     Args:
-        X (np.array): nput matrix
+        X (np.array): Input matrix
         marginals (list[np.array]): a list of marginals
 
     Returns:

--- a/pam/planner/ipf.py
+++ b/pam/planner/ipf.py
@@ -1,22 +1,47 @@
+import warnings
 from typing import Optional
 
 import numpy as np
 
 
-def safe_divide(m, s):
-    return np.divide(m, s, out=np.zeros(m.shape, dtype=np.float64), where=s != 0)
+def safe_divide(x: np.array, y: np.array) -> np.array:
+    """Safely divide two arrays. When dividing by zero, the result is set to zero.
 
 
-def get_scaling_factor(X: np.array, sel_dim: int, marginals: np.array):
+    Args:
+        x (np.array): Nominator array.
+        y (np.array): Denominator array.
+
+    Returns:
+        np.array: Divided array.
+    """
+    return np.divide(x, y, out=np.zeros(x.shape, dtype=np.float64), where=y != 0)
+
+
+def get_scaling_factor(X: np.ndarray, sel_dim: int, marginals: np.array) -> np.ndarray:
+    """Get the scaling factors required to match a set of marginals for a selected matrix dimension.
+        The returned matrix will have the same dimensions as the input matrix
+
+    Args:
+        X (np.ndarray): The matrix to be scaled.
+        sel_dim (int): The matrix dimension that corresponds to the marginals.
+        marginals (np.array): The target values for the selected dimension.
+
+    Returns:
+        np.ndarray: A matrix that can be multiplied by the input matrix
+            in order to get a new matrix that matches the maginals for the selected dimension.
+    """
     other_dims = tuple(i for i in range(X.ndim) if i != sel_dim)
     totals = X.sum(axis=other_dims)
+    if ((totals == 0) & (totals != marginals)).sum():
+        warnings.warn("Zero-cell issue found! Please check the seed matrix totals.", UserWarning)
     scaling_factor = safe_divide(marginals, totals)
     scaling_factor = np.expand_dims(scaling_factor, other_dims)
 
     return scaling_factor
 
 
-def get_max_error(X: np.array, marginals: list[np.array]) -> float:
+def get_max_error(X: np.ndarray, marginals: list[np.array]) -> float:
     """Get the maximum absolute percentage between a matrix and a set of marginals.
 
     Args:
@@ -27,9 +52,10 @@ def get_max_error(X: np.array, marginals: list[np.array]) -> float:
         float: the maximum error value
     """
     max_error = 0
-    for sel_dim in range(X.ndim):
-        scaling_factor = get_scaling_factor(X, sel_dim, marginals[sel_dim])
-        max_error = max(max_error, abs(scaling_factor.max() - 1))
+    for dim in range(X.ndim):
+        scaling_factor = get_scaling_factor(X, dim, marginals[dim])
+        max_error = max(max_error, abs(scaling_factor - 1).max())
+
     return max_error
 
 

--- a/pam/planner/ipf.py
+++ b/pam/planner/ipf.py
@@ -1,0 +1,62 @@
+from typing import Optional
+
+import numpy as np
+
+
+def safe_divide(m, s):
+    return np.divide(m, s, out=np.zeros(m.shape, dtype=np.float64), where=s != 0)
+
+
+def get_scaling_factor(X: np.array, sel_dim: int, marginals: np.array):
+    other_dims = tuple(i for i in range(X.ndim) if i != sel_dim)
+    totals = X.sum(axis=other_dims)
+    scaling_factor = safe_divide(marginals, totals)
+    scaling_factor = np.expand_dims(scaling_factor, other_dims)
+
+    return scaling_factor
+
+
+def get_max_error(X: np.array, marginals: list[np.array]) -> float:
+    """Get the maximum absolute percentage between a matrix and a set of marginals.
+
+    Args:
+        X (np.array): nput matrix
+        marginals (list[np.array]): a list of marginals
+
+    Returns:
+        float: the maximum error value
+    """
+    max_error = 0
+    for sel_dim in range(X.ndim):
+        scaling_factor = get_scaling_factor(X, sel_dim, marginals[sel_dim])
+        max_error = max(max_error, abs(scaling_factor.max() - 1))
+    return max_error
+
+
+def ipf(
+    X: np.array,
+    marginals: list[np.array],
+    tolerance: Optional[float] = 0.001,
+    max_iterations: Optional[int] = 10**3,
+) -> np.array:
+    """Apply Iterative Proportional Fitting on a multi-dimensional matrix.
+
+    Args:
+        X (np.array): Initial matrix.
+        marginals (list[np.array]): Total to match, one for each matrix dimension.
+        tolerance (Optional[float], optional): Max accepted percentage difference to the targets. Defaults to 0.001.
+        max_iterations (Optional[int], optional): Max number of iterations. Defaults to 10**3.
+
+    Returns:
+        np.array: A fitted matrix that matches the marginals for each dimension.
+    """
+    X_fitted = X.copy()
+    iters = 0
+    max_error = get_max_error(X, marginals)
+    while (max_error > tolerance) and (iters < max_iterations):
+        for sel_dim in range(X_fitted.ndim):
+            scaling_factor = get_scaling_factor(X_fitted, sel_dim, marginals[sel_dim])
+            X_fitted *= scaling_factor
+        iters += 1
+
+    return X_fitted

--- a/pam/planner/utils_planner.py
+++ b/pam/planner/utils_planner.py
@@ -158,3 +158,17 @@ def convert_single_anchor_roundtrip(chain: list[Union[Activity, Leg]]) -> None:
         chain.insert(0, act)
         chain.append(leg)
         chain.append(act)
+
+
+def safe_divide(x: np.array, y: np.array) -> np.array:
+    """Safely divide two arrays. When dividing by zero, the result is set to zero.
+
+
+    Args:
+        x (np.array): Numerator array.
+        y (np.array): Denominator array.
+
+    Returns:
+        np.array: Divided array.
+    """
+    return np.divide(x, y, out=np.zeros(x.shape, dtype=np.float64), where=y != 0)

--- a/tests/test_28_planner_ipf.py
+++ b/tests/test_28_planner_ipf.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from pam.planner import ipf
@@ -8,6 +9,21 @@ from pam.planner import ipf
 def marginals():
     m = [np.array([20, 80]), np.array([60, 40]), np.array([30, 60, 10])]
     return m
+
+
+@pytest.fixture
+def zone_data():
+    df = pd.DataFrame(
+        {
+            "zone": ["a", "b"],
+            "subpopulation|rich": [30, 80],
+            "subpopulation|medium": [0, 0],
+            "subpopulation|poor": [70, 120],
+            "age|yes": [60, 110],
+            "age|no": [40, 90],
+        }
+    ).set_index("zone")
+    return df
 
 
 def test_random_seed_matches_marginals(marginals):
@@ -31,7 +47,49 @@ def test_ipf_matrix_retains_shape(marginals):
     assert fitted.shape == X.shape
 
 
-def test_ipf_raises_zero_cell_problem(marginals):
+def test_ipf_warns_zero_cell_issue(marginals):
     X = np.zeros(tuple(map(len, marginals)))
     with pytest.warns(UserWarning):
         ipf.ipf(X, marginals, max_iterations=10)
+
+
+def test_zone_data_preprocessing(zone_data):
+    expected_encodings = {"subpopulation": ["rich", "medium", "poor"], "age": ["yes", "no"]}
+    expected_marginals = {
+        "a": [np.array([30, 0, 70]), np.array([60, 40])],
+        "b": [np.array([80, 0, 120]), np.array([110, 90])],
+    }
+    encodings, marginals = ipf.prepare_zone_marginals(zone_data)
+    assert encodings == expected_encodings
+    for zone, m in marginals.items():
+        for i, arr in enumerate(m):
+            np.testing.assert_almost_equal(arr, expected_marginals[zone][i])
+
+
+def test_encoded_population_sizes(population, zone_data):
+    encodings, marginals = ipf.prepare_zone_marginals(zone_data)
+    encoded_population = ipf.encode_population(population, encodings)
+    assert len(encoded_population[(0, 0)]) == 1  # rich-yes: chris
+    # poor - no: fatema, fred, gerry
+    assert len(encoded_population[(2, 1)]) == 3
+    assert len(encoded_population[(0, 1)]) == 1  # rich, no: nick
+
+
+def test_missing_category_in_population_raises_error(population, zone_data):
+    with pytest.raises(ValueError):
+        ipf.generate_population(population, zone_data)
+
+
+def test_generate_fitted_population_matches_marginals(population, zone_data):
+    population["B"]["gerry"].attributes["age"] = "yes"  # avoid zero-cell issue
+    pop = ipf.generate_population(population, zone_data)
+
+    # check totals for each zone and category
+    for zone, irow in zone_data.iterrows():
+        for col, v in irow.items():
+            n = 0
+            var, cl = col.split("|")
+            for hid, pid, person in pop.people():
+                if (person.attributes[var] == cl) and (person.attributes["hzone"] == zone):
+                    n += 1
+            assert n == v

--- a/tests/test_28_planner_ipf.py
+++ b/tests/test_28_planner_ipf.py
@@ -68,7 +68,7 @@ def test_zone_data_preprocessing(zone_data):
 
 def test_encoded_population_sizes(population, zone_data):
     encodings, marginals = ipf.prepare_zone_marginals(zone_data)
-    encoded_population = ipf.encode_population(population, encodings)
+    encoded_population = ipf.get_sample_pool(population, encodings)
     assert len(encoded_population[(0, 0)]) == 1  # rich-yes: chris
     # poor - no: fatema, fred, gerry
     assert len(encoded_population[(2, 1)]) == 3

--- a/tests/test_28_planner_ipf.py
+++ b/tests/test_28_planner_ipf.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pytest
+
+from pam.planner.ipf import ipf
+
+
+@pytest.fixture
+def marginals():
+    m = [np.array([20, 80]), np.array([60, 40]), np.array([30, 60, 10])]
+    return m
+
+
+def test_random_seed_matches_marginals(marginals):
+    X = np.zeros(tuple(map(len, marginals))) + 0.001
+    fitted = ipf(X, marginals, max_iterations=10)
+    np.testing.assert_almost_equal(fitted.sum((1, 2)), marginals[0])
+
+
+def test_ipf_maxes_patience_out():
+    pass

--- a/tests/test_28_planner_ipf.py
+++ b/tests/test_28_planner_ipf.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pam.planner.ipf import ipf
+from pam.planner import ipf
 
 
 @pytest.fixture
@@ -12,9 +12,26 @@ def marginals():
 
 def test_random_seed_matches_marginals(marginals):
     X = np.zeros(tuple(map(len, marginals))) + 0.001
-    fitted = ipf(X, marginals, max_iterations=10)
+    fitted = ipf.ipf(X, marginals, max_iterations=10)
     np.testing.assert_almost_equal(fitted.sum((1, 2)), marginals[0])
+    np.testing.assert_almost_equal(fitted.sum((0, 2)), marginals[1])
+    np.testing.assert_almost_equal(fitted.sum((0, 1)), marginals[2])
 
 
-def test_ipf_maxes_patience_out():
-    pass
+def test_ipf_maxes_patience_out(mocker):
+    mocker.patch.object(ipf, "get_scaling_factor", return_value=np.ones((2, 2)) * 2)
+    ipf.ipf(np.zeros((2, 2)) + 0.1, np.ones((2, 2)), max_iterations=0)
+    # only called once for each dimension at the start
+    assert ipf.get_scaling_factor.call_count == 2
+
+
+def test_ipf_matrix_retains_shape(marginals):
+    X = np.zeros(tuple(map(len, marginals))) + 0.001
+    fitted = ipf.ipf(X, marginals, max_iterations=10)
+    assert fitted.shape == X.shape
+
+
+def test_ipf_raises_zero_cell_problem(marginals):
+    X = np.zeros(tuple(map(len, marginals)))
+    with pytest.warns(UserWarning):
+        ipf.ipf(X, marginals, max_iterations=10)


### PR DESCRIPTION
Introduces methods for creating a simple synthetic population using an Iterative Proportional Fitting (IPF) approach.

A resampled population can be generated by providing a seed PAM population, and a dataframe with zone marginals.

```
from pam.planner import ipf
population = ipf.generate_population(seed_population, df_zones)
```

Example provided under `./examples/18_advanced.ipynb`.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Tests added to cover contribution
- [x] Documentation updated
