### PR TITLE
Fix long run time and reintroduce timing benchmark test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - optimise.grid.grid_search fixed ([#239]).
 - `TourPlanner` prevents sampling of duplicate destinations, and prevents origin being sampled as a destination ([#231]).
 - Fix for [#221](https://github.com/arup-group/pam/issues/221), improved "pt simplification" ([#222])
+- Slow loading of data with e.g., [pam.read.load_travel_diary][pam.read.diary.load_travel_diary] when using pandas v2.1.1 (caused by `pandas.MultiIndex.groupby`, see [pandas issue #55256](https://github.com/pandas-dev/pandas/issues/55256)). ([#258])
 
 ### Added
 - MATSim warm starting example ([#239]).
@@ -90,6 +91,7 @@ This is the first version of PAM which follows semantic versioning and can be co
 [v0.2.1]: https://github.com/arup-group/pam/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/arup-group/pam/compare/initial_version...v0.2.0
 
+[#258]: https://github.com/arup-group/pam/pull/258
 [#248]: https://github.com/arup-group/pam/pull/248
 [#240]: https://github.com/arup-group/pam/pull/240
 [#231]: https://github.com/arup-group/pam/pull/231

--- a/pam/read/__init__.py
+++ b/pam/read/__init__.py
@@ -8,7 +8,6 @@ from pam.read.diary import (
     add_persons_from_trips,
     build_population,
     from_to_travel_diary_read,
-    hh_person_df_to_dict,
     load_travel_diary,
     sample_population,
     tour_based_travel_diary_read,

--- a/pam/read/diary.py
+++ b/pam/read/diary.py
@@ -506,12 +506,13 @@ def tour_based_travel_diary_read(
         trips=trips, persons_attributes=persons_attributes, hhs_attributes=hhs_attributes
     )
 
-    if "seq" in trips.columns:
-        trips = trips.set_index(["hid", "pid", "seq"])
-        if sort_by_seq is None:
-            sort_by_seq = True
-    else:
-        trips = trips.set_index(["hid", "pid"])
+    if sort_by_seq is None and "seq" in trips.columns:
+        sort_by_seq = True
+    if "seq" not in trips.columns:
+        seq = trips.groupby(["hid", "pid"]).cumcount()
+        trips = trips.assign(seq=seq.values)
+
+    trips = trips.set_index(["hid", "pid", "seq"])
 
     if sort_by_seq:
         trips = trips.sort_index()
@@ -611,12 +612,13 @@ def trip_based_travel_diary_read(
         trips=trips, persons_attributes=persons_attributes, hhs_attributes=hhs_attributes
     )
 
-    if "seq" in trips.columns:
-        trips = trips.set_index(["hid", "pid", "seq"])
-        if sort_by_seq is None:
-            sort_by_seq = True
-    else:
-        trips = trips.set_index(["hid", "pid"])
+    if sort_by_seq is None and "seq" in trips.columns:
+        sort_by_seq = True
+    if "seq" not in trips.columns:
+        seq = trips.groupby(["hid", "pid"]).cumcount()
+        trips = trips.assign(seq=seq.values)
+
+    trips = trips.set_index(["hid", "pid", "seq"])
 
     if sort_by_seq:
         trips = trips.sort_index()
@@ -712,12 +714,17 @@ def from_to_travel_diary_read(
     population = build_population(
         trips=trips, persons_attributes=persons_attributes, hhs_attributes=hhs_attributes
     )
-    if "seq" in trips.columns:
-        trips = trips.set_index(["hid", "pid", "seq"])
-        if sort_by_seq is None or sort_by_seq:
-            trips = trips.sort_index()
-    else:
-        trips = trips.set_index(["hid", "pid"])
+
+    if sort_by_seq is None and "seq" in trips.columns:
+        sort_by_seq = True
+    if "seq" not in trips.columns:
+        seq = trips.groupby(["hid", "pid"]).cumcount()
+        trips = trips.assign(seq=seq.values)
+
+    trips = trips.set_index(["hid", "pid", "seq"])
+
+    if sort_by_seq:
+        trips = trips.sort_index()
 
     for hid, household in population:
         for pid, person in household:

--- a/tests/test_100_memory_profiling.py
+++ b/tests/test_100_memory_profiling.py
@@ -6,11 +6,13 @@ import pytest
 from pam import read
 
 BENCHMARK_MEM = "2890.59 MB"
+BENCHMARK_SECONDS = 200
 
 data_dir = Path(__file__).parent / "test_data"
 
 
 @pytest.mark.limit_memory(BENCHMARK_MEM)
+@pytest.mark.timeout(BENCHMARK_SECONDS)
 @pytest.mark.high_mem
 def test_activity_loader():
     trips = pd.read_csv(data_dir / "extended_travel_diaries.csv.gz")

--- a/tests/test_100_memory_profiling.py
+++ b/tests/test_100_memory_profiling.py
@@ -10,9 +10,8 @@ BENCHMARK_SECONDS = 90
 
 data_dir = Path(__file__).parent / "test_data"
 
-pytest.fixture(scope="module")
 
-
+@pytest.fixture(scope="module")
 def trips_attrs():
     trips = pd.read_csv(data_dir / "extended_travel_diaries.csv.gz")
     attributes = pd.read_csv(data_dir / "extended_persons_data.csv.gz")

--- a/tests/test_100_memory_profiling.py
+++ b/tests/test_100_memory_profiling.py
@@ -5,17 +5,28 @@ import pytest
 
 from pam import read
 
-BENCHMARK_MEM = "2890.59 MB"
-BENCHMARK_SECONDS = 300
+BENCHMARK_MEM = "1400 MB"
+BENCHMARK_SECONDS = 90
 
 data_dir = Path(__file__).parent / "test_data"
 
+pytest.fixture(scope="module")
 
-@pytest.mark.limit_memory(BENCHMARK_MEM)
-@pytest.mark.timeout(BENCHMARK_SECONDS)
-@pytest.mark.high_mem
-def test_activity_loader():
+
+def trips_attrs():
     trips = pd.read_csv(data_dir / "extended_travel_diaries.csv.gz")
     attributes = pd.read_csv(data_dir / "extended_persons_data.csv.gz")
     attributes.set_index("pid", inplace=True)
-    read.load_travel_diary(trips, attributes)
+    return trips, attributes
+
+
+@pytest.mark.limit_memory(BENCHMARK_MEM)
+@pytest.mark.high_mem
+def test_activity_loader_mem(trips_attrs):
+    read.load_travel_diary(*trips_attrs)
+
+
+@pytest.mark.timeout(BENCHMARK_SECONDS)
+@pytest.mark.high_mem
+def test_activity_loader_time(trips_attrs):
+    read.load_travel_diary(*trips_attrs)

--- a/tests/test_100_memory_profiling.py
+++ b/tests/test_100_memory_profiling.py
@@ -6,7 +6,7 @@ import pytest
 from pam import read
 
 BENCHMARK_MEM = "1400 MB"
-BENCHMARK_SECONDS = 140
+BENCHMARK_SECONDS = 250
 
 data_dir = Path(__file__).parent / "test_data"
 
@@ -25,7 +25,7 @@ def test_activity_loader_mem(trips_attrs):
     read.load_travel_diary(*trips_attrs)
 
 
-@pytest.mark.timeout(BENCHMARK_SECONDS)
+@pytest.mark.timeout(BENCHMARK_SECONDS, func_only=True)
 @pytest.mark.high_mem
 def test_activity_loader_time(trips_attrs):
     read.load_travel_diary(*trips_attrs)

--- a/tests/test_100_memory_profiling.py
+++ b/tests/test_100_memory_profiling.py
@@ -6,7 +6,7 @@ import pytest
 from pam import read
 
 BENCHMARK_MEM = "2890.59 MB"
-BENCHMARK_SECONDS = 200
+BENCHMARK_SECONDS = 300
 
 data_dir = Path(__file__).parent / "test_data"
 

--- a/tests/test_100_memory_profiling.py
+++ b/tests/test_100_memory_profiling.py
@@ -6,7 +6,7 @@ import pytest
 from pam import read
 
 BENCHMARK_MEM = "1400 MB"
-BENCHMARK_SECONDS = 90
+BENCHMARK_SECONDS = 140
 
 data_dir = Path(__file__).parent / "test_data"
 


### PR DESCRIPTION
Fixes long memory profiling CI runtimes.

It seems that the timeout that I "fixed" by removing in #254 was actually trying to tell us something. A change in how pandas groupby works means that the current implementation on reading data became _unbelievably_ slow. To be honest, I'm surprised that pivoting a dataframe into a nested dict was applied for "performance" reasons to begin with... 

Anyway, I've got rid of the df->dict conversion. Locally, this not only makes it possible to run the timing/memory benchmark (CI was taking __hours__ for that test!) but actually halves the time it takes to run! Will be interesting to see if this leads to real speed-ups in PAM in more practical applications.

EDIT: this update leads to slower runtimes than the previous method after @Theodore-Chatziioannou tested it with a real dataset (10-20% slower). We should fix this and the profiling dataset so that it is catching runtimes that align better with real PAM usecases.

UPDATE: memory requirements also half when making this change. The benchmark is now ~1.4GB instead of ~2.8GB.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [x] Tests added to cover contribution
- [ ] Documentation updated
