### PR TITLE
Try updating GDAL

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -17,7 +17,7 @@ jobs:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
     with:
       os: ubuntu-latest
-      py3version: "11"
+      py3version: "12"
       notebook_kernel: pam
       lint: false
       upload_to_codecov: false

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -16,7 +16,7 @@ jobs:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
     with:
       os: ubuntu-latest
-      py3version: "11"
+      py3version: "12"
       notebook_kernel: pam
       pytest_args: '--no-cov'  # ignore coverage
       cache_mamba_env: false

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest]
         py3version: ["9", "10"]
       fail-fast: false
     uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@try-python--m-pytest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -16,10 +16,10 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest]
         py3version: ["9", "10", "11"]
       fail-fast: false
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@try-python--m-pytest
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@bf00346490f8547340c83a58942942bc8458f428
     with:
       os: ${{ matrix.os }}
       py3version: ${{ matrix.py3version }}

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        py3version: ["10", "11"]
+        py3version: ["10", "12"]
       fail-fast: false
     uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
     with:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        py3version: ["10", "12"]
+        py3version: ["9", "10"]
       fail-fast: false
     uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@try-python--m-pytest
     with:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         py3version: ["10", "12"]
       fail-fast: false
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@try-python--m-pytest
     with:
       os: ${{ matrix.os }}
       py3version: ${{ matrix.py3version }}
@@ -29,17 +29,17 @@ jobs:
       upload_to_codecov: false
 
   test-coverage:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@try-python--m-pytest
     with:
       os: ubuntu-latest
-      py3version: "11"
+      py3version: "12"
       notebook_kernel: pam
       lint: false
       pytest_args: 'tests/'  # ignore example notebooks
       upload_to_codecov: true
 
   memory-profile:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-memory-profile.yml@main
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-memory-profile.yml@try-python--m-pytest
     with:
-      py3version: "11"
+      py3version: "12"
       upload_flamegraph: true

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        py3version: ["9", "11"]
+        py3version: ["10", "11"]
       fail-fast: false
     uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@main
     with:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -16,8 +16,8 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [windows-latest]
-        py3version: ["9", "10"]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        py3version: ["9", "10", "11"]
       fail-fast: false
     uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@try-python--m-pytest
     with:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ numpy >= 1, < 2
 pandas >= 1.5, < 3
 plotly >= 4, < 6
 prettytable >= 3, < 4
-python-Levenshtein >= 0.21, < 0.22
+python-Levenshtein >= 0.21, < 0.24
 rich >= 12, < 14
 Rtree >= 1, < 2
 s2sphere < 0.3

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click < 9
-gdal = 3.8.1
+gdal >= 3.8, < 3.8.2
 geopandas >= 0.13, < 0.14
 ipykernel < 7
 lxml < 5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click < 9
-gdal >= 3.7, < 3.8
+gdal = 3.8.1
 geopandas >= 0.13, < 0.14
 ipykernel < 7
 lxml < 5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click < 9
-gdal < 3.6
+gdal >= 3.7
 geopandas >= 0.13, < 0.14
 ipykernel < 7
 lxml < 5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click < 9
-gdal < 3.8
+gdal >= 3.6, < 3.7
 geopandas >= 0.13, < 0.14
 ipykernel < 7
 lxml < 5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click < 9
-gdal < 3.6
+gdal < 3.8
 geopandas >= 0.13, < 0.14
 ipykernel < 7
 lxml < 5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click < 9
-gdal >= 3.7
+gdal >= 3.7, < 3.8
 geopandas >= 0.13, < 0.14
 ipykernel < 7
 lxml < 5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click < 9
-gdal >= 3.6, < 3.7
+gdal >= 3.7
 geopandas >= 0.13, < 0.14
 ipykernel < 7
 lxml < 5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 click < 9
-gdal >= 3.7
+gdal < 3.6
 geopandas >= 0.13, < 0.14
 ipykernel < 7
 lxml < 5


### PR DESCRIPTION
@Theodore-Chatziioannou was having problems on Windows with GDAL v3.6 but with this relatively strict dependency pinning we might be causing other downstream issues in https://github.com/arup-group/ersa/pull/56 so I'm trying out updating the pinning to skip v3.6 and seeing what the CI thinks about it.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Tests added to cover contribution
- [ ] Documentation updated
