### PR TITLE
Fix ci build matplotlib error

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ geopandas >= 0.13, < 0.15
 importlib_resources >= 6, < 7
 ipykernel < 7
 lxml < 5
-matplotlib >= 3, < 4
+matplotlib >= 3, < 3.10
 numpy >= 1, < 2
 pandas >= 1.5, < 3
 plotly >= 4, < 6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ geopandas >= 0.13, < 0.15
 importlib_resources >= 6, < 7
 ipykernel < 7
 lxml < 5
-matplotlib >= 3, < 3.10
+matplotlib >= 3, < 4
 numpy >= 1, < 2
 pandas >= 1.5, < 3
 plotly >= 4, < 6

--- a/src/pam/plot/stats.py
+++ b/src/pam/plot/stats.py
@@ -166,7 +166,7 @@ def plot_activity_duration(list_of_populations, exclude=None, axis=None):
         axis.bar(x, y)
         axis.plot()
         axis.set_title(title)
-        axis.xaxis.set_label("")
+        axis.xaxis.set_label_text("")
         axis.xaxis.set_ticks(x)
         axis.xaxis.set_ticklabels(x, rotation=x_label_rotation)
     return outputs_df
@@ -191,7 +191,7 @@ def plot_leg_duration(list_of_populations, axis=None):
         axis.bar(x, y)
         axis.plot()
         axis.set_title(title)
-        axis.xaxis.set_label("")
+        axis.xaxis.set_label_text("")
         axis.xaxis.set_ticks(x)
         axis.xaxis.set_ticklabels(x, rotation=x_label_rotation)
     return outputs_df


### PR DESCRIPTION
- Fixes #287

## Before the Change

One of the unit tests was broken:

<img width="1683" alt="Screenshot 2024-12-18 at 19 10 44" src="https://github.com/user-attachments/assets/1f8ad29c-3cb6-4b55-b81b-a4c9ce123220" />
<img width="1686" alt="Screenshot 2024-12-18 at 19 11 00" src="https://github.com/user-attachments/assets/05384836-5ab7-425a-a2b9-684716fd8750" />


## After the Change

The build is fixed:

<img width="1687" alt="Screenshot 2024-12-18 at 19 11 31" src="https://github.com/user-attachments/assets/73f4fae3-73f0-4e1d-9e26-a7fb3a853acc" />
<img width="1692" alt="Screenshot 2024-12-18 at 19 11 49" src="https://github.com/user-attachments/assets/53225966-9769-4ae2-b509-1952f0c10c7f" />

## Is the Change Safe?

The previous attempt to set a label on the x-axis of plots (via `axis.xaxis.set_label("")`) was:

- effectively a no-op, setting no label, as discussed [here](https://github.com/matplotlib/matplotlib/issues/27971)
- attempting to set an empty string as the label in any case
- failing silently in `matplotlib < 3.10`, but... noisily in `matplotlib 3.10`

In functional terms, we have changed nothing, but we now avoid the error caused by the breaking change in `matplotlib 3.10`.


## Checklist

**Not Applicable**

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Tests added to cover contribution
- [ ] Documentation updated
