### PR TITLE
Fix syntax for passing CI build result into the Slack notification action

### DIFF
--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -30,6 +30,6 @@ jobs:
     uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@main
     secrets: inherit
     with:
-      result: needs.test.result
+      result: ${{ needs.test.result }}
       channel: pam-feeds
       message: Daily CI action


### PR DESCRIPTION
- Fixes #277 (reopened)

It turns out that Slack notifications from the daily CI build had *two* problems:

- Incorrect target Slack channel name (fixed in [the previous PR](https://github.com/arup-group/pam/pull/278 ))
- Incorrect syntax for passing the build result into the Slack notification action (fixed in this PR)

## Before fix

The literal value `needs.test.result` was being passed to the Slack notification Action, rather than the dynamic value of the build/test Actions job result as intended. The Slack action only sends notifications for the `result` values `success` and `failure`, hence no notification was triggered:

<img width="1170" alt="Screenshot 2024-05-22 at 11 26 43" src="https://github.com/arup-group/pam/assets/250899/42088e21-e006-471b-bb74-ac5005612f88">

## After fix

For full in situ verification, we will need to wait until the scheduled daily CI build next runs for PAM after this PR is merged. However, I have used the [same syntax](https://github.com/arup-group/gelato/blob/8a86dd087e427e0bffe7e12a4290fb951d17d371/.github/workflows/ci.yml#L65) that worked in my current branch of Gelato, where the build Slack notifications are working:

<img width="1153" alt="Screenshot 2024-05-22 at 12 00 11" src="https://github.com/arup-group/pam/assets/250899/20633d6a-2740-43e8-80e6-07bc46f3a30b">

<img width="861" alt="Screenshot 2024-05-22 at 12 14 31" src="https://github.com/arup-group/pam/assets/250899/bba4b8b2-3fbc-4d0b-8b86-02685f7c25af">


## Why no corresponding change to `docs.yml`?

In addition to `daily-scheduled-ci.yml`, there is another workflow that sends Slack notifications: `docs.yml`. However, that workflow **only sends notifications on failure**. It [accurately detects failure](https://github.com/arup-group/pam/blob/9c6f340ca105e876d940465a72ee4442f218065e/.github/workflows/docs.yml#L29), and then [passes the literal value `failure` ](https://github.com/arup-group/pam/blob/9c6f340ca105e876d940465a72ee4442f218065e/.github/workflows/docs.yml#L33)as an input to the Slack action, rather than attempting to pass the dynamic variable representing the job result. We have been seeing Slack failure notifications from `docs.yml` since the fix to the target channel name:

<img width="790" alt="Screenshot 2024-05-22 at 12 10 48" src="https://github.com/arup-group/pam/assets/250899/dee736e8-6c48-4468-8a5a-b06c9cf02536">







