### PR TITLE
Correct the reusable actions version tags in the CI workflows

### DIFF
--- a/.github/workflows/commit-ci.yml
+++ b/.github/workflows/commit-ci.yml
@@ -25,5 +25,5 @@ jobs:
   aws-upload:
     needs: test
     if: needs.test.result == 'success'
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/aws-upload.yml@v1.1.0
     secrets: inherit

--- a/.github/workflows/daily-scheduled-ci.yml
+++ b/.github/workflows/daily-scheduled-ci.yml
@@ -13,7 +13,7 @@ jobs:
 
   test:
     needs: get-date
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/python-install-lint-test.yml@v1.1.0
     with:
       os: ubuntu-latest
       py3version: "12"
@@ -27,7 +27,7 @@ jobs:
   slack-notify-ci:
     needs: test
     if: always()
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@v1.1.0
     secrets: inherit
     with:
       result: ${{ needs.test.result }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
   slack-notify-ci-failure:
     needs: [docs-test, docs-update-latest]
     if: always() && contains(needs.*.result, 'failure')
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/slack-notify.yml@v1.1.0
     secrets: inherit
     with:
       result: 'failure'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   conda-build:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-build.yml@v1.1.0
     secrets: inherit
     with:
       package_name: cml-pam
       environment: pre-release
 
   pip-build:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-build.yml@v1.1.0
     secrets: inherit
     with:
       package_name: cml-pam

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   conda-upload:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/conda-upload.yml@v1.1.0
     secrets: inherit
     with:
       package_name: cml-pam
@@ -14,7 +14,7 @@ jobs:
       environment: release
 
   pip-upload:
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/pip-upload.yml@v1.1.0
     secrets: inherit
     with:
       package_name: cml-pam
@@ -24,7 +24,7 @@ jobs:
   docs-stable:
     permissions:
       contents: write
-    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.1
+    uses: arup-group/actions-city-modelling-lab/.github/workflows/docs-deploy.yml@v1.1.0
     with:
       deploy_type: update_stable
       notebook_kernel: pam


### PR DESCRIPTION
- Fixes #291 

So, the PR I merged to fix the builds used the wrong git tag for some of the actions (`v1.1.1` doesn't exist; we need `v1.1.0` - see [here](https://github.com/arup-group/actions-city-modelling-lab/tags)). Unfortunately, one of the places where the tag was correct was (part of) the CI commit workflow, so the build was fixed for that workflow but broken for the Daily CI, so we only discovered it was broken after merging:

<img width="1693" alt="Screenshot 2025-03-31 at 12 37 52" src="https://github.com/user-attachments/assets/72321615-a495-473a-ba0d-368a685213a7" />


# Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator.
All others should be checked by the reviewer(s).
You can add extra checklist items here if required by the PR.

- [x] CHANGELOG updated
- [x] Tests added to cover contribution
- [x] Documentation updated
