### PR TITLE
Remove timing benchmark

### DIFF
--- a/tests/test_100_memory_profiling.py
+++ b/tests/test_100_memory_profiling.py
@@ -6,13 +6,11 @@ import pytest
 from pam import read
 
 BENCHMARK_MEM = "2890.59 MB"
-BENCHMARK_SECONDS = 400
 
 data_dir = Path(__file__).parent / "test_data"
 
 
 @pytest.mark.limit_memory(BENCHMARK_MEM)
-@pytest.mark.timeout(BENCHMARK_SECONDS)
 @pytest.mark.high_mem
 def test_activity_loader():
     trips = pd.read_csv(data_dir / "extended_travel_diaries.csv.gz")


### PR DESCRIPTION
We're seeing odd behaviour with the timing benchmark in the memory profiling. I had already moved it from 280 seconds to 400 seconds to handle the GitHub Action runners seemingly being slower than local machines. However, in e.g. #249, this 400 second limit was breached (even though locally it still runs in under 280 secs).

The memory profiling is mainly meant to check that memory limits aren't breached, so I think it's OK to remove the timing benchmark. We can always see how long the CI test take in total to get an order-of-magnitude understanding of whether some central component in PAM now leads to long runtimes.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Tests added to cover contribution
- [ ] Documentation updated
