### PR TITLE
Fix the Slack notification channel name in build workflows

### DIFF
--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -31,5 +31,5 @@ jobs:
     secrets: inherit
     with:
       result: needs.test.result
-      channel: pam-feed
+      channel: pam-feeds
       message: Daily CI action

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,5 +31,5 @@ jobs:
     secrets: inherit
     with:
       result: 'failure'
-      channel: pam-feed
+      channel: pam-feeds
       message: Docs Build


### PR DESCRIPTION
- Fixes #277 

The misconfigured channel name my not be the only problem, but it needs fixing in any case and we'll see if the notifications start arriving after that. 

