### PR TITLE
facility link snapping

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/arup-group/cookiecutter-pypackage.git",
-  "commit": "fdc37ca81ad3f267199b04856722ea68648b9109",
+  "commit": "b7724521f898ab28f541d492aff8e2be2ed76a01",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
-* Facility link snapping.
+* Facility link snapping (#276).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+* Facility link snapping.
 
 ### Changed
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@ jupyter < 2
 mike >= 2, < 3
 mkdocs < 1.6
 mkdocs-material >= 9.4, < 10
-mkdocs-click >= 0.6, < 0.7
+mkdocs-click < 0.7
 mkdocs-jupyter < 0.24.7
 mkdocstrings-python < 2
 nbmake >= 1.5.1, < 2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,10 +1,10 @@
 cruft >= 2, < 3
 jupyter < 2
 mike >= 2, < 3
-mkdocs < 2
+mkdocs < 1.6
 mkdocs-material >= 9.4, < 10
-mkdocs-click < 0.7
-mkdocs-jupyter < 0.25
+mkdocs-click >= 0.6, < 0.7
+mkdocs-jupyter < 0.24.7
 mkdocstrings-python < 2
 nbmake >= 1.5.1, < 2
 pre-commit < 4

--- a/src/pam/cli.py
+++ b/src/pam/cli.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from pam import read, write
 from pam.operations.combine import pop_combine
 from pam.operations.cropping import simplify_population
+from pam.operations.snap import run_facility_link_snapping
 from pam.report.benchmarks import benchmarks as bms
 from pam.report.stringify import stringify_plans
 from pam.report.summary import pretty_print_summary, print_summary
@@ -667,3 +668,30 @@ def wipe_links(
 
     logger.info("Population wipe complete")
     logger.info(f"Output saved at {path_population_output}")
+
+
+
+@cli.command()
+@click.argument("path_population_in", type=click.Path(exists=True))
+@click.argument("path_population_out", type=click.Path(exists=False, writable=True))
+@click.argument("path_network_geometry", type=click.Path(exists=True))
+@click.option(
+    "--link_id_field",
+    "-f",
+    type=str,
+    default="id",
+    help="The link ID field to use in the network shapefile. Defaults to 'id'.",
+)
+def snap_facilities(
+    path_population_in: str,
+    path_population_out: str,
+    path_network_geometry: int,
+    link_id_field: Optional[str],
+):
+    """Snap facilities to a network geometry."""
+    run_facility_link_snapping(
+        path_population_in=path_population_in,
+        path_population_out=path_population_out,
+        path_network_geometry=path_network_geometry,
+        link_id_field=link_id_field
+    )

--- a/src/pam/cli.py
+++ b/src/pam/cli.py
@@ -670,7 +670,6 @@ def wipe_links(
     logger.info(f"Output saved at {path_population_output}")
 
 
-
 @cli.command()
 @click.argument("path_population_in", type=click.Path(exists=True))
 @click.argument("path_population_out", type=click.Path(exists=False, writable=True))
@@ -693,5 +692,5 @@ def snap_facilities(
         path_population_in=path_population_in,
         path_population_out=path_population_out,
         path_network_geometry=path_network_geometry,
-        link_id_field=link_id_field
+        link_id_field=link_id_field,
     )

--- a/src/pam/operations/snap.py
+++ b/src/pam/operations/snap.py
@@ -1,0 +1,48 @@
+""" Methods for snapping elements to the network or facilities. """
+
+import geopandas as gp
+
+from pam.core import Population
+from pam.read import read_matsim
+from pam.write import write_matsim
+
+
+def snap_facilities_to_network(
+    population: Population,
+    network: gp.GeoDataFrame,
+    link_id_field: str = "id"
+) -> None:
+    """Snaps activity facilities to a network geometry (in-place).
+
+    Args:
+        population (Population): A PAM popualtion.
+        network (gp.GeoDataFrame): A network geometry shapefile.
+        link_id_field (str, optional): The link ID field to use in the network shapefile. Defaults to "id".
+    """
+    link_ids = network[link_id_field]
+    for _, _, person in population.people():
+        for act in person.activities:
+            link_id = link_ids[network.distance(act.location.loc).argmin()]
+            act.location.link = link_id
+
+def run_facility_link_snapping(
+        path_population_in: str,
+        path_population_out: str,
+        path_network_geometry: str,
+        link_id_field: str = "id"
+)->None:
+    """Reads a population, snaps activity facilities to a network geometry, and saves the results.
+
+    Args:
+        path_population_in (str): Path to a PAM population.
+        path_population_out (str): The path to save the output population.
+        path_network_geometry (str): Path to the network geometry file.
+        link_id_field (str, optional): The link ID field to use in the network shapefile. Defaults to "id".
+    """
+    population = read_matsim(path_population_in)
+    if path_network_geometry.endswith(".parquet"):
+        network = gp.read_parquet(path_network_geometry)
+    else:
+        network = gp.read_file(path_network_geometry)
+    snap_facilities_to_network(population=population, network=network, link_id_field=link_id_field)
+    write_matsim(population=population, plans_path=path_population_out)

--- a/src/pam/operations/snap.py
+++ b/src/pam/operations/snap.py
@@ -8,9 +8,7 @@ from pam.write import write_matsim
 
 
 def snap_facilities_to_network(
-    population: Population,
-    network: gp.GeoDataFrame,
-    link_id_field: str = "id"
+    population: Population, network: gp.GeoDataFrame, link_id_field: str = "id"
 ) -> None:
     """Snaps activity facilities to a network geometry (in-place).
 
@@ -25,12 +23,13 @@ def snap_facilities_to_network(
             link_id = link_ids[network.distance(act.location.loc).argmin()]
             act.location.link = link_id
 
+
 def run_facility_link_snapping(
-        path_population_in: str,
-        path_population_out: str,
-        path_network_geometry: str,
-        link_id_field: str = "id"
-)->None:
+    path_population_in: str,
+    path_population_out: str,
+    path_network_geometry: str,
+    link_id_field: str = "id",
+) -> None:
     """Reads a population, snaps activity facilities to a network geometry, and saves the results.
 
     Args:

--- a/src/pam/operations/snap.py
+++ b/src/pam/operations/snap.py
@@ -1,5 +1,7 @@
 """ Methods for snapping elements to the network or facilities. """
 
+from pathlib import Path
+
 import geopandas as gp
 
 from pam.core import Population
@@ -13,7 +15,7 @@ def snap_facilities_to_network(
     """Snaps activity facilities to a network geometry (in-place).
 
     Args:
-        population (Population): A PAM popualtion.
+        population (Population): A PAM population.
         network (gp.GeoDataFrame): A network geometry shapefile.
         link_id_field (str, optional): The link ID field to use in the network shapefile. Defaults to "id".
     """
@@ -39,7 +41,7 @@ def run_facility_link_snapping(
         link_id_field (str, optional): The link ID field to use in the network shapefile. Defaults to "id".
     """
     population = read_matsim(path_population_in)
-    if path_network_geometry.endswith(".parquet"):
+    if ".parquet" in Path(path_network_geometry).suffixes:
         network = gp.read_parquet(path_network_geometry)
     else:
         network = gp.read_file(path_network_geometry)

--- a/tests/test_29_snap.py
+++ b/tests/test_29_snap.py
@@ -1,0 +1,33 @@
+import os
+from pathlib import Path
+
+import geopandas as gp
+from pam.operations.snap import run_facility_link_snapping, snap_facilities_to_network
+from pam.read import read_matsim
+
+TEST_DATA_DIR = Path(__file__).parent / "test_data"
+
+
+def test_add_snapping_adds_link_attribute(population_heh):
+    network=gp.read_file(os.path.join(TEST_DATA_DIR, "test_link_geometry.geojson"))
+    for _, _, person in population_heh.people():
+        for act in person.activities:
+            assert act.location.link is None
+
+    snap_facilities_to_network(population=population_heh, network=network)
+    for _, _, person in population_heh.people():
+        for act in person.activities:
+            assert act.location.link is not None
+
+def test_links_resnapped(tmpdir):
+    path_out=os.path.join(tmpdir, "pop_snapped.xml")
+    run_facility_link_snapping(
+        path_population_in=os.path.join(TEST_DATA_DIR, "1.plans.xml"), 
+        path_population_out=path_out, 
+        path_network_geometry=os.path.join(TEST_DATA_DIR, "test_link_geometry.geojson")
+    )
+    assert os.path.exists(path_out)
+    pop_snapped = read_matsim(path_out)
+    for _, _, person in pop_snapped.people():
+        for act in person.activities:
+            assert "link-" in act.location.link

--- a/tests/test_29_snap.py
+++ b/tests/test_29_snap.py
@@ -1,15 +1,13 @@
 import os
-from pathlib import Path
 
 import geopandas as gp
+import pytest
 from pam.operations.snap import run_facility_link_snapping, snap_facilities_to_network
 from pam.read import read_matsim
 
-TEST_DATA_DIR = Path(__file__).parent / "test_data"
-
 
 def test_add_snapping_adds_link_attribute(population_heh):
-    network = gp.read_file(os.path.join(TEST_DATA_DIR, "test_link_geometry.geojson"))
+    network = gp.read_file(pytest.test_data_dir / "test_link_geometry.geojson")
     for _, _, person in population_heh.people():
         for act in person.activities:
             assert act.location.link is None
@@ -19,13 +17,22 @@ def test_add_snapping_adds_link_attribute(population_heh):
         for act in person.activities:
             assert act.location.link is not None
 
+            # check that the link is indeed the nearest one
+            link_distance = (
+                network.set_index("id")
+                .loc[act.location.link, "geometry"]
+                .distance(act.location.loc)
+            )
+            min_distance = network.distance(act.location.loc).min()
+            assert link_distance == min_distance
+
 
 def test_links_resnapped(tmpdir):
     path_out = os.path.join(tmpdir, "pop_snapped.xml")
     run_facility_link_snapping(
-        path_population_in=os.path.join(TEST_DATA_DIR, "1.plans.xml"),
+        path_population_in=pytest.test_data_dir / "1.plans.xml",
         path_population_out=path_out,
-        path_network_geometry=os.path.join(TEST_DATA_DIR, "test_link_geometry.geojson"),
+        path_network_geometry=pytest.test_data_dir / "test_link_geometry.geojson",
     )
     assert os.path.exists(path_out)
     pop_snapped = read_matsim(path_out)

--- a/tests/test_29_snap.py
+++ b/tests/test_29_snap.py
@@ -9,7 +9,7 @@ TEST_DATA_DIR = Path(__file__).parent / "test_data"
 
 
 def test_add_snapping_adds_link_attribute(population_heh):
-    network=gp.read_file(os.path.join(TEST_DATA_DIR, "test_link_geometry.geojson"))
+    network = gp.read_file(os.path.join(TEST_DATA_DIR, "test_link_geometry.geojson"))
     for _, _, person in population_heh.people():
         for act in person.activities:
             assert act.location.link is None
@@ -19,12 +19,13 @@ def test_add_snapping_adds_link_attribute(population_heh):
         for act in person.activities:
             assert act.location.link is not None
 
+
 def test_links_resnapped(tmpdir):
-    path_out=os.path.join(tmpdir, "pop_snapped.xml")
+    path_out = os.path.join(tmpdir, "pop_snapped.xml")
     run_facility_link_snapping(
-        path_population_in=os.path.join(TEST_DATA_DIR, "1.plans.xml"), 
-        path_population_out=path_out, 
-        path_network_geometry=os.path.join(TEST_DATA_DIR, "test_link_geometry.geojson")
+        path_population_in=os.path.join(TEST_DATA_DIR, "1.plans.xml"),
+        path_population_out=path_out,
+        path_network_geometry=os.path.join(TEST_DATA_DIR, "test_link_geometry.geojson"),
     )
     assert os.path.exists(path_out)
     pop_snapped = read_matsim(path_out)

--- a/tests/test_data/test_link_geometry.geojson
+++ b/tests/test_data/test_link_geometry.geojson
@@ -1,0 +1,8 @@
+{
+"type": "FeatureCollection",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::2157" } },
+"features": [
+{ "type": "Feature", "properties": { "id": "link-1" }, "geometry": { "type": "LineString", "coordinates": [ [ 10000.0, 5000.0 ], [ 10000.0, 10000.0 ] ] } },
+{ "type": "Feature", "properties": { "id": "link-2" }, "geometry": { "type": "LineString", "coordinates": [ [ 10000.0, 10000.0 ], [ 5000.0, 5000.0 ] ] } }
+]
+}


### PR DESCRIPTION
Adds CLI method for snapping activity facilities to a network geometry. 

It can be invoked as: `pam snap-facilities <path_population_in> <path_population_out> <path_network_geometry> -f <link_id_field>`

```
pam snap-facilities --help

Usage: pam snap-facilities [OPTIONS] PATH_POPULATION_IN PATH_POPULATION_OUT
                           PATH_NETWORK_GEOMETRY

  Snap facilities to a network geometry.

Options:
  -f, --link_id_field TEXT  The link ID field to use in the network shapefile.
                            Defaults to 'id'.
  --help                    Show this message and exit.
```

For each activity, the method will identify the closest link in the shapefile, and add it as a `link=..` attribute to the activity element. Finally, the updated plans file will be saved to a new xml file.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [X] CHANGELOG updated
- [X] Tests added to cover contribution
- [ ] Documentation updated
