### PR TITLE
simple logging for cropping

### DIFF
--- a/docs/activity_plans.md
+++ b/docs/activity_plans.md
@@ -136,3 +136,4 @@ This is resulting some difficult to follow logic (e.g., [][pam.activity.Plan.fil
 The [`pam.operations.cropping`](reference/pam/operations/cropping.md) module allows to spatially subset populations, by simplifying plan components that take place outside the "core" area.
 Any activities or legs that do not affect that core area are removed from the agents' plans, and agents with fully-external plans are removed from the population.
 Examples of using the module can be found in the [][plan-cropping] notebook.
+Plan cropping now features basic logging on the input and then output population, quantifying the changes in agent and households as a result of the cropping. 

--- a/src/pam/operations/cropping.py
+++ b/src/pam/operations/cropping.py
@@ -23,17 +23,24 @@ def simplify_population(
 
     # remove empty person-plans and households
     remove_persons = []
+    track_those_removed = []
     for hid, pid, person in population.people():
         if len(person.plan) == 1 and person.plan.day[0].act == "external":
             remove_persons.append((hid, pid))
+            track_those_removed.append({"hid": hid, "pid": pid})
     for hid, pid in remove_persons:
         del population[hid].people[pid]
+
+    print(len(remove_persons), "persons to be removed")
 
     remove_hhs = [
         hid for hid in population.households if len(population.households[hid].people) == 0
     ]
     for hid in remove_hhs:
         del population.households[hid]
+
+    print(len(remove_hhs), "households to be removed")
+    print("After simplification", population.stats)
 
 
 def simplify_external_plans(


### PR DESCRIPTION
Partially addresses [#29](https://github.com/orgs/arup-group/projects/151/views/1?pane=issue&itemId=79437786) in BERTIE.

Simple intervention, basic logging on the population stats before and after cropping, as well as the number of agents and households removed. A more complex intervention may be added in due course.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Tests added to cover contribution
- [ ] Documentation updated
